### PR TITLE
Expand the `Set`s and indexing API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ smol_str     = "0.3.6"
 rustc-hash   = "2.1"
 ndarray      = "0.17"
 thiserror    = "2.0"
+num-traits   = "0.2"
 highs        = "2.1"
 grb          = "3.0"
 

--- a/README.md
+++ b/README.md
@@ -67,23 +67,84 @@ m.minimize(3.0 * x + 5.0 * y);
 m.maximize(x + 2.0 * y);
 ```
 
-### Indexed variables
+### Index sets
+
+`Set` is the modeling-layer container for an ordered, finite index set. Build
+one over integers, strings, or arbitrary tuples. You can combine sets with the
+Cartesian product operator `&a * &b`, and filter sparsely.
 
 ```rust
-use oximo::core::Set;
+use oximo::prelude::*;
 
 let items = Set::range(0..5);
-let xs = m.indexed_var("x", &items); // creates x[0] ... x[4]
+let n_items = Set::range(0..weights.len());
+let plants = Set::strings(["seattle", "san-diego"]);
 
-// Access individual variables
-let x0 = xs.get(&0).unwrap();
+// Cartesian product -> tuple keys, flattens automatically across nesting.
+let routes = &plants * &Set::strings(["nyc", "chi", "topeka"]);
+assert_eq!(routes.len(), 6);
+
+// Sparse subsets via filter without self-loops
+let arcs = (&plants * &plants).filter(|k| {
+    let p = k.as_tuple().unwrap();
+    p[0] != p[1]
+});
 ```
 
-### Summing over iterators
+### Indexed variables
+
+`Model::indexed_var(name, &set)` registers one scalar per key with auto-named
+entries like `x[seattle,nyc]`. Bounds apply uniformly by default, you can use
+`lb_by` / `ub_by` for per-key bounds.
 
 ```rust
-let total = sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x));
-m.constraint("cap", total.le(capacity));
+let m = Model::new("transport");
+let x = m.indexed_var("x", &routes).lb(0.0).build();
+
+// Scalar lookup: any type that converts to IndexKey works.
+let e1 = x[("seattle", "nyc")];
+let e2 = x[("san-diego", "chi")];
+
+// Per-key upper bound (e.g. capacity per arc).
+let _y = m.indexed_var("y", &routes)
+    .lb(0.0)
+    .ub_by(|(p, q): (String, String)| capacity_for(&p, &q))
+    .build();
+```
+
+### Rule-style constraints
+
+`Model::add_constraints_over` is a closure that receives the index as a typed
+value via `FromIndexKey`.
+
+Built-in impls cover `i64`, `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to
+arity 4. State the shape in the closure-arg annotation.
+
+```rust
+// Scalar set: one constraint per period.
+let periods = Set::range(0..T);
+m.add_constraints_over("setup", &periods, |t: usize| {
+    (x[t] - capacity * s[t]).le(0.0)
+});
+
+// Tuple set: destructure inline.
+m.add_constraints_over("supply", &plants, |p: String| {
+    sum(markets.iter().map(|q| x[(p.clone(), q)])).le(supply_of(&p))
+});
+
+// Want the raw key? Annotate as IndexKey (clones once per iteration).
+m.add_constraints_over("c", &set, |k: IndexKey| x[&k].le(1.0));
+```
+
+### Summing over sets
+
+```rust
+// Linear-fastpath aware: `sum` collapses to a single Linear arena node.
+let total_weight = sum(items.iter().map(|k| {
+    let i: usize = FromIndexKey::from_index_key(&k);
+    weights[i] * x[i]
+}));
+m.constraint("cap", total_weight.le(capacity));
 ```
 
 ## Solving

--- a/crates/oximo-core/Cargo.toml
+++ b/crates/oximo-core/Cargo.toml
@@ -15,6 +15,7 @@ smallvec.workspace = true
 smol_str.workspace = true
 rustc-hash.workspace = true
 ndarray.workspace = true
+num-traits.workspace = true
 thiserror.workspace = true
 
 [lints]

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -38,3 +38,10 @@ impl<'a, K: Into<IndexKey> + Clone> Index<K> for IndexedVar<'a> {
         self.entries.get(&key.into()).expect("IndexedVar: key not present")
     }
 }
+
+impl<'a> Index<&IndexKey> for IndexedVar<'a> {
+    type Output = Expr<'a>;
+    fn index(&self, key: &IndexKey) -> &Self::Output {
+        self.entries.get(key).expect("IndexedVar: key not present")
+    }
+}

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -20,10 +20,10 @@ pub use constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, 
 pub use domain::Domain;
 pub use error::{Error, Result};
 pub use indexed::IndexedVar;
-pub use model::{IndexedVarBuilder, Model, ModelKind};
+pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
-pub use set::{IndexKey, Set, SetIter};
+pub use set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
 pub use var::{VarBuilder, Variable};
 
 // Re-export the expression handle so downstream code does not need a separate

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -198,7 +198,7 @@ impl Model {
     /// # Example
     /// ```ignore
     /// // Scalar set: closure receives a usize directly.
-    /// m.add_constraints_over("upper", &i, |i: usize| x[i as i64].le(b[i]));
+    /// m.add_constraints_over("upper", &i, |i: usize| x[i].le(b[i]));
     ///
     /// // Tuple set: destructure inline.
     /// m.add_constraints_over("blo", &(&tasks * &events), |(t, n): (usize, usize)| {

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -355,19 +355,35 @@ impl<'a> IndexedVarBuilder<'a> {
         self
     }
     /// Per-key lower bound. Overrides [`Self::lb`] when both are set.
-    pub fn lb_by<F>(mut self, f: F) -> Self
+    ///
+    /// The closure receives a typed index value via [`FromIndexKey`].
+    /// Annotate the argument to select the projection:
+    /// ```ignore
+    /// .lb_by(|(p, q): (String, String)| floor_for(&p, &q))
+    /// .lb_by(|i: usize| lower_bounds[i])
+    /// ```
+    pub fn lb_by<K, F>(mut self, f: F) -> Self
     where
-        F: Fn(&IndexKey) -> f64 + 'a,
+        K: FromIndexKey,
+        F: Fn(K) -> f64 + 'a,
     {
-        self.lb_by = Some(Box::new(f));
+        self.lb_by = Some(Box::new(move |k: &IndexKey| f(K::from_index_key(k))));
         self
     }
     /// Per-key upper bound. Overrides [`Self::ub`] when both are set.
-    pub fn ub_by<F>(mut self, f: F) -> Self
+    ///
+    /// The closure receives a typed index value via [`FromIndexKey`]; annotate
+    /// the argument to select the projection:
+    /// ```ignore
+    /// .ub_by(|(p, q): (String, String)| capacity_for(&p, &q))
+    /// .ub_by(|i: usize| upper_bounds[i])
+    /// ```
+    pub fn ub_by<K, F>(mut self, f: F) -> Self
     where
-        F: Fn(&IndexKey) -> f64 + 'a,
+        K: FromIndexKey,
+        F: Fn(K) -> f64 + 'a,
     {
-        self.ub_by = Some(Box::new(f));
+        self.ub_by = Some(Box::new(move |k: &IndexKey| f(K::from_index_key(k))));
         self
     }
     pub fn domain(mut self, d: Domain) -> Self {

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -9,7 +9,7 @@ use crate::domain::Domain;
 use crate::error::{Error, Result};
 use crate::indexed::IndexedVar;
 use crate::objective::{Objective, ObjectiveSense};
-use crate::set::{IndexKey, Set};
+use crate::set::{FromIndexKey, IndexKey, Set};
 use crate::var::{VarBuilder, Variable};
 
 /// The kind of mathematical program a `Model` represents.
@@ -112,6 +112,8 @@ impl Model {
             keys: set.iter().collect(),
             lb: f64::NEG_INFINITY,
             ub: f64::INFINITY,
+            lb_by: None,
+            ub_by: None,
             domain: Domain::Real,
         }
     }
@@ -182,6 +184,36 @@ impl Model {
         I: IntoIterator<Item = (SmolStr, ConstraintExpr<'a>)>,
     {
         for (name, c) in items {
+            self.constraint(name, c);
+        }
+    }
+
+    /// Rule-style bulk constraint registration.
+    ///
+    /// The closure receives the index as a typed value `K`. Any type
+    /// implementing [`FromIndexKey`] is accepted. Built-in impls cover `i64`,
+    /// `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to arity 4.
+    /// The user states the expected shape via the closure-arg annotation.
+    ///
+    /// # Example
+    /// ```ignore
+    /// // Scalar set: closure receives a usize directly.
+    /// m.add_constraints_over("upper", &i, |i: usize| x[i as i64].le(b[i]));
+    ///
+    /// // Tuple set: destructure inline.
+    /// m.add_constraints_over("blo", &(&tasks * &events), |(t, n): (usize, usize)| {
+    ///     (b[(t, n)] - b_min[t] * w[(t, n)]).ge(0.0)
+    /// });
+    /// ```
+    pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, mut rule: F)
+    where
+        K: FromIndexKey,
+        F: FnMut(K) -> ConstraintExpr<'a>,
+    {
+        for key in set {
+            let typed = K::from_index_key(&key);
+            let c = rule(typed);
+            let name: SmolStr = format_index_name(name_prefix, &key).into();
             self.constraint(name, c);
         }
     }
@@ -280,6 +312,8 @@ fn has_nonlinear(arena: &ExprArena, id: oximo_expr::ExprId) -> bool {
 /// `flow[2]` as separate scalar variables in the model. Call `.build()` to get
 /// an [`IndexedVar`] that maps each key to its [`Expr`] handle. Bounds and
 /// domain set here apply uniformly to every scalar in the collection.
+type BoundFn<'a> = Box<dyn Fn(&IndexKey) -> f64 + 'a>;
+
 #[must_use = "IndexedVarBuilder does nothing until you call .build()"]
 pub struct IndexedVarBuilder<'a> {
     model: &'a Model,
@@ -287,6 +321,8 @@ pub struct IndexedVarBuilder<'a> {
     keys: Vec<IndexKey>,
     lb: f64,
     ub: f64,
+    lb_by: Option<BoundFn<'a>>,
+    ub_by: Option<BoundFn<'a>>,
     domain: Domain,
 }
 
@@ -297,6 +333,8 @@ impl<'a> std::fmt::Debug for IndexedVarBuilder<'a> {
             .field("keys", &self.keys.len())
             .field("lb", &self.lb)
             .field("ub", &self.ub)
+            .field("per_key_lb", &self.lb_by.is_some())
+            .field("per_key_ub", &self.ub_by.is_some())
             .field("domain", &self.domain)
             .finish()
     }
@@ -314,6 +352,22 @@ impl<'a> IndexedVarBuilder<'a> {
     pub fn bounds(mut self, lb: f64, ub: f64) -> Self {
         self.lb = lb;
         self.ub = ub;
+        self
+    }
+    /// Per-key lower bound. Overrides [`Self::lb`] when both are set.
+    pub fn lb_by<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&IndexKey) -> f64 + 'a,
+    {
+        self.lb_by = Some(Box::new(f));
+        self
+    }
+    /// Per-key upper bound. Overrides [`Self::ub`] when both are set.
+    pub fn ub_by<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&IndexKey) -> f64 + 'a,
+    {
+        self.ub_by = Some(Box::new(f));
         self
     }
     pub fn domain(mut self, d: Domain) -> Self {
@@ -335,8 +389,9 @@ impl<'a> IndexedVarBuilder<'a> {
         let mut entries = FxHashMap::default();
         for key in self.keys {
             let scalar_name: SmolStr = format_index_name(&self.base_name, &key).into();
-            let expr =
-                self.model.var(scalar_name).lb(self.lb).ub(self.ub).domain(self.domain).build();
+            let lb = self.lb_by.as_ref().map_or(self.lb, |f| f(&key));
+            let ub = self.ub_by.as_ref().map_or(self.ub, |f| f(&key));
+            let expr = self.model.var(scalar_name).lb(lb).ub(ub).domain(self.domain).build();
             entries.insert(key, expr);
         }
         IndexedVar { entries }
@@ -344,8 +399,34 @@ impl<'a> IndexedVarBuilder<'a> {
 }
 
 fn format_index_name(base: &str, key: &IndexKey) -> String {
+    let mut out = String::with_capacity(base.len() + 4);
+    out.push_str(base);
+    out.push('[');
+    write_key_parts(&mut out, key);
+    out.push(']');
+    out
+}
+
+fn write_key_parts(out: &mut String, key: &IndexKey) {
+    use std::fmt::Write;
     match key {
-        IndexKey::Int(i) => format!("{base}[{i}]"),
-        IndexKey::Str(s) => format!("{base}[{s}]"),
+        IndexKey::Int(i) => write!(out, "{i}").unwrap(),
+        IndexKey::Str(s) => out.push_str(s),
+        IndexKey::Tuple(parts) => {
+            for (i, p) in parts.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_key_parts(out, p);
+            }
+        }
     }
+}
+
+/// Public render of an `IndexKey`'s textual form, used by helpers like
+/// [`Model::add_constraints_over`] to derive constraint names.
+pub fn display_index_key(key: &IndexKey) -> String {
+    let mut out = String::new();
+    write_key_parts(&mut out, key);
+    out
 }

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -2,9 +2,9 @@ pub use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, R
 pub use crate::domain::Domain;
 pub use crate::error::Error;
 pub use crate::indexed::IndexedVar;
-pub use crate::model::{IndexedVarBuilder, Model, ModelKind};
+pub use crate::model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
-pub use crate::set::{IndexKey, Set, SetIter};
+pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, VarId, sum};

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -235,8 +235,8 @@ where
     }
 }
 
-/// Typed projection of an [`IndexKey`]. Implementations panic when the 
-/// key's shape does not match the target type, the same contract as 
+/// Typed projection of an [`IndexKey`]. Implementations panic when the
+/// key's shape does not match the target type, the same contract as
 /// [`crate::indexed::IndexedVar`] indexing on a missing key.
 ///
 /// Used by [`crate::model::Model::add_constraints_over`] (and similar rule

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -294,7 +294,7 @@ impl FromIndexKey for i32 {
 impl FromIndexKey for usize {
     fn from_index_key(k: &IndexKey) -> Self {
         let v = i64::from_index_key(k);
-        usize::try_from(v).unwrap_or_else(|_| panic!("negative key {v} cannot be usize"))
+        usize::try_from(v).unwrap_or_else(|_| panic!("key {v} out of usize range"))
     }
 }
 

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -74,7 +74,11 @@ impl Set {
     /// Cartesian product of two sets. Inner tuple keys are flattened so a
     /// product `(a * b) * c` yields 3-element tuples, not nested 2-tuples.
     pub fn product(a: &Set, b: &Set) -> Self {
-        let mut out = Vec::with_capacity(a.len() * b.len());
+        let mut out = Vec::new();
+        if let Some(capacity) = a.len().checked_mul(b.len()) {
+            // best-effort, fall back to dynamic growth on OOM
+            let _ = out.try_reserve_exact(capacity);
+        }
         for ka in a {
             for kb in b {
                 let mut parts: Vec<IndexKey> = Vec::new();
@@ -97,10 +101,26 @@ impl Set {
                 Self::Range(v.iter().copied().filter(|i| f(&IndexKey::Int(*i))).collect())
             }
             Self::Strings(v) => Self::Strings(
-                v.iter().filter(|s| f(&IndexKey::Str((*s).clone()))).cloned().collect(),
+                v.iter()
+                    .filter_map(|s| {
+                        let key = IndexKey::Str(s.clone());
+                        f(&key).then(|| match key {
+                            IndexKey::Str(owned) => owned,
+                            _ => unreachable!(),
+                        })
+                    })
+                    .collect(),
             ),
             Self::Tuples(v) => Self::Tuples(
-                v.iter().filter(|t| f(&IndexKey::Tuple((*t).clone()))).cloned().collect(),
+                v.iter()
+                    .filter_map(|t| {
+                        let key = IndexKey::Tuple(t.clone());
+                        f(&key).then(|| match key {
+                            IndexKey::Tuple(owned) => owned,
+                            _ => unreachable!(),
+                        })
+                    })
+                    .collect(),
             ),
         }
     }

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -1,23 +1,57 @@
+use std::ops::Mul;
+
+use num_traits::PrimInt;
 use rayon::prelude::*;
+
+// Note: I used `Box<[IndexKey]>` over:
+//   - `Vec<IndexKey>`: saves one word
+//     (no capacity field) since tuples are never mutated after construction.
+//
+//   - `SmallVec<[IndexKey; N]>` is rejected by the compiler: recursive size
+//      cycle
+
+/// Heap-allocated tuple key payload. Immutable after construction.
+pub type IndexTuple = Box<[IndexKey]>;
 
 /// A finite, ordered index set.
 ///
-/// For now we supports integer ranges and string lists.
-///
-/// TODO: Add tuple indexing alongside `IndexedVar` enhancements.
+/// Supports integer ranges, string lists, and arbitrary tuple lists (built via
+/// [`Set::product`] / the `&a * &b` operator, or constructed directly).
 #[derive(Clone, Debug)]
 pub enum Set {
     Range(Vec<i64>),
     Strings(Vec<String>),
+    Tuples(Vec<IndexTuple>),
 }
 
 impl Set {
-    pub fn range(r: std::ops::Range<i64>) -> Self {
-        Self::Range(r.collect())
+    /// Build an integer index set from a range over any primitive integer
+    /// type. Accepts `Range<i64>`, `Range<i32>`, `Range<usize>`, etc.
+    ///
+    /// The untyped literal form `Set::range(0..5)` defaults to `i32` and
+    /// works without annotation.
+    ///
+    /// # Panics
+    /// Panics if either range bound does not fit in `i64`.
+    pub fn range<T: PrimInt>(r: std::ops::Range<T>) -> Self {
+        let start = r.start.to_i64().expect("range start out of i64 range");
+        let end = r.end.to_i64().expect("range end out of i64 range");
+        Self::Range((start..end).collect())
     }
 
-    pub fn from_iter_i64<I: IntoIterator<Item = i64>>(iter: I) -> Self {
-        Self::Range(iter.into_iter().collect())
+    /// Build an integer index set from an iterator of any primitive integer
+    /// type. Useful when keys are sparse or computed (e.g. only even indices).
+    ///
+    /// # Panics
+    /// Panics if any element does not fit in `i64`.
+    pub fn from_ints<T, I>(iter: I) -> Self
+    where
+        T: PrimInt,
+        I: IntoIterator<Item = T>,
+    {
+        Self::Range(
+            iter.into_iter().map(|v| v.to_i64().expect("element out of i64 range")).collect(),
+        )
     }
 
     pub fn strings<I, S>(iter: I) -> Self
@@ -28,10 +62,54 @@ impl Set {
         Self::Strings(iter.into_iter().map(Into::into).collect())
     }
 
+    /// Build a tuple set directly from an iterator of keys.
+    pub fn tuples<I, T>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<IndexTuple>,
+    {
+        Self::Tuples(iter.into_iter().map(Into::into).collect())
+    }
+
+    /// Cartesian product of two sets. Inner tuple keys are flattened so a
+    /// product `(a * b) * c` yields 3-element tuples, not nested 2-tuples.
+    pub fn product(a: &Set, b: &Set) -> Self {
+        let mut out = Vec::with_capacity(a.len() * b.len());
+        for ka in a {
+            for kb in b {
+                let mut parts: Vec<IndexKey> = Vec::new();
+                push_flat(&mut parts, ka.clone());
+                push_flat(&mut parts, kb);
+                out.push(parts.into_boxed_slice());
+            }
+        }
+        Self::Tuples(out)
+    }
+
+    /// Filter keys with a predicate. Preserves the original variant where
+    /// possible, filtered `Range`/`Strings` stay in their native variant.
+    pub fn filter<F>(&self, mut f: F) -> Self
+    where
+        F: FnMut(&IndexKey) -> bool,
+    {
+        match self {
+            Self::Range(v) => {
+                Self::Range(v.iter().copied().filter(|i| f(&IndexKey::Int(*i))).collect())
+            }
+            Self::Strings(v) => Self::Strings(
+                v.iter().filter(|s| f(&IndexKey::Str((*s).clone()))).cloned().collect(),
+            ),
+            Self::Tuples(v) => Self::Tuples(
+                v.iter().filter(|t| f(&IndexKey::Tuple((*t).clone()))).cloned().collect(),
+            ),
+        }
+    }
+
     pub fn len(&self) -> usize {
         match self {
             Self::Range(v) => v.len(),
             Self::Strings(v) => v.len(),
+            Self::Tuples(v) => v.len(),
         }
     }
 
@@ -40,18 +118,75 @@ impl Set {
     }
 }
 
-/// A serializable index key from a `Set`.
-///
-/// TODO: Add composite tuples.
+fn push_flat(dst: &mut Vec<IndexKey>, k: IndexKey) {
+    match k {
+        IndexKey::Tuple(inner) => dst.extend(inner.into_vec()),
+        other => dst.push(other),
+    }
+}
+
+fn make_tuple<I: IntoIterator<Item = IndexKey>>(items: I) -> IndexTuple {
+    let mut v: Vec<IndexKey> = Vec::new();
+    for k in items {
+        push_flat(&mut v, k);
+    }
+    v.into_boxed_slice()
+}
+
+impl Mul<&Set> for &Set {
+    type Output = Set;
+    fn mul(self, rhs: &Set) -> Set {
+        Set::product(self, rhs)
+    }
+}
+
+/// A serializable index key from a [`Set`].
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum IndexKey {
     Int(i64),
     Str(String),
+    Tuple(IndexTuple),
+}
+
+impl IndexKey {
+    /// Build a tuple key from any iterable of convertible items. Nested tuple
+    /// keys are flattened.
+    pub fn tuple<I, T>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<IndexKey>,
+    {
+        Self::Tuple(make_tuple(iter.into_iter().map(Into::into)))
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        if let Self::Int(v) = self { Some(*v) } else { None }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        if let Self::Str(s) = self { Some(s.as_str()) } else { None }
+    }
+
+    pub fn as_tuple(&self) -> Option<&[IndexKey]> {
+        if let Self::Tuple(t) = self { Some(&t[..]) } else { None }
+    }
 }
 
 impl From<i64> for IndexKey {
     fn from(v: i64) -> Self {
         Self::Int(v)
+    }
+}
+
+impl From<i32> for IndexKey {
+    fn from(v: i32) -> Self {
+        Self::Int(i64::from(v))
+    }
+}
+
+impl From<usize> for IndexKey {
+    fn from(v: usize) -> Self {
+        Self::Int(i64::try_from(v).expect("usize -> i64 overflow"))
     }
 }
 
@@ -64,6 +199,135 @@ impl From<&str> for IndexKey {
 impl From<String> for IndexKey {
     fn from(s: String) -> Self {
         Self::Str(s)
+    }
+}
+
+impl<A, B> From<(A, B)> for IndexKey
+where
+    A: Into<IndexKey>,
+    B: Into<IndexKey>,
+{
+    fn from(t: (A, B)) -> Self {
+        Self::Tuple(make_tuple([t.0.into(), t.1.into()]))
+    }
+}
+
+impl<A, B, C> From<(A, B, C)> for IndexKey
+where
+    A: Into<IndexKey>,
+    B: Into<IndexKey>,
+    C: Into<IndexKey>,
+{
+    fn from(t: (A, B, C)) -> Self {
+        Self::Tuple(make_tuple([t.0.into(), t.1.into(), t.2.into()]))
+    }
+}
+
+impl<A, B, C, D> From<(A, B, C, D)> for IndexKey
+where
+    A: Into<IndexKey>,
+    B: Into<IndexKey>,
+    C: Into<IndexKey>,
+    D: Into<IndexKey>,
+{
+    fn from(t: (A, B, C, D)) -> Self {
+        Self::Tuple(make_tuple([t.0.into(), t.1.into(), t.2.into(), t.3.into()]))
+    }
+}
+
+/// Typed projection of an [`IndexKey`]. Implementations panic when the 
+/// key's shape does not match the target type, the same contract as 
+/// [`crate::indexed::IndexedVar`] indexing on a missing key.
+///
+/// Used by [`crate::model::Model::add_constraints_over`] (and similar rule
+/// helpers) to give the closure typed indices directly:
+///
+/// ```ignore
+/// m.add_constraints_over("supply", &(&plants * &markets), |(p, m): (String, String)| {
+///     // p, m are native String, no manual unpack
+///     ...
+/// });
+/// ```
+pub trait FromIndexKey: Sized {
+    fn from_index_key(k: &IndexKey) -> Self;
+}
+
+impl FromIndexKey for IndexKey {
+    fn from_index_key(k: &IndexKey) -> Self {
+        k.clone()
+    }
+}
+
+impl FromIndexKey for i64 {
+    fn from_index_key(k: &IndexKey) -> Self {
+        k.as_i64().unwrap_or_else(|| panic!("expected Int key, got {k:?}"))
+    }
+}
+
+impl FromIndexKey for i32 {
+    fn from_index_key(k: &IndexKey) -> Self {
+        let v = i64::from_index_key(k);
+        i32::try_from(v).unwrap_or_else(|_| panic!("key {v} out of i32 range"))
+    }
+}
+
+impl FromIndexKey for usize {
+    fn from_index_key(k: &IndexKey) -> Self {
+        let v = i64::from_index_key(k);
+        usize::try_from(v).unwrap_or_else(|_| panic!("negative key {v} cannot be usize"))
+    }
+}
+
+impl FromIndexKey for String {
+    fn from_index_key(k: &IndexKey) -> Self {
+        k.as_str().unwrap_or_else(|| panic!("expected Str key, got {k:?}")).to_owned()
+    }
+}
+
+fn tuple_parts<'a>(k: &'a IndexKey, expected: usize) -> &'a [IndexKey] {
+    let p = k.as_tuple().unwrap_or_else(|| panic!("expected Tuple key, got {k:?}"));
+    assert_eq!(p.len(), expected, "expected tuple of arity {expected}, got arity {}", p.len());
+    p
+}
+
+impl<A, B> FromIndexKey for (A, B)
+where
+    A: FromIndexKey,
+    B: FromIndexKey,
+{
+    fn from_index_key(k: &IndexKey) -> Self {
+        let p = tuple_parts(k, 2);
+        (A::from_index_key(&p[0]), B::from_index_key(&p[1]))
+    }
+}
+
+impl<A, B, C> FromIndexKey for (A, B, C)
+where
+    A: FromIndexKey,
+    B: FromIndexKey,
+    C: FromIndexKey,
+{
+    fn from_index_key(k: &IndexKey) -> Self {
+        let p = tuple_parts(k, 3);
+        (A::from_index_key(&p[0]), B::from_index_key(&p[1]), C::from_index_key(&p[2]))
+    }
+}
+
+impl<A, B, C, D> FromIndexKey for (A, B, C, D)
+where
+    A: FromIndexKey,
+    B: FromIndexKey,
+    C: FromIndexKey,
+    D: FromIndexKey,
+{
+    fn from_index_key(k: &IndexKey) -> Self {
+        let p = tuple_parts(k, 4);
+        (
+            A::from_index_key(&p[0]),
+            B::from_index_key(&p[1]),
+            C::from_index_key(&p[2]),
+            D::from_index_key(&p[3]),
+        )
     }
 }
 
@@ -84,6 +348,7 @@ impl Set {
         match self {
             Self::Range(v) => v.par_iter().map(|i| IndexKey::Int(*i)).collect::<Vec<_>>(),
             Self::Strings(v) => v.par_iter().map(|s| IndexKey::Str(s.clone())).collect::<Vec<_>>(),
+            Self::Tuples(v) => v.par_iter().map(|t| IndexKey::Tuple(t.clone())).collect::<Vec<_>>(),
         }
         .into_par_iter()
     }
@@ -101,6 +366,7 @@ impl<'a> Iterator for SetIter<'a> {
         let out = match self.set {
             Set::Range(v) => v.get(self.pos).copied().map(IndexKey::Int),
             Set::Strings(v) => v.get(self.pos).cloned().map(IndexKey::Str),
+            Set::Tuples(v) => v.get(self.pos).cloned().map(IndexKey::Tuple),
         };
         if out.is_some() {
             self.pos += 1;

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -1,0 +1,291 @@
+#![allow(clippy::float_cmp)]
+
+use oximo_core::prelude::*;
+
+#[test]
+fn range_set_iteration_order() {
+    let s = Set::range(0..3);
+    let keys: Vec<_> = s.iter().collect();
+    assert_eq!(keys, vec![IndexKey::Int(0), IndexKey::Int(1), IndexKey::Int(2)]);
+    assert_eq!(s.len(), 3);
+}
+
+#[test]
+fn range_accepts_any_primitive_int_type() {
+    // Default untyped literals -> i32.
+    assert_eq!(Set::range(0..3).len(), 3);
+
+    // Range<usize> (common when keys come from a `.len()`).
+    let len: usize = 4;
+    assert_eq!(Set::range(0..len).len(), 4);
+
+    // Range<i64> (explicit).
+    assert_eq!(Set::range(0_i64..5).len(), 5);
+
+    // Range<u32>, Range<i8>, also work via PrimInt.
+    assert_eq!(Set::range(0_u32..2).len(), 2);
+    assert_eq!(Set::range(0_i8..6).len(), 6);
+}
+
+#[test]
+fn from_ints_with_sparse_iterator() {
+    let evens: Vec<usize> = vec![0, 2, 4, 6, 8];
+    let s = Set::from_ints(evens);
+    let keys: Vec<i64> = s.iter().map(|k| k.as_i64().unwrap()).collect();
+    assert_eq!(keys, vec![0, 2, 4, 6, 8]);
+}
+
+#[test]
+fn strings_set_iteration_order() {
+    let s = Set::strings(["a", "b", "c"]);
+    let keys: Vec<_> = s.iter().collect();
+    assert_eq!(keys.len(), 3);
+    assert_eq!(keys[0].as_str(), Some("a"));
+    assert_eq!(keys[2].as_str(), Some("c"));
+}
+
+#[test]
+fn cartesian_product_yields_all_pairs() {
+    let i = Set::range(0..2);
+    let j = Set::range(0..3);
+    let ij = &i * &j;
+    assert_eq!(ij.len(), 6);
+    let keys: Vec<_> = ij.iter().collect();
+    // First key is (0,0).
+    let first = keys[0].as_tuple().unwrap();
+    assert_eq!(first.len(), 2);
+    assert_eq!(first[0].as_i64(), Some(0));
+    assert_eq!(first[1].as_i64(), Some(0));
+    // Last key is (1,2).
+    let last = keys[5].as_tuple().unwrap();
+    assert_eq!(last[0].as_i64(), Some(1));
+    assert_eq!(last[1].as_i64(), Some(2));
+}
+
+#[test]
+fn product_flattens_nested_tuples() {
+    let a = Set::range(0..2);
+    let b = Set::range(0..2);
+    let c = Set::range(0..2);
+    let abc = &(&a * &b) * &c;
+    let keys: Vec<_> = abc.iter().collect();
+    assert_eq!(keys.len(), 8);
+    for k in &keys {
+        let parts = k.as_tuple().unwrap();
+        assert_eq!(parts.len(), 3, "tuple must be 3-arity, not nested");
+        for p in parts {
+            assert!(p.as_i64().is_some(), "all parts must be scalars after flattening");
+        }
+    }
+}
+
+#[test]
+fn filter_keeps_variant_for_range() {
+    let s = Set::range(0..10).filter(|k| k.as_i64().unwrap() % 2 == 0);
+    assert!(matches!(s, Set::Range(_)));
+    assert_eq!(s.len(), 5);
+}
+
+#[test]
+fn filter_keeps_variant_for_tuples() {
+    let i = Set::range(0..3);
+    let j = Set::range(0..3);
+    let filtered = (&i * &j).filter(|k| {
+        let p = k.as_tuple().unwrap();
+        p[0].as_i64() != p[1].as_i64()
+    });
+    assert!(matches!(filtered, Set::Tuples(_)));
+    assert_eq!(filtered.len(), 6);
+}
+
+#[test]
+fn filter_on_product() {
+    let i = Set::range(0..3);
+    let j = Set::range(0..3);
+    let diag = (&i * &j).filter(|k| {
+        let p = k.as_tuple().unwrap();
+        p[0].as_i64() == p[1].as_i64()
+    });
+    assert_eq!(diag.len(), 3);
+}
+
+#[test]
+fn tuple_key_from_pair_literal() {
+    let k: IndexKey = (1, 2).into();
+    let parts = k.as_tuple().unwrap();
+    assert_eq!(parts.len(), 2);
+    assert_eq!(parts[0].as_i64(), Some(1));
+    assert_eq!(parts[1].as_i64(), Some(2));
+}
+
+#[test]
+fn indexed_var_over_product_creates_named_scalars() {
+    let m = Model::new("net");
+    let plants = Set::strings(["seattle", "san-diego"]);
+    let markets = Set::strings(["nyc", "chi", "topeka"]);
+    let flow = m.indexed_var("flow", &(&plants * &markets)).lb(0.0).build();
+    assert_eq!(flow.len(), 6);
+    assert!(m.variable_id("flow[seattle,nyc]").is_some());
+    assert!(m.variable_id("flow[san-diego,topeka]").is_some());
+}
+
+#[test]
+fn indexed_var_per_key_bounds() {
+    let m = Model::new("ub_by");
+    let set = Set::range(0..3);
+    let _x = m
+        .indexed_var("x", &set)
+        .lb(0.0)
+        .ub_by(|k| {
+            #[allow(clippy::cast_precision_loss)]
+            let v = k.as_i64().unwrap() as f64;
+            v
+        })
+        .build();
+    let vars = m.variables();
+    assert_eq!(vars[0].ub, 0.0);
+    assert_eq!(vars[1].ub, 1.0);
+    assert_eq!(vars[2].ub, 2.0);
+}
+
+#[test]
+fn indexed_var_tuple_indexing() {
+    let model = Model::new("idx");
+    let rows = Set::range(0..2);
+    let cols = Set::range(0..2);
+    let x = model.indexed_var("x", &(&rows * &cols)).lb(0.0).build();
+    let by_tuple = x[(0, 1)];
+
+    let key: IndexKey = (1, 0).into();
+    let by_ref = x[&key];
+
+    // IDs must differ, the two scalars are not the same variable.
+    assert_ne!(format!("{by_tuple:?}"), format!("{by_ref:?}"));
+}
+
+#[test]
+fn add_constraints_over_scalar_typed_closure() {
+    let m = Model::new("rule");
+    let set = Set::range(0..3);
+    let x = m.indexed_var("x", &set).lb(0.0).build();
+    m.add_constraints_over("c", &set, |i: usize| x[i].le(10.0));
+    assert_eq!(m.num_constraints(), 3);
+    assert!(m.constraint_id("c[0]").is_some());
+    assert!(m.constraint_id("c[2]").is_some());
+}
+
+#[test]
+fn add_constraints_over_tuple_set_typed_closure() {
+    let m = Model::new("rule_tup");
+    let rows = Set::range(0..2);
+    let cols = Set::strings(["a", "b"]);
+    let ij = &rows * &cols;
+    let x = m.indexed_var("x", &ij).lb(0.0).build();
+    m.add_constraints_over("c", &ij, |(i, j): (i64, String)| x[(i, j)].le(5.0));
+    assert_eq!(m.num_constraints(), 4);
+    assert!(m.constraint_id("c[0,a]").is_some());
+    assert!(m.constraint_id("c[1,b]").is_some());
+}
+
+#[test]
+fn add_constraints_over_raw_key_escape_hatch() {
+    let m = Model::new("rule_raw");
+    let set = Set::range(0..2);
+    let x = m.indexed_var("x", &set).lb(0.0).build();
+    m.add_constraints_over("c", &set, |k: IndexKey| x[&k].le(1.0));
+    assert_eq!(m.num_constraints(), 2);
+}
+
+#[test]
+fn from_index_key_scalar_impls() {
+    let k = IndexKey::Int(42);
+    assert_eq!(i64::from_index_key(&k), 42_i64);
+    assert_eq!(usize::from_index_key(&k), 42_usize);
+    assert_eq!(i32::from_index_key(&k), 42_i32);
+
+    let s = IndexKey::Str("hi".into());
+    assert_eq!(String::from_index_key(&s), "hi");
+
+    // Identity: round-trips full key.
+    assert_eq!(IndexKey::from_index_key(&k), k);
+}
+
+#[test]
+fn from_index_key_tuple_impls() {
+    let k2: IndexKey = (1, "a").into();
+    let (a, b): (i64, String) = FromIndexKey::from_index_key(&k2);
+    assert_eq!(a, 1);
+    assert_eq!(b, "a");
+
+    let k3: IndexKey = (1, 2, 3).into();
+    let (a, b, c): (usize, usize, usize) = FromIndexKey::from_index_key(&k3);
+    assert_eq!((a, b, c), (1, 2, 3));
+
+    let k4: IndexKey = (1, 2, 3, 4).into();
+    let t: (i64, i64, i64, i64) = FromIndexKey::from_index_key(&k4);
+    assert_eq!(t, (1, 2, 3, 4));
+}
+
+#[test]
+fn lb_by_ub_by_override_binary_defaults() {
+    // binary() sets lb=0, ub=1 for all keys.
+    // lb_by/ub_by must win per-key: key 0 fixed to 1, key 2 fixed to 0,
+    // key 1 left as free binary (lb=0, ub=1).
+    let m = Model::new("fix");
+    let set = Set::range(0..3);
+    let _x = m
+        .indexed_var("x", &set)
+        .binary()
+        .lb_by(|k| if k.as_i64().unwrap() == 0 { 1.0 } else { 0.0 })
+        .ub_by(|k| if k.as_i64().unwrap() == 2 { 0.0 } else { 1.0 })
+        .build();
+    let vars = m.variables();
+    assert_eq!(vars[0].lb, 1.0); // fixed to 1
+    assert_eq!(vars[0].ub, 1.0);
+    assert_eq!(vars[1].lb, 0.0); // free binary
+    assert_eq!(vars[1].ub, 1.0);
+    assert_eq!(vars[2].lb, 0.0); // fixed to 0
+    assert_eq!(vars[2].ub, 0.0);
+}
+
+#[test]
+fn tuple_product_associativity_shape() {
+    let a = Set::range(0..2);
+    let b = Set::range(0..2);
+    let c = Set::range(0..2);
+
+    let left = &(&a * &b) * &c;
+    let right = &a * &(&b * &c);
+
+    let left_keys: Vec<_> = left.iter().collect();
+    let right_keys: Vec<_> = right.iter().collect();
+
+    assert_eq!(left_keys, right_keys);
+}
+
+#[test]
+fn duplicates_are_preserved() {
+    // Set is an ordered list, not a mathematical set. Duplicates survive.
+    let s = Set::from_ints(vec![1_i32, 1, 2]);
+    assert_eq!(s.len(), 3);
+    let keys: Vec<i64> = s.iter().map(|k| k.as_i64().unwrap()).collect();
+    assert_eq!(keys, vec![1, 1, 2]);
+
+    let t = Set::strings(["a", "a", "b"]);
+    assert_eq!(t.len(), 3);
+    assert_eq!(t.iter().filter(|k| k.as_str() == Some("a")).count(), 2);
+}
+
+#[test]
+#[should_panic(expected = "expected tuple of arity 2")]
+fn from_index_key_panics_on_arity_mismatch() {
+    let k: IndexKey = (1, 2, 3).into();
+    let _: (i64, i64) = FromIndexKey::from_index_key(&k);
+}
+
+#[test]
+#[should_panic(expected = "negative key")]
+fn from_index_key_panics_on_negative_usize() {
+    let k = IndexKey::Int(-1);
+    let _ = usize::from_index_key(&k);
+}

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -136,10 +136,11 @@ fn indexed_var_per_key_bounds() {
     let _x = m
         .indexed_var("x", &set)
         .lb(0.0)
-        .ub_by(|k| {
+        .ub_by(|k: i64| {
             #[allow(clippy::cast_precision_loss)]
-            let v = k.as_i64().unwrap() as f64;
-            v
+            {
+                k as f64
+            }
         })
         .build();
     let vars = m.variables();
@@ -236,8 +237,8 @@ fn lb_by_ub_by_override_binary_defaults() {
     let _x = m
         .indexed_var("x", &set)
         .binary()
-        .lb_by(|k| if k.as_i64().unwrap() == 0 { 1.0 } else { 0.0 })
-        .ub_by(|k| if k.as_i64().unwrap() == 2 { 0.0 } else { 1.0 })
+        .lb_by(|k: i64| if k == 0 { 1.0 } else { 0.0 })
+        .ub_by(|k: i64| if k == 2 { 0.0 } else { 1.0 })
         .build();
     let vars = m.variables();
     assert_eq!(vars[0].lb, 1.0); // fixed to 1

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -161,7 +161,7 @@ fn indexed_var_tuple_indexing() {
     let by_ref = x[&key];
 
     // IDs must differ, the two scalars are not the same variable.
-    assert_ne!(format!("{by_tuple:?}"), format!("{by_ref:?}"));
+    assert_ne!(by_tuple.id, by_ref.id);
 }
 
 #[test]
@@ -285,7 +285,7 @@ fn from_index_key_panics_on_arity_mismatch() {
 }
 
 #[test]
-#[should_panic(expected = "negative key")]
+#[should_panic(expected = "out of usize range")]
 fn from_index_key_panics_on_negative_usize() {
     let k = IndexKey::Int(-1);
     let _ = usize::from_index_key(&k);

--- a/crates/oximo/examples/lot_sizing.rs
+++ b/crates/oximo/examples/lot_sizing.rs
@@ -42,7 +42,7 @@
 //! "The capacitated lot sizing problem: a review of models
 //! and algorithms", Omega, 31(5), 365-378, 2003.
 
-#![allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#![allow(clippy::many_single_char_names)]
 
 #[cfg(any(feature = "gurobi", feature = "highs"))]
 use oximo::prelude::*;
@@ -67,24 +67,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let safety_stock = 30.0;
 
     let m = Model::new("lot_sizing");
-    let periods = Set::range(0..T as i64);
+    let periods = Set::range(0..T);
 
     let x = m.indexed_var("x", &periods).lb(0.0).ub(capacity).build();
     let h = m.indexed_var("h", &periods).lb(0.0).build();
     let s = m.indexed_var("s", &periods).binary().build();
 
-    m.constraint("inv_bal_0", (h[0i64] - x[0i64]).eq(initial_inventory - demand[0]));
-    for t in 1..T as i64 {
-        m.constraint(format!("inv_bal_{t}"), (h[t] - h[t - 1] - x[t]).eq(-demand[t as usize]));
-    }
-    for t in 0..T as i64 {
-        m.constraint(format!("setup_{t}"), (x[t] - capacity * s[t]).le(0.0));
-    }
-    m.constraint("safety_stock", h[T as i64 - 1].ge(safety_stock));
+    m.constraint("inv_bal[0]", (h[0] - x[0]).eq(initial_inventory - demand[0]));
+    m.add_constraints_over("inv_bal", &periods.filter(|k| k.as_i64().unwrap() > 0), |t: usize| {
+        (h[t] - h[t - 1] - x[t]).eq(-demand[t])
+    });
+    m.add_constraints_over("setup", &periods, |t: usize| (x[t] - capacity * s[t]).le(0.0));
+    m.constraint("safety_stock", h[T - 1].ge(safety_stock));
 
-    let cost =
-        sum((0..T as i64)
-            .map(|t| prod_cost[t as usize] * x[t] + setup_cost * s[t] + hold_cost * h[t]));
+    let cost = sum(periods.iter().map(|k| {
+        let t: usize = FromIndexKey::from_index_key(&k);
+        prod_cost[t] * x[t] + setup_cost * s[t] + hold_cost * h[t]
+    }));
     m.minimize(cost);
 
     #[cfg(feature = "gurobi")]
@@ -118,11 +117,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "-".repeat(55));
 
     let mut total_check = 0.0;
-    for t in 0..T as i64 {
+    for t in 0..T {
         let xt = result.value_of(x[t]).unwrap_or(0.0);
         let ht = result.value_of(h[t]).unwrap_or(0.0);
         let st = result.value_of(s[t]).unwrap_or(0.0);
-        let period_cost = prod_cost[t as usize] * xt + setup_cost * st + hold_cost * ht;
+        let period_cost = prod_cost[t] * xt + setup_cost * st + hold_cost * ht;
         total_check += period_cost;
         println!(
             "{:<8} {:>10.1} {:>10.1} {:>8} {:>12.2}",

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -88,31 +88,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let unavailable: &[usize] = &[15, 18];
 
     let m = Model::new("reaction_path");
+    let chemicals = Set::strings(CHEMICALS);
 
-    let y: Vec<_> = CHEMICALS
-        .iter()
-        .enumerate()
-        .map(|(i, name)| {
-            let b = m.var(*name).binary();
-            if available.contains(&i) {
-                b.fix(1.0).build()
-            } else if unavailable.contains(&i) {
-                b.fix(0.0).build()
-            } else {
-                b.build()
-            }
+    let y = m
+        .indexed_var("y", &chemicals)
+        .binary()
+        .lb_by(|k| {
+            let name = k.as_str().unwrap();
+            if available.iter().any(|&i| CHEMICALS[i] == name) { 1.0 } else { 0.0 }
         })
-        .collect();
+        .ub_by(|k| {
+            let name = k.as_str().unwrap();
+            if unavailable.iter().any(|&i| CHEMICALS[i] == name) { 0.0 } else { 1.0 }
+        })
+        .build();
 
     // sum_vv (1 - y[vv]) >= 1 - y[v]
     //    <=>  y[v] - sum_vv y[vv] >= 1 - |reactants|
     for &(rx, prod, reactants) in logicc {
         let n = reactants.len() as f64;
-        let reactant_sum = sum(reactants.iter().map(|&vv| y[vv]));
-        m.constraint(format!("leq_{rx}"), (y[prod] - reactant_sum).ge(1.0 - n));
+        let reactant_sum = sum(reactants.iter().map(|&vv| y[CHEMICALS[vv]]));
+        m.constraint(format!("leq_{rx}"), (y[CHEMICALS[prod]] - reactant_sum).ge(1.0 - n));
     }
 
-    m.minimize(y[5]); // y06 = acetone
+    m.minimize(y["y06"]); // acetone
 
     #[cfg(feature = "gams")]
     let result = {
@@ -135,16 +134,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let synthesizable: Vec<&str> = y
+    let synthesizable: Vec<&str> = CHEMICALS
         .iter()
-        .enumerate()
-        .filter_map(|(i, var)| {
-            if (result.value_of(*var).unwrap_or(0.0) - 1.0).abs() < 1e-6 {
-                Some(CHEMICALS[i])
-            } else {
-                None
-            }
-        })
+        .copied()
+        .filter(|name| (result.value_of(y[*name]).unwrap_or(0.0) - 1.0).abs() < 1e-6)
         .collect();
     if !synthesizable.is_empty() {
         println!("Synthesizable chemicals: {}", synthesizable.join(", "));

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -93,14 +93,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let y = m
         .indexed_var("y", &chemicals)
         .binary()
-        .lb_by(|k| {
-            let name = k.as_str().unwrap();
-            if available.iter().any(|&i| CHEMICALS[i] == name) { 1.0 } else { 0.0 }
-        })
-        .ub_by(|k| {
-            let name = k.as_str().unwrap();
-            if unavailable.iter().any(|&i| CHEMICALS[i] == name) { 0.0 } else { 1.0 }
-        })
+        .lb_by(
+            |name: String| {
+                if available.iter().any(|&i| CHEMICALS[i] == name) { 1.0 } else { 0.0 }
+            },
+        )
+        .ub_by(
+            |name: String| {
+                if unavailable.iter().any(|&i| CHEMICALS[i] == name) { 0.0 } else { 1.0 }
+            },
+        )
         .build();
 
     // sum_vv (1 - y[vv]) >= 1 - y[v]


### PR DESCRIPTION
## Description

This PR expands the modeling API for `Set` and indexing.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)

## Changes Made

- Update `Set` API, an ordered, finite index set. The user can build one over integers, strings, or arbitrary tuples.
- Use `num-traits` to provide a generic API.
- Update examples.
- Update README.