### PR TITLE
Add GAMS writer and backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/oximo-highs",
     "crates/oximo-io",
     "crates/oximo-gurobi",
+    "crates/oximo-gams",
     "crates/oximo",
 ]
 
@@ -29,6 +30,7 @@ oximo-solver = { path = "crates/oximo-solver", version = "0.1.0" }
 oximo-highs  = { path = "crates/oximo-highs",  version = "0.1.0" }
 oximo-io     = { path = "crates/oximo-io",     version = "0.1.0" }
 oximo-gurobi = { path = "crates/oximo-gurobi", version = "0.1.0" }
+oximo-gams   = { path = "crates/oximo-gams",   version = "0.1.0" }
 
 rayon        = "1.12"
 smallvec     = "1.15"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ println!("y   = {:?}", result.value_of(y)); // 4.0
 | `highs`  | HiGHS LP/MILP solver (bundled, no install)        | yes     |
 | `io`     | MPS and LP file writers                           | yes     |
 | `gurobi` | Gurobi LP/MILP solver (requires licensed install) | no      |
+| `gams`   | GAMS solver bridge (requires GAMS on PATH)        | no      |
 
 ```toml
 [dependencies]
 oximo = "0.1"                                      # HiGHS + MPS/LP writers
 oximo = { version = "0.1", features = ["gurobi"] } # add Gurobi
+oximo = { version = "0.1", features = ["gams"] }   # add GAMS backend
 ```
 
 ## Building models
@@ -123,6 +125,17 @@ let result = Gurobi.solve(&m, &GurobiOptions::default()
     .seed(101))?;
 ```
 
+### GAMS
+
+Requires GAMS on `PATH`. Supports solving models via GAMS solvers (CPLEX, BARON, etc.). See [`crates/oximo-gams/README.md`](crates/oximo-gams/README.md).
+
+```rust
+use oximo::prelude::*;
+use oximo::solvers::Gams;
+
+let result = Gams.solve(&m, &GamsOptions::default())?;
+```
+
 ## Reading results
 
 ```rust
@@ -170,10 +183,12 @@ io::write_lp(&m, "model.lp")?;
 | `oximo-io`     | MPS and LP writers                                    |
 | `oximo-highs`  | HiGHS backend                                         |
 | `oximo-gurobi` | Gurobi backend                                        |
+| `oximo-gams`   | GAMS writer and backend                               |
 
 ## Requirements
 
 - Gurobi feature: Gurobi, `GUROBI_HOME` set, valid license
+- GAMS feature: GAMS on `PATH`, valid license
 
 ## License
 

--- a/crates/oximo-gams/Cargo.toml
+++ b/crates/oximo-gams/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "GAMS writer and backend for oximo"
+readme = "README.md"
 
 [dependencies]
 oximo-expr.workspace = true

--- a/crates/oximo-gams/Cargo.toml
+++ b/crates/oximo-gams/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "oximo-gams"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "GAMS writer and backend for oximo"
+
+[dependencies]
+oximo-expr.workspace = true
+oximo-core.workspace = true
+oximo-solver.workspace = true
+rustc-hash.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oximo-gams/README.md
+++ b/crates/oximo-gams/README.md
@@ -1,0 +1,167 @@
+# oximo-gams
+
+GAMS LP/MILP backend for [oximo](https://github.com/germanheim/oximo).
+
+Writes an oximo [`Model`] to a temporary `.gms` file, invokes the GAMS executable via `std::process::Command`, and parses the solution from a PUT-generated text file. Supports `LP` and `MILP` model kinds. **QP/NLP/MINLP return `SolverError::UnsupportedKind` for now**.
+
+The sub-solver is determined by the GAMS installation (default) or set explicitly via [`GamsOptions::solver`]. Any solver available in your GAMS distribution can be targeted, see [Sub-solver selection](#sub-solver-selection) below.
+
+## Requirements
+
+**A licensed GAMS installation must be on `PATH`.**
+
+1. Download and install [GAMS](https://www.gams.com/download/) for your platform.
+2. Obtain and activate a GAMS license.
+3. Verify by running `gams` in a terminal.
+
+If `gams` is not on `PATH`, pass an explicit path via [`GamsOptions::gams_path`] or [`Gams::with_exec`]:
+
+```rust
+use oximo_gams::Gams;
+let solver = Gams::with_exec("/opt/gams47/gams");
+```
+
+## Usage
+
+Enable the `gams` feature on the umbrella `oximo` crate:
+
+```toml
+[dependencies]
+oximo = { version = "0.1", features = ["gams"] }
+```
+
+To use this crate directly:
+
+```toml
+[dependencies]
+oximo-gams   = "0.1"
+oximo-core   = "0.1"
+oximo-solver = "0.1"
+```
+
+## Quick example
+
+```rust
+use oximo::prelude::*;
+use oximo::solvers::Gams;
+
+let m = Model::new("transport");
+let x = m.var("x").lb(0.0).build();
+let y = m.var("y").lb(0.0).ub(4.0).build();
+
+m.constraint("c1", (x + 2.0 * y).le(14.0));
+m.constraint("c2", (3.0 * x - y).ge(0.0));
+m.constraint("c3", (x - y).le(2.0));
+m.maximize(3.0 * x + 4.0 * y);
+
+let result = Gams::new().solve(&m, &GamsOptions::default())?;
+println!("status = {:?}", result.status);
+println!("obj    = {:?}", result.objective);
+```
+
+Run the bundled example:
+
+```sh
+cargo run -p oximo --example reaction_path --features gams
+```
+
+## Options
+
+`GamsOptions` is a plain struct with builder methods. Universal options come from `UniversalOptionsExt`.
+
+### Universal options (via `UniversalOptionsExt`)
+
+| Method                  | GAMS statement                                               | Default |
+|-------------------------|--------------------------------------------------------------|---------|
+| `.time_limit(Duration)` | `option ResLim = <seconds>;`                                 | none    |
+| `.threads(usize)`       | `option threads = <n>;`                                      | none    |
+| `.verbose(bool)`        | Forwards GAMS stdout/stderr to `raw_log` (suppresses `lo=0`) | none    |
+
+### GAMS-specific options
+
+| Method              | Description                                                    | Default              |
+|---------------------|----------------------------------------------------------------|----------------------|
+| `.mip_gap(f64)`     | `option OptCR = <gap>;` — relative MIP optimality gap          | none                 |
+| `.solver(config)`   | Sub-solver selection; see [below](#sub-solver-selection)       | none                 |
+| `.gams_path(path)`  | Override path to the `gams` executable                         | `"gams"` from `PATH` |
+
+```rust
+use std::time::Duration;
+use oximo_gams::GamsOptions;
+use oximo_solver::UniversalOptionsExt;
+
+let opts = GamsOptions::default()
+    .time_limit(Duration::from_secs(300))
+    .threads(4)
+    .mip_gap(0.005)
+    .verbose(true);
+```
+
+## Sub-solver selection
+
+Pass a [`GamsSolverConfig`] to `.solver(...)` to select a GAMS sub-solver. This emits
+`option {LP|MIP} = <NAME>;` in the generated `.gms` file.
+
+```rust
+use oximo_gams::{GamsOptions, GamsSolver, GamsSolverConfig};
+
+// Named selection, no typed option file
+let opts = GamsOptions::default().solver(GamsSolver::Cplex);
+
+// Or via Custom for any solver name not in the enum
+let opts = GamsOptions::default().solver(GamsSolver::Custom("MOSEK".into()));
+```
+
+### Per-solver typed options
+
+Wrap the sub-solver's options struct in `GamsSolverConfig` to have oximo write a
+`<solver>.opt` file. GAMS picks it up via `model.optfile = 1`.
+
+```rust
+use oximo_gams::{GamsBaronOptions, GamsSolverConfig, GamsOptions};
+use std::time::Duration;
+use oximo_solver::UniversalOptionsExt;
+
+let opts = GamsOptions::default()
+    .time_limit(Duration::from_secs(120))
+    .solver(GamsSolverConfig::Baron(GamsBaronOptions {
+        eps_r: Some(1e-4),
+        threads: Some(4),
+        ..Default::default()
+    }));
+```
+
+Supported typed-option structs:
+
+| Struct                | Sub-solver | Reference                                         |
+|-----------------------|------------|---------------------------------------------------|
+| `GamsBaronOptions`    | BARON      | <https://www.gams.com/latest/docs/S_BARON.html>   |
+| `GamsCbcOptions`      | CBC        | <https://www.gams.com/latest/docs/S_CBC.html>     |
+| `GamsCplexOptions`    | CPLEX      | <https://www.gams.com/latest/docs/S_CPLEX.html>   |
+| `GamsGurobiOptions`   | GUROBI     | <https://www.gams.com/latest/docs/S_GUROBI.html>  |
+| `GamsHighsOptions`    | HIGHS      | <https://www.gams.com/latest/docs/S_HIGHS.html>   |
+| `GamsIpoptOptions`    | IPOPT      | <https://www.gams.com/latest/docs/S_IPOPT.html>   |
+| `GamsKnitroOptions`   | KNITRO     | <https://www.gams.com/latest/docs/S_KNITRO.html>  |
+| `GamsMosekOptions`    | MOSEK      | <https://www.gams.com/latest/docs/S_MOSEK.html>   |
+| `GamsScipOptions`     | SCIP       | <https://www.gams.com/latest/docs/S_SCIP.html>    |
+| `GamsXpressOptions`   | XPRESS     | <https://www.gams.com/latest/docs/S_XPRESS.html>  |
+
+For any other solver, use `GamsSolverConfig::Named(GamsSolver::Custom("NAME".into()))`.
+
+## Result
+
+`SolverResult` fields populated on `Optimal` or `Feasible`:
+
+- `objective` - objective value
+- `primal` - variable values keyed by `VarId`; access via `result.value_of(var)`
+- `status` - mapped from GAMS model-status codes (1=Optimal, 4=Infeasible, 3=Unbounded, ...)
+- `solve_time` - wall time around the GAMS process invocation
+- `raw_log` - GAMS stdout/stderr, populated when `verbose(true)` or when GAMS exits non-zero
+
+`dual`, `reduced_costs`, and `iterations` are not populated by this backend.
+
+## License
+
+MIT OR Apache-2.0
+
+> **Note:** GAMS itself is commercial software. A valid GAMS license is required at runtime. This crate is not affiliated with GAMS Development Corporation.

--- a/crates/oximo-gams/src/lib.rs
+++ b/crates/oximo-gams/src/lib.rs
@@ -1,0 +1,92 @@
+//! GAMS writer and backend for oximo.
+//!
+//! Translates an oximo [`Model`] into a GAMS `.gms` file, invokes the GAMS
+//! executable via [`std::process::Command`], and parses the solution from a
+//! PUT-generated text file.
+//!
+//! # Requirements
+//!
+//! A licensed GAMS installation must be available. The executable is resolved
+//! from `PATH` by default, but can be overridden with [`GamsOptions::gams_path`] or
+//! [`Gams::with_exec`].
+//!
+//! # Supported options
+//!
+//! Common option ([`CommonOptions`](oximo_solver::CommonOptions)) honored:
+//!
+//! | Field        | GAMS statement                                                    |
+//! |--------------|-------------------------------------------------------------------|
+//! | `time_limit` | `option ResLim = <seconds>;`                                      |
+//! | `mip_gap`    | `option OptCR = <gap>;`                                           |
+//! | `threads`    | `option threads = <n>;`                                           |
+//! | `verbose`    | Forwards GAMS stdout/stderr to `raw_log` (suppresses `lo=0` flag) |
+//!
+//! GAMS-specific options ([`GamsOptions`]):
+//!
+//! | Field       | Description                                                                   |
+//! |-------------|-------------------------------------------------------------------------------|
+//! | `solver`    | Sub-solver name ([`GamsSolver::Baron`], `Cplex`, `Custom("MOSEK".into())`, …) |
+//! | `gams_path` | Path to the `gams` executable                                                 |
+//!
+//! # Per-solver typed options
+//!
+//! Pass a [`GamsSolverConfig`] to [`GamsOptions::solver`] to select a sub-solver
+//! and write a typed `<solver>.opt` file. GAMS picks it up via `model.optfile = 1`.
+#![forbid(unsafe_code)]
+
+mod options;
+mod solver_options;
+mod translate;
+
+pub use options::{GamsOptions, GamsSolver};
+pub use solver_options::{
+    GamsBaronOptions, GamsCbcCuts, GamsCbcOptions, GamsCbcPresolve, GamsCplexMipEmphasis,
+    GamsCplexOptions, GamsGurobiMipFocus, GamsGurobiOptions, GamsHighsOptions, GamsHighsPresolve,
+    GamsHighsSolver, GamsIpoptLinearSolver, GamsIpoptMuStrategy, GamsIpoptOptions,
+    GamsKnitroAlgorithm, GamsKnitroOptions, GamsMosekOptions, GamsScipOptions, GamsSolverConfig,
+    GamsXpressOptions,
+};
+pub use translate::solve;
+
+use oximo_core::{Model, ModelKind};
+use oximo_solver::{Solver, SolverError, SolverResult};
+
+/// GAMS solver backend.
+///
+/// Writes the model to a temporary `.gms` file, invokes the GAMS executable,
+/// and returns the parsed [`SolverResult`].
+#[derive(Debug, Default, Clone)]
+pub struct Gams {
+    /// Optional override for the GAMS executable path. When `None`, `"gams"` is
+    /// looked up from the system `PATH`. Overridden per-call by
+    /// [`GamsOptions::gams_path`].
+    pub exec: Option<String>,
+}
+
+impl Gams {
+    /// Create a backend that uses `gams` from `PATH`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a backend pointing at an explicit GAMS executable path.
+    pub fn with_exec(path: impl Into<String>) -> Self {
+        Self { exec: Some(path.into()) }
+    }
+}
+
+impl Solver for Gams {
+    type Options = GamsOptions;
+
+    fn name(&self) -> &str {
+        "gams"
+    }
+
+    fn supports(&self, kind: ModelKind) -> bool {
+        matches!(kind, ModelKind::LP | ModelKind::MILP)
+    }
+
+    fn solve(&mut self, model: &Model, opts: &GamsOptions) -> Result<SolverResult, SolverError> {
+        translate::solve(model, opts, self.exec.as_deref())
+    }
+}

--- a/crates/oximo-gams/src/options.rs
+++ b/crates/oximo-gams/src/options.rs
@@ -1,0 +1,187 @@
+use std::fmt::Write as FmtWrite;
+use std::path::PathBuf;
+
+use oximo_solver::{HasUniversal, UniversalOptions};
+
+use crate::solver_options::GamsSolverConfig;
+
+/// GAMS-specific solver options.
+#[derive(Clone, Debug, Default)]
+pub struct GamsOptions {
+    pub universal: UniversalOptions,
+    pub mip_gap: Option<f64>,
+    /// Sub-solver selection with optional typed options.
+    /// Translates to `option {LP|MIP} = <name>;` plus a `<solver>.opt` file
+    /// when options are set.
+    pub solver: Option<GamsSolverConfig>,
+    /// Override for the `gams` executable. When `None`, `"gams"` is looked up
+    /// from `PATH`.
+    pub gams_path: Option<PathBuf>,
+}
+
+/// Named GAMS sub-solver. Use [`GamsSolver::Custom`] for any name that isn't
+/// a pre-enumerated variant.
+///
+/// Reference: https://www.gams.com/latest/docs/S_MAIN.html#SOLVERS_MODEL_TYPES
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GamsSolver {
+    /// ALPHAECP: MINLP
+    AlphaEcp,
+    /// ANTIGONE: LP, MIP, NLP, MINLP, QCP, MIQCP, Global
+    Antigone,
+    /// BARON: LP, MIP, NLP, MCP, MPEC, CNS, MINLP, QCP, MIQCP, Global
+    Baron,
+    /// CBC: LP, MIP
+    Cbc,
+    /// CONOPT: NLP, DNLP, CNS, MPEC
+    Conopt,
+    /// COPT: LP, MIP, QCP, MIQCP
+    Copt,
+    /// CPLEX: LP, MIP, QCP, MIQCP
+    Cplex,
+    /// DECIS: LP, Stochastic
+    Decis,
+    /// DICOPT: MINLP
+    Dicopt,
+    /// GLPK: LP, MIP (not in GAMS docs but recognized)
+    Glpk,
+    /// GUROBI: LP, MIP, NLP, MINLP, QCP, MIQCP, Global
+    Gurobi,
+    /// GUSS: LP, MIP, NLP, MCP, MPEC, CNS, DNLP, MINLP, QCP, MIQCP
+    Guss,
+    /// HiGHS: LP, MIP
+    Highs,
+    /// IPOPT: NLP, DNLP, CNS, MPEC
+    Ipopt,
+    /// JAMS: MPEC
+    Jams,
+    /// KESTREL: all model types (remote solver submission)
+    Kestrel,
+    /// KNITRO: LP, MIP, NLP, MCP, MPEC, CNS, DNLP, MINLP, QCP, MIQCP
+    Knitro,
+    /// LINDO: LP, MIP, NLP, MCP, MPEC, CNS, DNLP, MINLP, QCP, Stochastic, Global
+    Lindo,
+    /// LINDOGLOBAL: LP, MIP, NLP, MINLP, QCP, MIQCP, Global
+    LindoGlobal,
+    /// MILES: MCP
+    Miles,
+    /// MINOS: NLP, DNLP, CNS, MPEC
+    Minos,
+    /// MOSEK: LP, MIP, NLP, QCP, MIQCP
+    Mosek,
+    /// NLPEC: NLP, MPEC
+    Nlpec,
+    /// ODHCPLEX: LP, MIP
+    OdhCplex,
+    /// PATH: MCP, MPEC
+    Path,
+    /// QUADMINOS: NLP
+    QuadMinos,
+    /// RESHOP: NLP
+    Reshop,
+    /// SBB: NLP, MINLP
+    Sbb,
+    /// SCIP: LP, MIP, NLP, MINLP, QCP, MIQCP, Global
+    Scip,
+    /// SHOT: MINLP
+    Shot,
+    /// SNOPT: NLP, DNLP, CNS, MPEC
+    Snopt,
+    /// SOPLEX: LP
+    Soplex,
+    /// XPRESS: LP, MIP, NLP, MINLP, QCP, MIQCP, Global
+    Xpress,
+    /// Any other GAMS-recognized solver name, emitted verbatim.
+    Custom(String),
+}
+
+impl GamsSolver {
+    /// GAMS solver keyword used in the `option {LP|MIP} = ...;` statement.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::AlphaEcp => "ALPHAECP",
+            Self::Antigone => "ANTIGONE",
+            Self::Baron => "BARON",
+            Self::Cbc => "CBC",
+            Self::Conopt => "CONOPT",
+            Self::Copt => "COPT",
+            Self::Cplex => "CPLEX",
+            Self::Decis => "DECIS",
+            Self::Dicopt => "DICOPT",
+            Self::Glpk => "GLPK",
+            Self::Gurobi => "GUROBI",
+            Self::Guss => "GUSS",
+            Self::Highs => "HIGHS",
+            Self::Ipopt => "IPOPT",
+            Self::Jams => "JAMS",
+            Self::Kestrel => "KESTREL",
+            Self::Knitro => "KNITRO",
+            Self::Lindo => "LINDO",
+            Self::LindoGlobal => "LINDOGLOBAL",
+            Self::Miles => "MILES",
+            Self::Minos => "MINOS",
+            Self::Mosek => "MOSEK",
+            Self::Nlpec => "NLPEC",
+            Self::OdhCplex => "ODHCPLEX",
+            Self::Path => "PATH",
+            Self::QuadMinos => "QUADMINOS",
+            Self::Reshop => "RESHOP",
+            Self::Sbb => "SBB",
+            Self::Scip => "SCIP",
+            Self::Shot => "SHOT",
+            Self::Snopt => "SNOPT",
+            Self::Soplex => "SOPLEX",
+            Self::Xpress => "XPRESS",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+}
+
+impl GamsOptions {
+    #[must_use]
+    pub fn mip_gap(mut self, gap: f64) -> Self {
+        self.mip_gap = Some(gap);
+        self
+    }
+
+    #[must_use]
+    pub fn solver(mut self, s: impl Into<GamsSolverConfig>) -> Self {
+        self.solver = Some(s.into());
+        self
+    }
+
+    #[must_use]
+    pub fn gams_path(mut self, p: impl Into<PathBuf>) -> Self {
+        self.gams_path = Some(p.into());
+        self
+    }
+}
+
+impl HasUniversal for GamsOptions {
+    fn universal(&self) -> &UniversalOptions {
+        &self.universal
+    }
+
+    fn universal_mut(&mut self) -> &mut UniversalOptions {
+        &mut self.universal
+    }
+}
+
+/// Emit GAMS option statements into `gms` before the `Solve` statement.
+///
+/// `solve_type` is `"LP"` or `"MIP"`, used to scope the `solver` option.
+pub fn write_options(gms: &mut String, o: &GamsOptions, solve_type: &str) {
+    if let Some(d) = o.universal.time_limit {
+        writeln!(gms, "option ResLim = {};", d.as_secs_f64()).unwrap();
+    }
+    if let Some(g) = o.mip_gap {
+        writeln!(gms, "option OptCR = {g};").unwrap();
+    }
+    if let Some(n) = o.universal.threads {
+        writeln!(gms, "option threads = {n};").unwrap();
+    }
+    if let Some(s) = &o.solver {
+        writeln!(gms, "option {solve_type} = {};", s.gams_name()).unwrap();
+    }
+}

--- a/crates/oximo-gams/src/options.rs
+++ b/crates/oximo-gams/src/options.rs
@@ -185,3 +185,64 @@ pub fn write_options(gms: &mut String, o: &GamsOptions, solve_type: &str) {
         writeln!(gms, "option {solve_type} = {};", s.gams_name()).unwrap();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use oximo_solver::UniversalOptionsExt;
+
+    use super::*;
+
+    #[test]
+    fn builder_sets_fields() {
+        use crate::solver_options::{GamsBaronOptions, GamsSolverConfig};
+        let o = GamsOptions::default()
+            .time_limit(Duration::from_secs(45))
+            .threads(2)
+            .mip_gap(0.001)
+            .verbose(true)
+            .solver(GamsSolverConfig::Baron(GamsBaronOptions::default()))
+            .gams_path("/opt/gams/gams");
+        assert_eq!(o.universal.time_limit, Some(Duration::from_secs(45)));
+        assert_eq!(o.universal.threads, Some(2));
+        assert_eq!(o.mip_gap, Some(0.001));
+        assert!(matches!(o.solver, Some(GamsSolverConfig::Baron(_))));
+        assert_eq!(o.gams_path.as_deref(), Some(std::path::Path::new("/opt/gams/gams")));
+    }
+
+    #[test]
+    fn write_options_emits_solver_baron() {
+        use crate::solver_options::{GamsBaronOptions, GamsSolverConfig};
+        let o = GamsOptions::default().solver(GamsSolverConfig::Baron(GamsBaronOptions::default()));
+        let mut gms = String::new();
+        write_options(&mut gms, &o, "MIP");
+        assert!(gms.contains("option MIP = BARON;"), "got: {gms}");
+    }
+
+    #[test]
+    fn write_options_emits_custom_solver_verbatim() {
+        let o = GamsOptions::default().solver(GamsSolver::Custom("MOSEK".into()));
+        let mut gms = String::new();
+        write_options(&mut gms, &o, "LP");
+        assert!(gms.contains("option LP = MOSEK;"), "got: {gms}");
+    }
+
+    #[test]
+    fn write_options_emits_time_and_gap() {
+        let o = GamsOptions::default().time_limit(Duration::from_secs(10)).mip_gap(0.05).threads(4);
+        let mut gms = String::new();
+        write_options(&mut gms, &o, "MIP");
+        assert!(gms.contains("option ResLim = 10"));
+        assert!(gms.contains("option OptCR = 0.05"));
+        assert!(gms.contains("option threads = 4"));
+    }
+
+    #[test]
+    fn write_options_empty_for_default() {
+        let o = GamsOptions::default();
+        let mut gms = String::new();
+        write_options(&mut gms, &o, "LP");
+        assert!(gms.is_empty());
+    }
+}

--- a/crates/oximo-gams/src/solver_options.rs
+++ b/crates/oximo-gams/src/solver_options.rs
@@ -821,3 +821,200 @@ impl GamsXpressOptions {
         n > 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::GamsSolver;
+
+    #[test]
+    fn baron_writes_space_separated() {
+        let cfg = GamsSolverConfig::Baron(GamsBaronOptions {
+            threads: Some(4),
+            eps_r: Some(0.01),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("Threads 4\n"), "got: {buf}");
+        assert!(buf.contains("EpsR 0.01\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn highs_writes_eq_separated() {
+        let cfg = GamsSolverConfig::Highs(GamsHighsOptions {
+            mip_rel_gap: Some(0.05),
+            threads: Some(2),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("mip_rel_gap = 0.05\n"), "got: {buf}");
+        assert!(buf.contains("threads = 2\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn highs_presolve_and_solver_enum() {
+        let cfg = GamsSolverConfig::Highs(GamsHighsOptions {
+            presolve: Some(GamsHighsPresolve::Off),
+            solver: Some(GamsHighsSolver::Simplex),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("presolve = off\n"), "got: {buf}");
+        assert!(buf.contains("solver = simplex\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn scip_writes_eq_separated() {
+        let cfg = GamsSolverConfig::Scip(GamsScipOptions {
+            mip_rel_gap: Some(0.01),
+            node_limit: Some(1000),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("limits/gap = 0.01\n"), "got: {buf}");
+        assert!(buf.contains("limits/nodes = 1000\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn gurobi_writes_space_separated() {
+        let cfg = GamsSolverConfig::Gurobi(GamsGurobiOptions {
+            threads: Some(8),
+            mip_focus: Some(GamsGurobiMipFocus::Feasibility),
+            presolve: Some(2),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("threads 8\n"), "got: {buf}");
+        assert!(buf.contains("mipfocus 1\n"), "got: {buf}");
+        assert!(buf.contains("presolve 2\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn cplex_bool_as_int_and_emphasis() {
+        let cfg = GamsSolverConfig::Cplex(GamsCplexOptions {
+            presolve: Some(false),
+            mip_emphasis: Some(GamsCplexMipEmphasis::Feasibility),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("preind 0\n"), "got: {buf}");
+        assert!(buf.contains("mipemphasis 1\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn cbc_enum_options() {
+        let cfg = GamsSolverConfig::Cbc(GamsCbcOptions {
+            presolve: Some(GamsCbcPresolve::On),
+            cuts: Some(GamsCbcCuts::Root),
+            heuristics: Some(true),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("presolve on\n"), "got: {buf}");
+        assert!(buf.contains("cuts root\n"), "got: {buf}");
+        assert!(buf.contains("heuristics 1\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn ipopt_string_options() {
+        let cfg = GamsSolverConfig::Ipopt(GamsIpoptOptions {
+            linear_solver: Some(GamsIpoptLinearSolver::Ma57),
+            mu_strategy: Some(GamsIpoptMuStrategy::Adaptive),
+            max_iter: Some(500),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("linear_solver ma57\n"), "got: {buf}");
+        assert!(buf.contains("mu_strategy adaptive\n"), "got: {buf}");
+        assert!(buf.contains("max_iter 500\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn knitro_algorithm_enum() {
+        let cfg = GamsSolverConfig::Knitro(GamsKnitroOptions {
+            algorithm: Some(GamsKnitroAlgorithm::Sqp),
+            mip_rel_gap: Some(0.001),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("nlp_algorithm 4\n"), "got: {buf}");
+        assert!(buf.contains("mip_opt_gap_rel 0.001\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn mosek_long_key_names() {
+        let cfg = GamsSolverConfig::Mosek(GamsMosekOptions {
+            threads: Some(2),
+            mip_rel_gap: Some(1e-4),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("MSK_IPAR_NUM_THREADS 2\n"), "got: {buf}");
+        assert!(buf.contains("MSK_DPAR_MIO_TOL_REL_GAP 0.0001\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn xpress_bool_presolve_and_gap() {
+        let cfg = GamsSolverConfig::Xpress(GamsXpressOptions {
+            presolve: Some(false),
+            mip_rel_gap: Some(0.02),
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("presolve 0\n"), "got: {buf}");
+        assert!(buf.contains("mipRelStop 0.02\n"), "got: {buf}");
+    }
+
+    #[test]
+    fn empty_options_writes_nothing() {
+        let cfg = GamsSolverConfig::Baron(GamsBaronOptions::default());
+        let mut buf = String::new();
+        assert!(!cfg.write_opt_file(&mut buf));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn named_writes_nothing() {
+        let cfg = GamsSolverConfig::Named(GamsSolver::Baron);
+        let mut buf = String::new();
+        assert!(!cfg.write_opt_file(&mut buf));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn gams_name_matches_variant() {
+        assert_eq!(GamsSolverConfig::Baron(GamsBaronOptions::default()).gams_name(), "BARON");
+        assert_eq!(GamsSolverConfig::Cbc(GamsCbcOptions::default()).gams_name(), "CBC");
+        assert_eq!(GamsSolverConfig::Cplex(GamsCplexOptions::default()).gams_name(), "CPLEX");
+        assert_eq!(GamsSolverConfig::Gurobi(GamsGurobiOptions::default()).gams_name(), "GUROBI");
+        assert_eq!(GamsSolverConfig::Highs(GamsHighsOptions::default()).gams_name(), "HIGHS");
+        assert_eq!(GamsSolverConfig::Ipopt(GamsIpoptOptions::default()).gams_name(), "IPOPT");
+        assert_eq!(GamsSolverConfig::Knitro(GamsKnitroOptions::default()).gams_name(), "KNITRO");
+        assert_eq!(GamsSolverConfig::Mosek(GamsMosekOptions::default()).gams_name(), "MOSEK");
+        assert_eq!(GamsSolverConfig::Scip(GamsScipOptions::default()).gams_name(), "SCIP");
+        assert_eq!(GamsSolverConfig::Xpress(GamsXpressOptions::default()).gams_name(), "XPRESS");
+        assert_eq!(GamsSolverConfig::Named(GamsSolver::Cplex).gams_name(), "CPLEX");
+        assert_eq!(
+            GamsSolverConfig::Named(GamsSolver::Custom("MYMIP".into())).gams_name(),
+            "MYMIP"
+        );
+    }
+
+    #[test]
+    fn from_gams_solver_becomes_named() {
+        let cfg: GamsSolverConfig = GamsSolver::Gurobi.into();
+        assert!(matches!(cfg, GamsSolverConfig::Named(GamsSolver::Gurobi)));
+        assert_eq!(cfg.gams_name(), "GUROBI");
+    }
+}

--- a/crates/oximo-gams/src/solver_options.rs
+++ b/crates/oximo-gams/src/solver_options.rs
@@ -1,0 +1,823 @@
+//! Per-solver typed option structs and [`GamsSolverConfig`].
+// TODO: Add more SolverConfig variants for other solvers when we add NLP/MINLP support
+
+use std::fmt::Write as FmtWrite;
+
+use crate::options::GamsSolver;
+
+// - Config enum
+
+/// Selects a GAMS sub-solver and optionally carries typed options written to
+/// a `<solver>.opt` file before invoking GAMS.
+///
+/// Use [`GamsSolverConfig::Named`] to select a solver by name with no extra
+/// options.
+///
+/// A [`From<GamsSolver>`] impl allows passing a bare `GamsSolver` wherever
+/// a `GamsSolverConfig` is expected.
+///
+/// References:
+/// - "GAMS Solver Manuals," GAMS Development Corporation.
+///   <https://www.gams.com/latest/docs/S_MAIN.html#SOLVERS_MODEL_TYPES> (accessed May 14, 2026).
+#[derive(Clone, Debug)]
+pub enum GamsSolverConfig {
+    Baron(GamsBaronOptions),
+    Cbc(GamsCbcOptions),
+    Cplex(GamsCplexOptions),
+    Gurobi(GamsGurobiOptions),
+    Highs(GamsHighsOptions),
+    Ipopt(GamsIpoptOptions),
+    Knitro(GamsKnitroOptions),
+    Mosek(GamsMosekOptions),
+    Scip(GamsScipOptions),
+    Xpress(GamsXpressOptions),
+    /// Any solver selectable by name with no typed option file.
+    Named(GamsSolver),
+}
+
+impl GamsSolverConfig {
+    /// GAMS solver keyword for `option {LP|MIP} = ...;`.
+    #[must_use]
+    pub fn gams_name(&self) -> &str {
+        match self {
+            Self::Baron(_) => "BARON",
+            Self::Cbc(_) => "CBC",
+            Self::Cplex(_) => "CPLEX",
+            Self::Gurobi(_) => "GUROBI",
+            Self::Highs(_) => "HIGHS",
+            Self::Ipopt(_) => "IPOPT",
+            Self::Knitro(_) => "KNITRO",
+            Self::Mosek(_) => "MOSEK",
+            Self::Scip(_) => "SCIP",
+            Self::Xpress(_) => "XPRESS",
+            Self::Named(s) => s.name(),
+        }
+    }
+
+    /// Write options to `buf`. Returns `true` if anything was written.
+    /// When `true`, the caller should write `buf` to `<solver_lowercase>.opt`
+    /// in the GAMS working directory and set `model.optfile = 1`.
+    #[must_use]
+    pub fn write_opt_file(&self, buf: &mut String) -> bool {
+        match self {
+            Self::Baron(o) => o.write(buf),
+            Self::Cbc(o) => o.write(buf),
+            Self::Cplex(o) => o.write(buf),
+            Self::Gurobi(o) => o.write(buf),
+            Self::Highs(o) => o.write(buf),
+            Self::Ipopt(o) => o.write(buf),
+            Self::Knitro(o) => o.write(buf),
+            Self::Mosek(o) => o.write(buf),
+            Self::Scip(o) => o.write(buf),
+            Self::Xpress(o) => o.write(buf),
+            Self::Named(_) => false,
+        }
+    }
+}
+
+impl From<GamsSolver> for GamsSolverConfig {
+    fn from(s: GamsSolver) -> Self {
+        Self::Named(s)
+    }
+}
+
+// - Helpers
+
+fn kv(buf: &mut String, key: &str, val: impl std::fmt::Display) {
+    writeln!(buf, "{key} {val}").unwrap();
+}
+
+fn kv_eq(buf: &mut String, key: &str, val: impl std::fmt::Display) {
+    writeln!(buf, "{key} = {val}").unwrap();
+}
+
+// - BARON
+
+/// Options for the BARON global solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_BARON.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsBaronOptions {
+    /// Max wall-clock time in seconds (`MaxTime`)
+    pub max_time: Option<f64>,
+    /// Max branch-and-reduce iterations (`MaxIter`)
+    pub max_iter: Option<i64>,
+    /// Relative optimality gap (`EpsR`)
+    pub eps_r: Option<f64>,
+    /// Absolute optimality gap (`EpsA`)
+    pub eps_a: Option<f64>,
+    /// Absolute constraint feasibility tolerance (`AbsConFeasTol`)
+    pub abs_con_feas_tol: Option<f64>,
+    /// Absolute integrality tolerance (`AbsIntFeasTol`)
+    pub abs_int_feas_tol: Option<f64>,
+    /// Threads for MIP subproblems (`Threads`)
+    pub threads: Option<u32>,
+    /// Local searches in preprocessing (`NumLoc`)
+    pub num_loc: Option<i32>,
+    /// Number of feasible solutions to find (`NumSol`)
+    pub num_sol: Option<i32>,
+    /// Objective cutoff (`CutOff`)
+    pub cut_off: Option<f64>,
+}
+
+impl GamsBaronOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("MaxTime", self.max_time);
+        w!("MaxIter", self.max_iter);
+        w!("EpsR", self.eps_r);
+        w!("EpsA", self.eps_a);
+        w!("AbsConFeasTol", self.abs_con_feas_tol);
+        w!("AbsIntFeasTol", self.abs_int_feas_tol);
+        w!("Threads", self.threads);
+        w!("NumLoc", self.num_loc);
+        w!("NumSol", self.num_sol);
+        w!("CutOff", self.cut_off);
+        n > 0
+    }
+}
+
+// - CBC
+
+/// `presolve` setting for CBC.
+#[derive(Clone, Debug)]
+pub enum GamsCbcPresolve {
+    On,
+    Off,
+    More,
+}
+
+/// `cuts` setting for CBC.
+#[derive(Clone, Debug)]
+pub enum GamsCbcCuts {
+    Off,
+    On,
+    Root,
+    IfMove,
+    ForceOn,
+}
+
+/// Options for the CBC LP/MIP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_CBC.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsCbcOptions {
+    pub threads: Option<u32>,
+    /// Relative MIP gap (`optcr`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`optca`)
+    pub mip_abs_gap: Option<f64>,
+    /// Max branch-and-bound nodes (`nodlim`)
+    pub node_limit: Option<u64>,
+    pub presolve: Option<GamsCbcPresolve>,
+    pub cuts: Option<GamsCbcCuts>,
+    /// Enable MIP heuristics (`heuristics`)
+    pub heuristics: Option<bool>,
+}
+
+impl GamsCbcOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("threads", self.threads);
+        w!("optcr", self.mip_rel_gap);
+        w!("optca", self.mip_abs_gap);
+        w!("nodlim", self.node_limit);
+        if let Some(p) = &self.presolve {
+            kv(
+                buf,
+                "presolve",
+                match p {
+                    GamsCbcPresolve::On => "on",
+                    GamsCbcPresolve::Off => "off",
+                    GamsCbcPresolve::More => "more",
+                },
+            );
+            n += 1;
+        }
+        if let Some(c) = &self.cuts {
+            kv(
+                buf,
+                "cuts",
+                match c {
+                    GamsCbcCuts::Off => "off",
+                    GamsCbcCuts::On => "on",
+                    GamsCbcCuts::Root => "root",
+                    GamsCbcCuts::IfMove => "ifmove",
+                    GamsCbcCuts::ForceOn => "forceOn",
+                },
+            );
+            n += 1;
+        }
+        if let Some(h) = self.heuristics {
+            kv(buf, "heuristics", i32::from(h));
+            n += 1;
+        }
+        n > 0
+    }
+}
+
+// - CPLEX
+
+/// `mipemphasis` strategy for CPLEX.
+#[derive(Clone, Debug)]
+pub enum GamsCplexMipEmphasis {
+    /// Balanced: feasibility and optimality (0)
+    Balanced,
+    /// Emphasize feasibility (1)
+    Feasibility,
+    /// Emphasize proving optimality (2)
+    Optimality,
+    /// Emphasize best bound (3)
+    BestBound,
+    /// Emphasize hidden feasibility (4)
+    HiddenFeasibility,
+}
+
+/// Options for the CPLEX LP/MIP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_CPLEX.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsCplexOptions {
+    pub threads: Option<u32>,
+    /// Relative MIP gap (`epgap`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`epagap`)
+    pub mip_abs_gap: Option<f64>,
+    /// Max B&B nodes (`nodelim`)
+    pub node_limit: Option<u64>,
+    /// Limit on integer solutions found (`intsollim`)
+    pub int_sol_limit: Option<u32>,
+    /// Enable presolve (`preind`)
+    pub presolve: Option<bool>,
+    /// MIP solution tactics (`mipemphasis`)
+    pub mip_emphasis: Option<GamsCplexMipEmphasis>,
+    /// Node selection (`nodesel`)
+    pub node_select: Option<i32>,
+    /// Variable selection (`varsel`)
+    pub var_select: Option<i32>,
+    /// Integrality tolerance (`epint`)
+    pub int_tol: Option<f64>,
+    /// Feasibility tolerance (`eprhs`)
+    pub feasibility_tol: Option<f64>,
+    /// Optimality tolerance (`epopt`)
+    pub optimality_tol: Option<f64>,
+    /// LP algorithm (`lpmethod`)
+    pub lp_method: Option<i32>,
+}
+
+impl GamsCplexOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("threads", self.threads);
+        w!("epgap", self.mip_rel_gap);
+        w!("epagap", self.mip_abs_gap);
+        w!("nodelim", self.node_limit);
+        w!("intsollim", self.int_sol_limit);
+        if let Some(pre) = self.presolve {
+            kv(buf, "preind", i32::from(pre));
+            n += 1;
+        }
+        if let Some(e) = &self.mip_emphasis {
+            kv(
+                buf,
+                "mipemphasis",
+                match e {
+                    GamsCplexMipEmphasis::Balanced => 0,
+                    GamsCplexMipEmphasis::Feasibility => 1,
+                    GamsCplexMipEmphasis::Optimality => 2,
+                    GamsCplexMipEmphasis::BestBound => 3,
+                    GamsCplexMipEmphasis::HiddenFeasibility => 4,
+                },
+            );
+            n += 1;
+        }
+        w!("nodesel", self.node_select);
+        w!("varsel", self.var_select);
+        w!("epint", self.int_tol);
+        w!("eprhs", self.feasibility_tol);
+        w!("epopt", self.optimality_tol);
+        w!("lpmethod", self.lp_method);
+        n > 0
+    }
+}
+
+// - GUROBI
+
+/// `mipfocus` strategy for Gurobi.
+#[derive(Clone, Debug)]
+pub enum GamsGurobiMipFocus {
+    /// Balanced (0)
+    Balanced,
+    /// Emphasize feasible solutions (1)
+    Feasibility,
+    /// Emphasize proving optimality (2)
+    Optimality,
+    /// Emphasize improving best bound (3)
+    BestBound,
+}
+
+/// Options for the Gurobi LP/MIP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_GUROBI.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsGurobiOptions {
+    pub threads: Option<u32>,
+    /// Relative MIP gap (`mipgap`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`mipgapabs`)
+    pub mip_abs_gap: Option<f64>,
+    /// Max nodes (`nodelimit`).
+    pub node_limit: Option<u64>,
+    /// Presolve level (`presolve`)
+    pub presolve: Option<i32>,
+    /// Cut generation (`cuts`)
+    pub cuts: Option<i32>,
+    /// MIP heuristics effort (`heuristics`)
+    pub heuristics: Option<f64>,
+    /// Algorithm (`method`)
+    pub method: Option<i32>,
+    /// MIP solution focus (`mipfocus`)
+    pub mip_focus: Option<GamsGurobiMipFocus>,
+    /// Primal feasibility tolerance (`feasibilitytol`)
+    pub feasibility_tol: Option<f64>,
+    /// Integer feasibility tolerance (`intfeastol`)
+    pub int_feas_tol: Option<f64>,
+    /// Dual feasibility tolerance (`optimalitytol`)
+    pub optimality_tol: Option<f64>,
+}
+
+impl GamsGurobiOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("threads", self.threads);
+        w!("mipgap", self.mip_rel_gap);
+        w!("mipgapabs", self.mip_abs_gap);
+        w!("nodelimit", self.node_limit);
+        w!("presolve", self.presolve);
+        w!("cuts", self.cuts);
+        w!("heuristics", self.heuristics);
+        w!("method", self.method);
+        if let Some(f) = &self.mip_focus {
+            kv(
+                buf,
+                "mipfocus",
+                match f {
+                    GamsGurobiMipFocus::Balanced => 0,
+                    GamsGurobiMipFocus::Feasibility => 1,
+                    GamsGurobiMipFocus::Optimality => 2,
+                    GamsGurobiMipFocus::BestBound => 3,
+                },
+            );
+            n += 1;
+        }
+        w!("feasibilitytol", self.feasibility_tol);
+        w!("intfeastol", self.int_feas_tol);
+        w!("optimalitytol", self.optimality_tol);
+        n > 0
+    }
+}
+
+// - HiGHS
+
+/// `presolve` setting for HiGHS.
+#[derive(Clone, Debug)]
+pub enum GamsHighsPresolve {
+    On,
+    Off,
+    Choose,
+}
+
+/// LP algorithm for HiGHS.
+#[derive(Clone, Debug)]
+pub enum GamsHighsSolver {
+    Simplex,
+    Ipm,
+    Ipx,
+    Pdlp,
+    Choose,
+}
+
+/// Options for the HiGHS LP/MIP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_HIGHS.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsHighsOptions {
+    pub threads: Option<u32>,
+    /// Relative MIP gap (`mip_rel_gap`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`mip_abs_gap`)
+    pub mip_abs_gap: Option<f64>,
+    /// Max nodes (`nodlim`)
+    pub node_limit: Option<u64>,
+    pub presolve: Option<GamsHighsPresolve>,
+    pub solver: Option<GamsHighsSolver>,
+    pub primal_feasibility_tol: Option<f64>,
+    pub dual_feasibility_tol: Option<f64>,
+    pub optimality_tol: Option<f64>,
+}
+
+impl GamsHighsOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv_eq(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("threads", self.threads);
+        w!("mip_rel_gap", self.mip_rel_gap);
+        w!("mip_abs_gap", self.mip_abs_gap);
+        w!("nodlim", self.node_limit);
+        if let Some(p) = &self.presolve {
+            kv_eq(
+                buf,
+                "presolve",
+                match p {
+                    GamsHighsPresolve::On => "on",
+                    GamsHighsPresolve::Off => "off",
+                    GamsHighsPresolve::Choose => "choose",
+                },
+            );
+            n += 1;
+        }
+        if let Some(s) = &self.solver {
+            kv_eq(
+                buf,
+                "solver",
+                match s {
+                    GamsHighsSolver::Simplex => "simplex",
+                    GamsHighsSolver::Ipm => "ipm",
+                    GamsHighsSolver::Ipx => "ipx",
+                    GamsHighsSolver::Pdlp => "pdlp",
+                    GamsHighsSolver::Choose => "choose",
+                },
+            );
+            n += 1;
+        }
+        w!("primal_feasibility_tolerance", self.primal_feasibility_tol);
+        w!("dual_feasibility_tolerance", self.dual_feasibility_tol);
+        w!("optimality_tolerance", self.optimality_tol);
+        n > 0
+    }
+}
+
+// - IPOPT
+
+/// Linear solver for IPOPT.
+#[derive(Clone, Debug)]
+pub enum GamsIpoptLinearSolver {
+    Mumps,
+    Ma27,
+    Ma57,
+    Ma86,
+    Ma97,
+    PardisoMkl,
+}
+
+/// Barrier parameter update strategy for IPOPT.
+#[derive(Clone, Debug)]
+pub enum GamsIpoptMuStrategy {
+    Monotone,
+    Adaptive,
+}
+
+/// Options for the IPOPT NLP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_IPOPT.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsIpoptOptions {
+    /// Max iterations (`max_iter`)
+    pub max_iter: Option<u32>,
+    /// Primary optimality tolerance (`tol`)
+    pub tol: Option<f64>,
+    /// Constraint violation tolerance (`constr_viol_tol`)
+    pub constr_viol_tol: Option<f64>,
+    /// Dual infeasibility tolerance (`dual_inf_tol`)
+    pub dual_inf_tol: Option<f64>,
+    /// Complementarity tolerance (`compl_inf_tol`)
+    pub compl_inf_tol: Option<f64>,
+    /// Relaxed convergence tolerance (`acceptable_tol`)
+    pub acceptable_tol: Option<f64>,
+    pub linear_solver: Option<GamsIpoptLinearSolver>,
+    /// Print level 0–12 (`print_level`)
+    pub print_level: Option<u32>,
+    pub mu_strategy: Option<GamsIpoptMuStrategy>,
+}
+
+impl GamsIpoptOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("max_iter", self.max_iter);
+        w!("tol", self.tol);
+        w!("constr_viol_tol", self.constr_viol_tol);
+        w!("dual_inf_tol", self.dual_inf_tol);
+        w!("compl_inf_tol", self.compl_inf_tol);
+        w!("acceptable_tol", self.acceptable_tol);
+        if let Some(ls) = &self.linear_solver {
+            kv(
+                buf,
+                "linear_solver",
+                match ls {
+                    GamsIpoptLinearSolver::Mumps => "mumps",
+                    GamsIpoptLinearSolver::Ma27 => "ma27",
+                    GamsIpoptLinearSolver::Ma57 => "ma57",
+                    GamsIpoptLinearSolver::Ma86 => "ma86",
+                    GamsIpoptLinearSolver::Ma97 => "ma97",
+                    GamsIpoptLinearSolver::PardisoMkl => "pardisomkl",
+                },
+            );
+            n += 1;
+        }
+        w!("print_level", self.print_level);
+        if let Some(mu) = &self.mu_strategy {
+            kv(
+                buf,
+                "mu_strategy",
+                match mu {
+                    GamsIpoptMuStrategy::Monotone => "monotone",
+                    GamsIpoptMuStrategy::Adaptive => "adaptive",
+                },
+            );
+            n += 1;
+        }
+        n > 0
+    }
+}
+
+// - KNITRO
+
+/// NLP algorithm for KNITRO.
+#[derive(Clone, Debug)]
+pub enum GamsKnitroAlgorithm {
+    /// Automatic (0)
+    Auto,
+    /// Interior-point / Direct (1)
+    InteriorDirect,
+    /// Interior-point / CG (2)
+    InteriorCg,
+    /// Active-set (3)
+    ActiveSet,
+    /// SQP (4)
+    Sqp,
+}
+
+/// Options for the KNITRO NLP/MIP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_KNITRO.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsKnitroOptions {
+    pub algorithm: Option<GamsKnitroAlgorithm>,
+    /// Max iterations (`maxit`)
+    pub max_iter: Option<u32>,
+    /// Relative KKT optimality tolerance (`opttol`)
+    pub opt_tol: Option<f64>,
+    /// Absolute KKT optimality tolerance (`opttol_abs`)
+    pub opt_tol_abs: Option<f64>,
+    /// Relative feasibility tolerance (`feastol`)
+    pub feas_tol: Option<f64>,
+    /// Absolute feasibility tolerance (`feastol_abs`)
+    pub feas_tol_abs: Option<f64>,
+    pub threads: Option<u32>,
+    /// Max B&B nodes (`mip_maxnodes`)
+    pub mip_max_nodes: Option<u64>,
+    /// Relative MIP gap (`mip_opt_gap_rel`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`mip_opt_gap_abs`)
+    pub mip_abs_gap: Option<f64>,
+}
+
+impl GamsKnitroOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        if let Some(alg) = &self.algorithm {
+            kv(
+                buf,
+                "nlp_algorithm",
+                match alg {
+                    GamsKnitroAlgorithm::Auto => 0,
+                    GamsKnitroAlgorithm::InteriorDirect => 1,
+                    GamsKnitroAlgorithm::InteriorCg => 2,
+                    GamsKnitroAlgorithm::ActiveSet => 3,
+                    GamsKnitroAlgorithm::Sqp => 4,
+                },
+            );
+            n += 1;
+        }
+        w!("maxit", self.max_iter);
+        w!("opttol", self.opt_tol);
+        w!("opttol_abs", self.opt_tol_abs);
+        w!("feastol", self.feas_tol);
+        w!("feastol_abs", self.feas_tol_abs);
+        w!("threads", self.threads);
+        w!("mip_maxnodes", self.mip_max_nodes);
+        w!("mip_opt_gap_rel", self.mip_rel_gap);
+        w!("mip_opt_gap_abs", self.mip_abs_gap);
+        n > 0
+    }
+}
+
+// - MOSEK
+
+/// Options for the MOSEK LP/MIP/NLP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_MOSEK.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsMosekOptions {
+    /// Threads (`MSK_IPAR_NUM_THREADS`)
+    pub threads: Option<u32>,
+    /// Relative MIP gap (`MSK_DPAR_MIO_TOL_REL_GAP`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`MSK_DPAR_MIO_TOL_ABS_GAP`)
+    pub mip_abs_gap: Option<f64>,
+    /// Max relaxations in B&B (`MSK_IPAR_MIO_MAX_NUM_RELAXS`)
+    pub max_relaxations: Option<i64>,
+    /// Max branches (`MSK_IPAR_MIO_MAX_NUM_BRANCHES`)
+    pub max_branches: Option<i64>,
+    /// Primal feasibility tolerance (`MSK_DPAR_INTPNT_TOL_PFEAS`)
+    pub primal_feas_tol: Option<f64>,
+    /// Dual feasibility tolerance (`MSK_DPAR_INTPNT_TOL_DFEAS`)
+    pub dual_feas_tol: Option<f64>,
+    /// MIO feasibility tolerance (`MSK_DPAR_MIO_TOL_FEAS`)
+    pub mio_feas_tol: Option<f64>,
+    /// Integer relaxation tolerance (`MSK_DPAR_MIO_TOL_ABS_RELAX_INT`)
+    pub int_relax_tol: Option<f64>,
+}
+
+impl GamsMosekOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("MSK_IPAR_NUM_THREADS", self.threads);
+        w!("MSK_DPAR_MIO_TOL_REL_GAP", self.mip_rel_gap);
+        w!("MSK_DPAR_MIO_TOL_ABS_GAP", self.mip_abs_gap);
+        w!("MSK_IPAR_MIO_MAX_NUM_RELAXS", self.max_relaxations);
+        w!("MSK_IPAR_MIO_MAX_NUM_BRANCHES", self.max_branches);
+        w!("MSK_DPAR_INTPNT_TOL_PFEAS", self.primal_feas_tol);
+        w!("MSK_DPAR_INTPNT_TOL_DFEAS", self.dual_feas_tol);
+        w!("MSK_DPAR_MIO_TOL_FEAS", self.mio_feas_tol);
+        w!("MSK_DPAR_MIO_TOL_ABS_RELAX_INT", self.int_relax_tol);
+        n > 0
+    }
+}
+
+// - SCIP
+
+/// Options for the SCIP LP/MIP/NLP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_SCIP.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsScipOptions {
+    /// Max nodes (`limits/nodes`)
+    pub node_limit: Option<i64>,
+    /// Relative MIP gap (`limits/gap`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`limits/gapabs`)
+    pub mip_abs_gap: Option<f64>,
+    /// Stop after N feasible solutions (`limits/solutions`)
+    pub sol_limit: Option<u32>,
+    /// Primal feasibility tolerance (`numerics/feastol`)
+    pub feas_tol: Option<f64>,
+    /// Dual feasibility tolerance (`numerics/dualfeastol`)
+    pub dual_feas_tol: Option<f64>,
+    /// Max presolve rounds (`presolving/maxrounds`)
+    pub presolve_rounds: Option<i32>,
+    /// Separation rounds at root (`separating/maxroundsroot`)
+    pub sep_rounds_root: Option<u32>,
+}
+
+impl GamsScipOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv_eq(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("limits/nodes", self.node_limit);
+        w!("limits/gap", self.mip_rel_gap);
+        w!("limits/gapabs", self.mip_abs_gap);
+        w!("limits/solutions", self.sol_limit);
+        w!("numerics/feastol", self.feas_tol);
+        w!("numerics/dualfeastol", self.dual_feas_tol);
+        w!("presolving/maxrounds", self.presolve_rounds);
+        w!("separating/maxroundsroot", self.sep_rounds_root);
+        n > 0
+    }
+}
+
+// - XPRESS
+
+/// Options for the XPRESS LP/MIP solver.
+///
+/// Reference: <https://www.gams.com/latest/docs/S_XPRESS.html>
+#[derive(Clone, Debug, Default)]
+pub struct GamsXpressOptions {
+    pub threads: Option<u32>,
+    /// Relative MIP gap (`mipRelStop`)
+    pub mip_rel_gap: Option<f64>,
+    /// Absolute MIP gap (`mipAbsStop`)
+    pub mip_abs_gap: Option<f64>,
+    /// Max nodes (`maxNode`)
+    pub node_limit: Option<u64>,
+    /// Enable presolve (`presolve`)
+    pub presolve: Option<bool>,
+    /// Cut strategy (`cutStrategy`)
+    pub cut_strategy: Option<i32>,
+    /// Primal feasibility tolerance (`feasTol`)
+    pub feas_tol: Option<f64>,
+    /// Dual optimality tolerance (`optimalityTol`)
+    pub optimality_tol: Option<f64>,
+    /// MIP integrality tolerance (`mipTol`)
+    pub mip_tol: Option<f64>,
+    /// LP algorithm (`defaultAlg`)
+    pub lp_algorithm: Option<i32>,
+}
+
+impl GamsXpressOptions {
+    fn write(&self, buf: &mut String) -> bool {
+        let mut n = 0usize;
+        macro_rules! w {
+            ($key:expr, $opt:expr) => {
+                if let Some(v) = $opt {
+                    kv(buf, $key, v);
+                    n += 1;
+                }
+            };
+        }
+        w!("threads", self.threads);
+        w!("mipRelStop", self.mip_rel_gap);
+        w!("mipAbsStop", self.mip_abs_gap);
+        w!("maxNode", self.node_limit);
+        if let Some(p) = self.presolve {
+            kv(buf, "presolve", i32::from(p));
+            n += 1;
+        }
+        w!("cutStrategy", self.cut_strategy);
+        w!("feasTol", self.feas_tol);
+        w!("optimalityTol", self.optimality_tol);
+        w!("mipTol", self.mip_tol);
+        w!("defaultAlg", self.lp_algorithm);
+        n > 0
+    }
+}

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -122,10 +122,21 @@ pub fn solve(
 
     // Bounds
     for v in vars.iter() {
+        let i = v.id.index();
         if matches!(v.domain, Domain::Binary) {
+            // Default binary bounds are [0, 1], only emit when overridden.
+            if (v.lb - v.ub).abs() < f64::EPSILON {
+                writeln!(gms, "v{i}.fx = {};", fmt(v.lb)).unwrap();
+            } else {
+                if v.lb.abs() > f64::EPSILON {
+                    writeln!(gms, "v{i}.lo = {};", fmt(v.lb)).unwrap();
+                }
+                if (v.ub - 1.0).abs() > f64::EPSILON {
+                    writeln!(gms, "v{i}.up = {};", fmt(v.ub)).unwrap();
+                }
+            }
             continue;
         }
-        let i = v.id.index();
         // Lower bound
         if v.lb == f64::NEG_INFINITY {
             writeln!(gms, "v{i}.lo = -Inf;").unwrap();

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -1,0 +1,439 @@
+use std::fmt::Write as FmtWrite;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+use std::{fs, io};
+
+static SOLVE_ID: AtomicU64 = AtomicU64::new(0);
+
+use oximo_core::{Domain, Model, ModelKind, ObjectiveSense, Sense, VarId};
+use oximo_expr::{LinearTerms, extract_linear};
+use oximo_solver::{SolverError, SolverResult, SolverStatus};
+use rustc_hash::FxHashMap;
+
+use crate::GamsOptions;
+use crate::options::write_options;
+
+/// Write `model` to a temporary GAMS `.gms` file, execute the GAMS solver, and
+/// return the parsed [`SolverResult`].
+///
+/// `exec` is an optional override for the GAMS executable path; `None` uses
+/// `"gams"` resolved from `PATH`.
+///
+/// # Errors
+///
+/// Returns [`SolverError`] on unsupported model kind, nonlinear expressions,
+/// a missing GAMS executable, GAMS compilation errors, or I/O failures.
+///
+/// # Panics
+///
+/// Panics if variable indices overflow `u32`.
+#[allow(clippy::too_many_lines)]
+pub fn solve(
+    model: &Model,
+    opts: &GamsOptions,
+    exec: Option<&str>,
+) -> Result<SolverResult, SolverError> {
+    let kind = model.kind();
+    if !matches!(kind, ModelKind::LP | ModelKind::MILP) {
+        return Err(SolverError::UnsupportedKind(kind));
+    }
+
+    let arena = model.arena();
+    let vars = model.variables();
+    let constraints = model.constraints();
+    let objective = model.try_objective().map_err(SolverError::Core)?;
+
+    let obj_terms = extract_linear(&arena, objective.expr).ok_or(SolverError::Nonlinear)?;
+
+    let mut con_terms = Vec::with_capacity(constraints.len());
+    for c in constraints.iter() {
+        con_terms.push(extract_linear(&arena, c.lhs).ok_or(SolverError::Nonlinear)?);
+    }
+
+    let solve_type = if matches!(kind, ModelKind::MILP) { "MIP" } else { "LP" };
+    let sense_kw = match objective.sense {
+        ObjectiveSense::Minimize => "minimizing",
+        ObjectiveSense::Maximize => "maximizing",
+    };
+
+    // Pre-compute solver opt file content so we know whether to inject optfile=1.
+    let solver_opt: Option<(String, String)> = opts.solver.as_ref().and_then(|cfg| {
+        let mut buf = String::new();
+        if cfg.write_opt_file(&mut buf) {
+            let fname = format!("{}.opt", cfg.gams_name().to_ascii_lowercase());
+            Some((fname, buf))
+        } else {
+            None
+        }
+    });
+
+    // - Build the .gms file
+    let mut gms = String::with_capacity(4096);
+
+    writeln!(gms, "$title oximo_model").unwrap();
+    writeln!(gms, "$offSymList").unwrap();
+    writeln!(gms, "$offSymXRef").unwrap();
+    writeln!(gms, "option solprint = off;").unwrap();
+    writeln!(gms, "option limrow = 0;").unwrap();
+    writeln!(gms, "option limcol = 0;").unwrap();
+    writeln!(gms).unwrap();
+
+    // Variable declarations, split by domain
+    let (mut cont_vars, mut bin_vars, mut int_vars) = (Vec::new(), Vec::new(), Vec::new());
+    for v in vars.iter() {
+        match v.domain {
+            Domain::Binary => bin_vars.push(v),
+            Domain::Integer | Domain::SemiInteger { .. } => int_vars.push(v),
+            _ => cont_vars.push(v),
+        }
+    }
+
+    // Continuous + objective variable
+    write!(gms, "Variables\n    v_obj").unwrap();
+    for v in &cont_vars {
+        write!(gms, ", v{}", v.id.index()).unwrap();
+    }
+    writeln!(gms, ";").unwrap();
+
+    if !bin_vars.is_empty() {
+        write!(gms, "Binary Variables").unwrap();
+        for (k, v) in bin_vars.iter().enumerate() {
+            if k == 0 {
+                write!(gms, "\n    v{}", v.id.index()).unwrap();
+            } else {
+                write!(gms, ", v{}", v.id.index()).unwrap();
+            }
+        }
+        writeln!(gms, ";").unwrap();
+    }
+
+    if !int_vars.is_empty() {
+        write!(gms, "Integer Variables").unwrap();
+        for (k, v) in int_vars.iter().enumerate() {
+            if k == 0 {
+                write!(gms, "\n    v{}", v.id.index()).unwrap();
+            } else {
+                write!(gms, ", v{}", v.id.index()).unwrap();
+            }
+        }
+        writeln!(gms, ";").unwrap();
+    }
+    writeln!(gms).unwrap();
+
+    // Bounds
+    for v in vars.iter() {
+        if matches!(v.domain, Domain::Binary) {
+            continue;
+        }
+        let i = v.id.index();
+        // Lower bound
+        if v.lb == f64::NEG_INFINITY {
+            writeln!(gms, "v{i}.lo = -Inf;").unwrap();
+        } else if v.lb.is_finite() {
+            writeln!(gms, "v{i}.lo = {};", fmt(v.lb)).unwrap();
+        }
+        // Upper bound (+Inf is the GAMS default, only write when finite)
+        if v.ub.is_finite() {
+            writeln!(gms, "v{i}.up = {};", fmt(v.ub)).unwrap();
+        }
+    }
+    writeln!(gms).unwrap();
+
+    // Equations declaration
+    write!(gms, "Equations\n    eq_obj").unwrap();
+    for i in 0..constraints.len() {
+        write!(gms, ", eq_c{i}").unwrap();
+    }
+    writeln!(gms, ";").unwrap();
+    writeln!(gms).unwrap();
+
+    // Objective equation: v_obj =e= <full expr including constant>
+    write!(gms, "eq_obj..  v_obj =e=").unwrap();
+    write_expr(&mut gms, &obj_terms, true);
+    writeln!(gms, ";").unwrap();
+
+    // Constraint equations: variable terms only, constant folded into RHS
+    for (ci, (c, t)) in constraints.iter().zip(con_terms.iter()).enumerate() {
+        let adjusted_rhs = c.rhs - t.constant;
+        let sense_str = match c.sense {
+            Sense::Le => "=l=",
+            Sense::Ge => "=g=",
+            Sense::Eq => "=e=",
+        };
+        write!(gms, "eq_c{ci}..").unwrap();
+        write_expr(&mut gms, t, false);
+        writeln!(gms, " {sense_str} {};", fmt(adjusted_rhs)).unwrap();
+    }
+    writeln!(gms).unwrap();
+
+    // Options (time limit, MIP gap, sub-solver, etc.)
+    write_options(&mut gms, opts, solve_type);
+
+    // Model and solve statements
+    writeln!(gms, "Model oximo_m / all /;").unwrap();
+    if solver_opt.is_some() {
+        writeln!(gms, "oximo_m.optfile = 1;").unwrap();
+    }
+    writeln!(gms, "Solve oximo_m using {solve_type} {sense_kw} v_obj;").unwrap();
+    writeln!(gms).unwrap();
+
+    // - Temp directory
+    // Combine timestamp with a per-process atomic counter so concurrent
+    // invocations (e.g. parallel threads) never share a directory.
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis());
+    let id = SOLVE_ID.fetch_add(1, Ordering::Relaxed);
+    let tmp_dir = std::env::temp_dir().join(format!("oximo_gams_{ts}_{id}"));
+    fs::create_dir_all(&tmp_dir)
+        .map_err(|e| SolverError::Backend(format!("cannot create temp dir: {e}")))?;
+
+    let sol_path = tmp_dir.join("solution.txt");
+    writeln!(gms, "File oximo_sol / 'solution.txt' /;").unwrap();
+    writeln!(gms, "Put oximo_sol;").unwrap();
+    writeln!(gms, "Put 'STATUS=' oximo_m.modelstat:0:0 /;").unwrap();
+    writeln!(gms, "Put 'SOLVESTAT=' oximo_m.solvestat:0:0 /;").unwrap();
+    writeln!(gms, "Put 'OBJVAL=' v_obj.l:0:15 /;").unwrap();
+    for i in 0..vars.len() {
+        writeln!(gms, "Put '{i}=' v{i}.l:0:15 /;").unwrap();
+    }
+    writeln!(gms, "Putclose oximo_sol;").unwrap();
+
+    drop(arena);
+    drop(vars);
+    drop(constraints);
+
+    // - Write .gms file
+    let gms_path = tmp_dir.join("model.gms");
+    fs::write(&gms_path, &gms)
+        .map_err(|e| SolverError::Backend(format!("cannot write .gms file: {e}")))?;
+
+    // - Write solver opt file (if any)
+    if let Some((ref fname, ref content)) = solver_opt {
+        fs::write(tmp_dir.join(fname), content)
+            .map_err(|e| SolverError::Backend(format!("cannot write solver opt file: {e}")))?;
+    }
+
+    // - Execute GAMS
+    let gams_exec =
+        opts.gams_path.as_deref().and_then(std::path::Path::to_str).or(exec).unwrap_or("gams");
+
+    let verbose = opts.universal.verbose.unwrap_or(false);
+
+    let started = Instant::now();
+    let mut cmd = std::process::Command::new(gams_exec);
+    cmd.arg(&gms_path);
+    if !verbose {
+        cmd.arg("lo=0");
+    }
+    cmd.current_dir(&tmp_dir);
+
+    let output = cmd.output().map_err(|e| {
+        let _ = fs::remove_dir_all(&tmp_dir);
+        if e.kind() == io::ErrorKind::NotFound {
+            SolverError::Backend(format!(
+                "GAMS executable '{gams_exec}' not found. \
+                Install GAMS and ensure it is on PATH, or set the 'gams_path' option."
+            ))
+        } else {
+            SolverError::Backend(format!("failed to launch GAMS: {e}"))
+        }
+    })?;
+    let elapsed = started.elapsed();
+
+    let raw_log = if verbose || !output.status.success() {
+        let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+        if !output.stderr.is_empty() {
+            log.push('\n');
+            log.push_str(&String::from_utf8_lossy(&output.stderr));
+        }
+        Some(log)
+    } else {
+        None
+    };
+
+    // - Parse solution file
+    // Check the solution file before the exit code: GAMS may return a
+    // non-zero exit on infeasible/unbounded models while still writing a
+    // valid modelstat to the PUT file.
+    let result = if sol_path.exists() {
+        let content = fs::read_to_string(&sol_path)
+            .map_err(|e| SolverError::Backend(format!("cannot read solution file: {e}")))?;
+        parseoximo_solution(&content, elapsed, raw_log)
+    } else {
+        // No solution file. GAMS must have failed before the Solve statement
+        // (compilation error, license error, etc.).  Fall back to the listing.
+        let listing = fs::read_to_string(tmp_dir.join("model.lst")).unwrap_or_default();
+        let _ = fs::remove_dir_all(&tmp_dir);
+        let detail = if output.status.success() {
+            format!(
+                "GAMS did not produce a solution file. \
+                Check the .gms listing for compilation errors.\n{listing}"
+            )
+        } else {
+            format!("GAMS exited with code {:?}.\n{listing}", output.status.code())
+        };
+        return Err(SolverError::Backend(detail));
+    };
+
+    let _ = fs::remove_dir_all(&tmp_dir);
+    Ok(result)
+}
+
+/// Parse the PUT-generated solution file.
+fn parseoximo_solution(
+    content: &str,
+    elapsed: std::time::Duration,
+    raw_log: Option<String>,
+) -> SolverResult {
+    let mut modelstat: Option<i32> = None;
+    let mut solvestat: Option<i32> = None;
+    let mut obj_val: Option<f64> = None;
+    let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("STATUS=") {
+            modelstat = parse_gams_int(rest);
+        } else if let Some(rest) = line.strip_prefix("SOLVESTAT=") {
+            solvestat = parse_gams_int(rest);
+        } else if let Some(rest) = line.strip_prefix("OBJVAL=") {
+            obj_val = parse_gams_float(rest);
+        } else if let Some(eq) = line.find('=') {
+            let key = line[..eq].trim();
+            if let Ok(idx) = key.parse::<u32>() {
+                if let Some(val) = parse_gams_float(line[eq + 1..].trim()) {
+                    primal.insert(VarId(idx), val);
+                }
+            }
+        }
+    }
+
+    let status = map_status(modelstat.unwrap_or(13), solvestat.unwrap_or(0));
+
+    SolverResult {
+        objective: if status.has_solution() { obj_val } else { None },
+        primal: if status.has_solution() { primal } else { FxHashMap::default() },
+        dual: FxHashMap::default(),
+        reduced_costs: FxHashMap::default(),
+        status,
+        solve_time: elapsed,
+        iterations: 0,
+        raw_log,
+    }
+}
+
+/// Map GAMS model-status to `SolverStatus`.
+///
+/// Full modelstat table (codes 1-19):
+///  1 = Optimal,
+///  2 = Locally Optimal,
+///  3 = Unbounded,
+///  4 = Infeasible,
+///  5 = Locally Infeasible,
+///  6 = Intermediate Infeasible,
+///  7 = Feasible Solution,
+///  8 = Integer Solution,
+///  9 = Intermediate Non-integer,
+///  10 = Integer Infeasible,
+///  11 = Lic Problem No Solution,
+///  12 = Error Unknown,
+///  13 = Error No Solution,
+///  14 = No Solution Returned,
+///  15 = Solved Unique,
+///  16 = Solved,
+///  17 = Solved Singular,
+///  18 = Unbounded-No Solution,
+///  19 = Infeasible-No Solution.
+///
+/// References:
+/// "GAMS Output - Model Status," GAMS Development Corporation.
+/// <https://www.gams.com/latest/docs/UG_GAMSOutput.html#UG_GAMSOutput_ModelStatus> (accessed May 14, 2026).
+fn map_status(modelstat: i32, solvestat: i32) -> SolverStatus {
+    // TODO: Could refine this mapping if we modify the `SolverStatus` enum.
+    match modelstat {
+        1 | 15 | 16 => SolverStatus::Optimal,
+        2 | 7 | 9 | 17 => SolverStatus::Feasible,
+        3 | 18 => SolverStatus::Unbounded,
+        4 | 5 | 6 | 10 | 19 => SolverStatus::Infeasible,
+        // MIP integer solution: proven optimal when solvestat == 1 (normal completion)
+        8 => {
+            if solvestat == 1 {
+                SolverStatus::Optimal
+            } else {
+                SolverStatus::Feasible
+            }
+        }
+        11 => SolverStatus::Other("gams_license_error".into()),
+        _ => SolverStatus::Other(format!("gams_modelstat_{modelstat}")),
+    }
+}
+
+// - Helpers
+
+/// Append the linear expression `t` to `gms`.
+/// When `include_constant` is true, the constant term is included; otherwise
+/// only variable terms are emitted (used for constraints where the constant is
+/// folded into the RHS).
+fn write_expr(gms: &mut String, t: &LinearTerms, include_constant: bool) {
+    let mut first = true;
+    for (v, coef) in &t.coeffs {
+        if *coef == 0.0 {
+            continue;
+        }
+        let idx = v.index();
+        if first {
+            write!(gms, " {}*v{idx}", fmt(*coef)).unwrap();
+            first = false;
+        } else if *coef < 0.0 {
+            write!(gms, " - {}*v{idx}", fmt(-coef)).unwrap();
+        } else {
+            write!(gms, " + {}*v{idx}", fmt(*coef)).unwrap();
+        }
+    }
+    if include_constant && t.constant != 0.0 {
+        if first {
+            write!(gms, " {}", fmt(t.constant)).unwrap();
+            first = false;
+        } else if t.constant < 0.0 {
+            write!(gms, " - {}", fmt(-t.constant)).unwrap();
+        } else {
+            write!(gms, " + {}", fmt(t.constant)).unwrap();
+        }
+    }
+    if first {
+        write!(gms, " 0").unwrap();
+    }
+}
+
+/// Format an `f64` for use in a GAMS file.
+fn fmt(v: f64) -> String {
+    if v == f64::INFINITY {
+        return "+Inf".into();
+    }
+    if v == f64::NEG_INFINITY {
+        return "-Inf".into();
+    }
+    format!("{v}")
+}
+
+/// Parse a GAMS-formatted integer (may be written as `"1"` or `"1.000"`).
+fn parse_gams_int(s: &str) -> Option<i32> {
+    let trimmed = s.trim();
+    if let Ok(n) = trimmed.parse::<i32>() {
+        return Some(n);
+    }
+    // Fall back through f64 for GAMS formats like "1.000".
+    #[allow(clippy::cast_possible_truncation)]
+    trimmed.parse::<f64>().ok().map(|f| f.round() as i32)
+}
+
+/// Parse a GAMS-formatted float, tolerating GAMS special tokens.
+fn parse_gams_float(s: &str) -> Option<f64> {
+    match s.trim() {
+        "INF" | "+INF" | "Inf" | "+Inf" => Some(f64::INFINITY),
+        "-INF" | "-Inf" => Some(f64::NEG_INFINITY),
+        "NA" | "UNDF" | "EPS" => Some(0.0),
+        other => other.parse().ok(),
+    }
+}

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write as FmtWrite;
+use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use std::{fs, io};
@@ -239,7 +240,9 @@ pub fn solve(
     }
     cmd.current_dir(&tmp_dir);
 
-    let output = cmd.output().map_err(|e| {
+    // When verbose, inherit stdio so that GAMS writes directly to the terminal in
+    // real time. When silent, capture output so errors can be surfaced later.
+    let launch_err = |e: io::Error| {
         let _ = fs::remove_dir_all(&tmp_dir);
         if e.kind() == io::ErrorKind::NotFound {
             SolverError::Backend(format!(
@@ -249,19 +252,27 @@ pub fn solve(
         } else {
             SolverError::Backend(format!("failed to launch GAMS: {e}"))
         }
-    })?;
-    let elapsed = started.elapsed();
-
-    let raw_log = if verbose || !output.status.success() {
-        let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
-        if !output.stderr.is_empty() {
-            log.push('\n');
-            log.push_str(&String::from_utf8_lossy(&output.stderr));
-        }
-        Some(log)
-    } else {
-        None
     };
+
+    let (exit_ok, raw_log) = if verbose {
+        let status =
+            cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit()).status().map_err(launch_err)?;
+        (status.success(), None)
+    } else {
+        let out = cmd.output().map_err(launch_err)?;
+        let log = if out.status.success() {
+            None
+        } else {
+            let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+            if !out.stderr.is_empty() {
+                s.push('\n');
+                s.push_str(&String::from_utf8_lossy(&out.stderr));
+            }
+            Some(s)
+        };
+        (out.status.success(), log)
+    };
+    let elapsed = started.elapsed();
 
     // - Parse solution file
     // Check the solution file before the exit code: GAMS may return a
@@ -276,13 +287,13 @@ pub fn solve(
         // (compilation error, license error, etc.).  Fall back to the listing.
         let listing = fs::read_to_string(tmp_dir.join("model.lst")).unwrap_or_default();
         let _ = fs::remove_dir_all(&tmp_dir);
-        let detail = if output.status.success() {
+        let detail = if exit_ok {
             format!(
                 "GAMS did not produce a solution file. \
                 Check the .gms listing for compilation errors.\n{listing}"
             )
         } else {
-            format!("GAMS exited with code {:?}.\n{listing}", output.status.code())
+            format!("GAMS exited with a non-zero exit code.\n{listing}")
         };
         return Err(SolverError::Backend(detail));
     };

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -1,0 +1,156 @@
+//! Logical inference for reaction path synthesis (MILP).
+//!
+//! Given 22 possible chemical reactions over 34 chemicals, determine whether
+//! acetone (y06, ch3coch3) can be synthesized from a fixed set of raw materials
+//! and catalysts.
+//!
+//! Binary variable `y[v] = 1` if chemical `v` is synthesizable. Available raw
+//! materials are fixed to 1, unavailable chemicals to 0. For each reaction that
+//! can produce `v` from reactants `vv`:
+//!
+//! ```text
+//! sum_vv (1 - y[vv]) >= 1 - y[v]
+//! ```
+//!
+//! This forces: if all reactants are present, the product must be present.
+//! Minimizing `y[y06]` reveals whether acetone is synthesizable (optimal = 1).
+//!
+//! This example is translated from GAMS code in the REACTION model (SEQ=121).
+//!
+//! Reference:
+//! Raman, R, and Grossmann, I E, "Relation between MINLP Modeling
+//! and Logical Inference for Chemical Process Synthesis", Computers and
+//! Chemical Engineering 15, 2 (1991), 73–84.
+//!
+//! Run with HiGHS (default):
+//! ```text
+//! cargo run --example reaction_path
+//! ```
+//!
+//! Run with GAMS / CPLEX:
+//! ```text
+//! cargo run --example reaction_path --features gams
+//! ```
+//! Requires a licensed GAMS installation with CPLEX on PATH.
+
+#[cfg(any(feature = "gams", feature = "highs"))]
+use oximo::prelude::*;
+
+#[cfg(feature = "gams")]
+use oximo::gams::{GamsCplexOptions, GamsSolverConfig};
+#[cfg(feature = "gams")]
+use oximo::solvers::Gams;
+
+#[cfg(all(feature = "highs", not(feature = "gams")))]
+use oximo::solvers::Highs;
+
+#[cfg(any(feature = "gams", feature = "highs"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 34 chemicals: index = yXX - 1 (y01 -> 0, ..., y34 -> 33).
+    const CHEMICALS: [&str; 34] = [
+        "y01", "y02", "y03", "y04", "y05", "y06", "y07", "y08", "y09", "y10", "y11", "y12", "y13",
+        "y14", "y15", "y16", "y17", "y18", "y19", "y20", "y21", "y22", "y23", "y24", "y25", "y26",
+        "y27", "y28", "y29", "y30", "y31", "y32", "y33", "y34",
+    ];
+
+    // (reaction label, product index, reactant indices) - all 0-based.
+    // Transcribed from logicc set in GAMS REACTION model (SEQ=121).
+    let logicc: &[(&str, usize, &[usize])] = &[
+        ("rxn01", 3, &[0, 1, 2]),      // y04 <- y01 + y02 + y03
+        ("rxn02", 5, &[3, 4]),         // y06 <- y04 + y05
+        ("rxn03", 6, &[3, 4]),         // y07 <- y04 + y05
+        ("rxn04", 2, &[3, 4]),         // y03 <- y04 + y05
+        ("rxn05", 10, &[7, 8, 9]),     // y11 <- y08 + y09 + y10
+        ("rxn06", 5, &[10, 11, 12]),   // y06 <- y11 + y12 + y13
+        ("rxn07", 14, &[13, 8, 9, 4]), // y15 <- y14 + y09 + y10 + y05
+        ("rxn08", 5, &[14, 15, 16]),   // y06 <- y15 + y16 + y17
+        ("rxn09", 5, &[17, 18, 11]),   // y06 <- y18 + y19 + y12
+        ("rxn10", 19, &[17, 18, 11]),  // y20 <- y18 + y19 + y12
+        ("rxn11", 8, &[20, 21]),       // y09 <- y21 + y22
+        ("rxn12", 23, &[8, 22]),       // y24 <- y09 + y23
+        ("rxn13", 17, &[23, 16]),      // y18 <- y24 + y17
+        ("rxn14", 20, &[24, 25]),      // y21 <- y25 + y26
+        ("rxn15", 26, &[24, 25]),      // y27 <- y25 + y26
+        ("rxn16", 13, &[2, 27, 28]),   // y14 <- y03 + y28 + y29
+        ("rxn17", 31, &[29, 30, 11]),  // y32 <- y30 + y31 + y12
+        ("rxn18", 7, &[29, 30, 11]),   // y08 <- y30 + y31 + y12
+        ("rxn19", 29, &[24, 32]),      // y30 <- y25 + y33
+        ("rxn20", 12, &[24, 32]),      // y13 <- y25 + y33
+        ("rxn21", 0, &[33, 2]),        // y01 <- y34 + y03
+        ("rxn22", 33, &[13, 27]),      // y34 <- y14 + y28
+    ];
+
+    // y02, y03, y05, y10, y12, y13, y17, y22, y25, y26, y28, y31, y33: fixed to 1 via lb=ub=1.
+    let available: &[usize] = &[1, 2, 4, 9, 11, 12, 16, 21, 24, 25, 27, 30, 32];
+    // y16, y19: fixed to 0 via ub=0.
+    let unavailable: &[usize] = &[15, 18];
+
+    let m = Model::new("reaction_path");
+
+    // TODO: Improve this when we add the `.fix()` method for fixing variables.
+    let y: Vec<_> = CHEMICALS
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let b = m.var(*name).binary();
+            if available.contains(&i) {
+                b.lb(1.0).ub(1.0).build()
+            } else if unavailable.contains(&i) {
+                b.ub(0.0).build()
+            } else {
+                b.build()
+            }
+        })
+        .collect();
+
+    // sum_vv (1 - y[vv]) >= 1 - y[v]
+    //    <=>  y[v] - sum_vv y[vv] >= 1 - |reactants|
+    for &(rx, prod, reactants) in logicc {
+        let n = reactants.len() as f64;
+        let reactant_sum = sum(reactants.iter().map(|&vv| y[vv]));
+        m.constraint(format!("leq_{rx}"), (y[prod] - reactant_sum).ge(1.0 - n));
+    }
+
+    m.minimize(y[5]); // y06 = acetone
+
+    #[cfg(feature = "gams")]
+    let result = {
+        let opts = GamsOptions::default()
+            .time_limit(std::time::Duration::from_secs(60))
+            .solver(GamsSolverConfig::Cplex(GamsCplexOptions::default()))
+            .verbose(true);
+        let mut solver = Gams::new();
+        solver.solve(&m, &opts)?
+    };
+
+    #[cfg(all(feature = "highs", not(feature = "gams")))]
+    let result = Highs.solve(&m, &HighsOptions::default().verbose(true))?;
+
+    println!("Status : {:?}", result.status);
+    if let Some(obj) = result.objective {
+        println!(
+            "Acetone (y06, ch3coch3): {}",
+            if obj == 1.0 { "Synthesizable" } else { "Not synthesizable" }
+        );
+    }
+
+    let synthesizable: Vec<&str> = y
+        .iter()
+        .enumerate()
+        .filter_map(|(i, var)| {
+            if result.value_of(*var).unwrap_or(0.0) == 1.0 { Some(CHEMICALS[i]) } else { None }
+        })
+        .collect();
+    if !synthesizable.is_empty() {
+        println!("Synthesizable chemicals: {}", synthesizable.join(", "));
+    }
+
+    Ok(())
+}
+
+#[cfg(not(any(feature = "gams", feature = "highs")))]
+fn main() {
+    println!("Enable at least one solver feature:");
+    println!("  cargo run --example reaction_path                  # HiGHS (default)");
+    println!("  cargo run --example reaction_path --features gams  # GAMS/CPLEX");
+}

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -27,6 +27,22 @@ pub use oximo_highs::{HighsMethod, HighsOptions, HighsPresolve};
 
 #[cfg(feature = "gurobi")]
 pub use oximo_gurobi::{GurobiOptions, GurobiPresolve};
+
+#[cfg(feature = "gams")]
+pub use oximo_gams::{GamsOptions, GamsSolver};
+
+/// GAMS backend types: sub-solver selection and per-solver option structs.
+#[cfg(feature = "gams")]
+pub mod gams {
+    pub use oximo_gams::{
+        GamsBaronOptions, GamsCbcCuts, GamsCbcOptions, GamsCbcPresolve, GamsCplexMipEmphasis,
+        GamsCplexOptions, GamsGurobiMipFocus, GamsGurobiOptions, GamsHighsOptions,
+        GamsHighsPresolve, GamsHighsSolver, GamsIpoptLinearSolver, GamsIpoptMuStrategy,
+        GamsIpoptOptions, GamsKnitroAlgorithm, GamsKnitroOptions, GamsMosekOptions, GamsOptions,
+        GamsScipOptions, GamsSolver, GamsSolverConfig, GamsXpressOptions,
+    };
+}
+
 pub mod prelude {
     //! Glob-import target. Brings the modeling and solver surface into scope.
     pub use oximo_core::prelude::*;
@@ -40,6 +56,9 @@ pub mod prelude {
 
     #[cfg(feature = "gurobi")]
     pub use oximo_gurobi::{GurobiOptions, GurobiPresolve};
+
+    #[cfg(feature = "gams")]
+    pub use oximo_gams::{GamsOptions, GamsSolver};
 }
 
 pub mod solvers {

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests shell out to a GAMS installation and are therefore
 //! compiled and run only when `--features gams` is passed.  Each test
-//! mirrors the corresponding HiGHS test in `solve.rs` so that regressions 
+//! mirrors the corresponding HiGHS test in `solve.rs` so that regressions
 //! are caught on both backends.
 //!
 //! Run with:

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -1,0 +1,107 @@
+//! Integration tests for the GAMS backend.
+//!
+//! These tests shell out to a GAMS installation and are therefore
+//! compiled and run only when `--features gams` is passed.  Each test
+//! mirrors the corresponding HiGHS test in `solve.rs` so that regressions 
+//! are caught on both backends.
+//!
+//! Run with:
+//! ```
+//! cargo test -p oximo --features gams --test solve_gams
+//! ```
+
+#![cfg(feature = "gams")]
+
+use std::time::Duration;
+
+use oximo::gams::{GamsHighsOptions, GamsHighsSolver, GamsSolverConfig};
+use oximo::prelude::*;
+use oximo::solvers::Gams;
+
+#[test]
+fn gams_lp_canonical() {
+    let m = Model::new("lp");
+    let x = m.var("x").lb(0.0).build();
+    let y = m.var("y").lb(0.0).ub(4.0).build();
+    m.constraint("c1", (x + 2.0 * y).le(14.0));
+    m.constraint("c2", (3.0 * x - y).ge(0.0));
+    m.constraint("c3", (x - y).le(2.0));
+    m.maximize(3.0 * x + 4.0 * y);
+
+    let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
+    let result = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(result.status, SolverStatus::Optimal);
+    assert!((result.objective.unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective);
+    assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-4);
+    assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-4);
+}
+
+#[test]
+fn gams_knapsack_milp() {
+    let weights = [3.0, 4.0, 2.0, 5.0, 1.0, 6.0, 7.0, 2.0];
+    let values = [10.0, 12.0, 5.0, 14.0, 3.0, 18.0, 22.0, 6.0];
+
+    let m = Model::new("knapsack");
+    let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
+    let weight_sum = sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x));
+    m.constraint("cap", weight_sum.le(15.0));
+    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+
+    let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
+    let result = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(result.status, SolverStatus::Optimal);
+    assert!((result.objective.unwrap() - 47.0).abs() < 1e-4, "obj={:?}", result.objective);
+}
+
+#[test]
+fn gams_infeasible_returns_status() {
+    let m = Model::new("infeas");
+    let x = m.var("x").lb(0.0).ub(1.0).build();
+    m.constraint("c1", x.ge(5.0));
+    m.minimize(x);
+
+    let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
+    let result = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(result.status, SolverStatus::Infeasible);
+}
+
+#[test]
+fn gams_mip_gap_option() {
+    let weights = [3.0, 4.0, 2.0, 5.0, 1.0];
+    let values = [10.0, 12.0, 5.0, 14.0, 3.0];
+    let m = Model::new("ks");
+    let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
+    m.constraint("cap", sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x)).le(8.0));
+    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+
+    let result = Gams::new().solve(&m, &GamsOptions::default().mip_gap(0.5)).unwrap();
+    assert!(
+        matches!(result.status, SolverStatus::Optimal | SolverStatus::Feasible),
+        "unexpected status: {:?}",
+        result.status
+    );
+    assert!(result.objective.unwrap() > 0.0);
+}
+
+/// Exercises the typed-options path: a `highs.opt` file is written with
+/// `solver = simplex` and GAMS picks it up via `model.optfile = 1`.
+///
+/// Requires GAMS with HiGHS available as a sub-solver.
+#[test]
+fn gams_highs_opt_file_simplex() {
+    let m = Model::new("lp");
+    let x = m.var("x").lb(0.0).build();
+    let y = m.var("y").lb(0.0).ub(4.0).build();
+    m.constraint("c1", (x + 2.0 * y).le(14.0));
+    m.constraint("c2", (3.0 * x - y).ge(0.0));
+    m.constraint("c3", (x - y).le(2.0));
+    m.maximize(3.0 * x + 4.0 * y);
+
+    let opts = GamsOptions::default().solver(GamsSolverConfig::Highs(GamsHighsOptions {
+        solver: Some(GamsHighsSolver::Simplex),
+        ..Default::default()
+    }));
+    let result = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(result.status, SolverStatus::Optimal);
+    assert!((result.objective.unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective);
+}


### PR DESCRIPTION
This commit adds a GAMS writer and backend.

**Note: The API and implementation were written by me, but LLMs were used to generate the `SolverConfig` code. The structs for each solver's options were added using GitHub Copilot, with references to the GAMS docs.**