### PR TITLE
Add new `sum_over` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,35 @@ let _y = m.indexed_var("y", &routes)
     .build();
 ```
 
+### Summing over sets
+
+`sum_over(&set, |k| expr)` reads as `sum_{k in set} expr(k)`. The closure
+receives the index as a typed value via `FromIndexKey`. Built-in impls cover
+`i64`, `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to arity 4.
+State the shape in the closure-arg annotation.
+
+```rust,ignore
+// Single sum: sum_{i in items} weights[i] * x[i]
+let total_weight = sum_over(&items, |i: usize| weights[i] * x[i]);
+m.constraint("cap", total_weight.le(capacity));
+
+// Double sum, flat: sum_{(p,q) in P*M} c[p,q] * x[p,q]
+let total_cost = sum_over(&(&plants * &markets), |(p, q): (String, String)| {
+    c[(&p, &q)] * x[(p, q)]
+});
+
+// Coefficient-weighted sum on paired Vecs: sum_{i} w_i * x_i
+let weight_sum = dot(&xs, &weights);
+
+// Freeform iterator -> use Iterator::sum.
+let active = (0..n).filter(|&i| online[i]).map(|i| x[i]).sum::<Expr>();
+```
+
 ### Rule-style constraints
 
-`Model::add_constraints_over` is a closure that receives the index as a typed
-value via `FromIndexKey`.
-
-Built-in impls cover `i64`, `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to
-arity 4. State the shape in the closure-arg annotation.
+`Model::add_constraints_over` is the constraint equivalent of `sum_over`, a
+closure receives the index as a typed value and returns one constraint per
+set element.
 
 ```rust,ignore
 // Scalar set: one constraint per period.
@@ -139,24 +161,13 @@ m.add_constraints_over("setup", &periods, |t: usize| {
     (x[t] - capacity * s[t]).le(0.0)
 });
 
-// Tuple set: destructure inline.
+// Tuple set: destructure inline. Inner `sum_over` builds the LHS expression.
 m.add_constraints_over("supply", &plants, |p: String| {
-    sum(markets.iter().map(|q| x[(&p, q)])).le(supply_of(&p))
+    sum_over(&markets, |q: String| x[(&p, q)]).le(supply_of(&p))
 });
 
 // Want the raw key? Annotate as IndexKey (clones once per iteration).
 m.add_constraints_over("c", &set, |k: IndexKey| x[&k].le(1.0));
-```
-
-### Summing over sets
-
-```rust,ignore
-// Linear-fastpath aware: `sum` collapses to a single Linear arena node.
-let total_weight = sum(items.iter().map(|k| {
-    let i: usize = FromIndexKey::from_index_key(&k);
-    weights[i] * x[i]
-}));
-m.constraint("cap", total_weight.le(capacity));
 ```
 
 ## Solving

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod objective;
 pub mod param;
 pub mod prelude;
 pub mod set;
+pub mod sum;
 pub mod var;
 
 pub use constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
@@ -20,8 +21,9 @@ pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
 pub use set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
+pub use sum::{SumDomain, sum_over};
 pub use var::{VarBuilder, Variable};
 
 // Re-export the expression handle so downstream code does not need a separate
 // `oximo-expr` import.
-pub use oximo_expr::{Expr, ExprArena, ExprId, ExprNode, ParamId, VarId};
+pub use oximo_expr::{Expr, ExprArena, ExprId, ExprNode, ParamId, VarId, dot};

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -6,5 +6,6 @@ pub use crate::model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
+pub use crate::sum::{SumDomain, sum_over};
 pub use crate::var::{VarBuilder, Variable};
-pub use oximo_expr::{Expr, ExprId, VarId, sum};
+pub use oximo_expr::{Expr, ExprId, VarId, dot};

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -1,0 +1,183 @@
+use oximo_expr::Expr;
+
+use crate::set::{FromIndexKey, Set};
+
+/// Domain over which [`sum_over`] iterates. Lets a single `sum_over` call
+/// accept either an [`Set`] (with typed key decoding via [`FromIndexKey`])
+/// or a borrowed slice of `Copy` keys, without intermediate conversions.
+pub trait SumDomain<K> {
+    fn for_each_key(&self, f: &mut dyn FnMut(K));
+}
+
+impl<K: FromIndexKey> SumDomain<K> for Set {
+    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
+        for k in self {
+            f(K::from_index_key(&k));
+        }
+    }
+}
+
+impl<K: Copy> SumDomain<K> for [K] {
+    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
+        for &k in self {
+            f(k);
+        }
+    }
+}
+
+impl<K: Copy> SumDomain<K> for Vec<K> {
+    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
+        self.as_slice().for_each_key(f);
+    }
+}
+
+impl<K: Copy, const N: usize> SumDomain<K> for [K; N] {
+    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
+        self.as_slice().for_each_key(f);
+    }
+}
+
+/// Sum an expression over every element of a domain.
+///
+/// Reads as the mathematical `sum_{k in domain} f(k)`. The closure parameter is
+/// either decoded from the domain's [`IndexKey`] via [`FromIndexKey`] (when
+/// the domain is a [`Set`]) or yielded directly (when the domain is a slice
+/// of `Copy` keys).
+///
+/// # Panics
+/// Panics if `domain` is empty, the resulting expression has no arena to
+/// attach to.
+pub fn sum_over<'a, K, D, F>(domain: &D, mut f: F) -> Expr<'a>
+where
+    D: SumDomain<K> + ?Sized,
+    F: FnMut(K) -> Expr<'a>,
+{
+    let mut acc: Option<Expr<'a>> = None;
+    domain.for_each_key(&mut |k| {
+        let e = f(k);
+        acc = Some(match acc {
+            Some(a) => a + e,
+            None => e,
+        });
+    });
+    acc.expect("sum_over on empty domain")
+}
+
+#[cfg(test)]
+mod tests {
+    use oximo_expr::extract_linear;
+
+    use super::*;
+    use crate::model::Model;
+    use crate::set::IndexKey;
+
+    #[test]
+    fn sum_over_scalar_set() {
+        let m = Model::new("scalar");
+        let items = Set::range(0..4);
+        let x = m.indexed_var("x", &items).lb(0.0).build();
+
+        let total = sum_over(&items, |i: usize| x[i]);
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 4);
+        assert!(terms.coeffs.iter().all(|(_, c)| (c - 1.0).abs() < f64::EPSILON));
+    }
+
+    #[test]
+    fn sum_over_tuple_set() {
+        let m = Model::new("tuple");
+        let plants = Set::strings(["seattle", "san-diego"]);
+        let markets = Set::strings(["nyc", "chicago", "topeka"]);
+        let routes = &plants * &markets;
+        let x = m.indexed_var("x", &routes).lb(0.0).build();
+
+        let total = sum_over(&routes, |(p, q): (String, String)| x[(p, q)]);
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 6);
+    }
+
+    #[test]
+    fn nested_sum_over_double_sum() {
+        let m = Model::new("nested");
+        let plants = Set::strings(["a", "b"]);
+        let markets = Set::strings(["x", "y", "z"]);
+        let routes = &plants * &markets;
+        let x = m.indexed_var("x", &routes).lb(0.0).build();
+
+        let total = sum_over(&plants, |p: String| sum_over(&markets, |q: String| x[(&p, q)]));
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 6);
+    }
+
+    #[test]
+    fn sum_over_passes_raw_index_key() {
+        let m = Model::new("rawkey");
+        let items = Set::range(0..3);
+        let x = m.indexed_var("x", &items).lb(0.0).build();
+
+        let total = sum_over(&items, |k: IndexKey| x[k]);
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 3);
+    }
+
+    #[test]
+    fn sum_over_slice_of_usize() {
+        let m = Model::new("slice");
+        let items = Set::range(0..5);
+        let x = m.indexed_var("x", &items).lb(0.0).build();
+
+        let picked: &[usize] = &[0, 2, 4];
+        let total = sum_over(picked, |i: usize| x[i]);
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 3);
+    }
+
+    #[test]
+    fn sum_over_vec_of_usize() {
+        let m = Model::new("vec");
+        let items = Set::range(0..5);
+        let x = m.indexed_var("x", &items).lb(0.0).build();
+
+        let picked: Vec<usize> = vec![1, 3];
+        let total = sum_over(&picked, |i: usize| x[i]);
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 2);
+    }
+
+    #[test]
+    fn sum_over_array_of_usize() {
+        let m = Model::new("array");
+        let items = Set::range(0..5);
+        let x = m.indexed_var("x", &items).lb(0.0).build();
+
+        let picked: [usize; 4] = [0, 1, 2, 3];
+        let total = sum_over(&picked, |i: usize| x[i]);
+        let arena = m.arena();
+        let terms = extract_linear(&arena, total.id).expect("linear");
+        assert_eq!(terms.coeffs.len(), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "sum_over on empty domain")]
+    fn sum_over_empty_set_panics() {
+        let m = Model::new("empty");
+        let empty = Set::range(0..0);
+        let _x = m.indexed_var("x", &Set::range(0..1)).lb(0.0).build();
+        let _ = sum_over(&empty, |_: usize| panic!("closure should not run"));
+    }
+
+    #[test]
+    #[should_panic(expected = "sum_over on empty domain")]
+    fn sum_over_empty_slice_panics() {
+        let m = Model::new("empty_slice");
+        let _x = m.indexed_var("x", &Set::range(0..1)).lb(0.0).build();
+        let empty: &[usize] = &[];
+        let _ = sum_over(empty, |_: usize| panic!("closure should not run"));
+    }
+}

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -40,7 +40,7 @@ impl<K: Copy, const N: usize> SumDomain<K> for [K; N] {
 /// Sum an expression over every element of a domain.
 ///
 /// Reads as the mathematical `sum_{k in domain} f(k)`. The closure parameter is
-/// either decoded from the domain's [`IndexKey`] via [`FromIndexKey`] (when
+/// either decoded from the domain's [`crate::set::IndexKey`] via [`FromIndexKey`] (when
 /// the domain is a [`Set`]) or yielded directly (when the domain is a slice
 /// of `Copy` keys).
 ///

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -3,37 +3,37 @@ use oximo_expr::Expr;
 use crate::set::{FromIndexKey, Set};
 
 /// Domain over which [`sum_over`] iterates. Lets a single `sum_over` call
-/// accept either an [`Set`] (with typed key decoding via [`FromIndexKey`])
+/// accept either a [`Set`] (with typed key decoding via [`FromIndexKey`])
 /// or a borrowed slice of `Copy` keys, without intermediate conversions.
+///
+/// Returns an iterator (rather than taking a callback) so the trait method
+/// monomorphizes through to the loop body in [`sum_over`], allowing inlining
+/// in hot sums. Implementations are typically one line.
 pub trait SumDomain<K> {
-    fn for_each_key(&self, f: &mut dyn FnMut(K));
+    fn keys(&self) -> impl Iterator<Item = K> + '_;
 }
 
 impl<K: FromIndexKey> SumDomain<K> for Set {
-    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
-        for k in self {
-            f(K::from_index_key(&k));
-        }
+    fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        self.iter().map(|k| K::from_index_key(&k))
     }
 }
 
 impl<K: Copy> SumDomain<K> for [K] {
-    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
-        for &k in self {
-            f(k);
-        }
+    fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        self.iter().copied()
     }
 }
 
 impl<K: Copy> SumDomain<K> for Vec<K> {
-    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
-        self.as_slice().for_each_key(f);
+    fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        self.iter().copied()
     }
 }
 
 impl<K: Copy, const N: usize> SumDomain<K> for [K; N] {
-    fn for_each_key(&self, f: &mut dyn FnMut(K)) {
-        self.as_slice().for_each_key(f);
+    fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        self.iter().copied()
     }
 }
 
@@ -52,15 +52,9 @@ where
     D: SumDomain<K> + ?Sized,
     F: FnMut(K) -> Expr<'a>,
 {
-    let mut acc: Option<Expr<'a>> = None;
-    domain.for_each_key(&mut |k| {
-        let e = f(k);
-        acc = Some(match acc {
-            Some(a) => a + e,
-            None => e,
-        });
-    });
-    acc.expect("sum_over on empty domain")
+    let mut iter = domain.keys();
+    let first = f(iter.next().expect("sum_over on empty domain"));
+    iter.fold(first, |acc, k| acc + f(k))
 }
 
 #[cfg(test)]

--- a/crates/oximo-expr/README.md
+++ b/crates/oximo-expr/README.md
@@ -59,14 +59,24 @@ expr.log()
 
 ## Utilities
 
-### `sum`
+### Summing expressions
+
+`Expr` implements `std::iter::Sum`, so any iterator of `Expr` (or `&Expr`) can
+be collapsed with the standard `.sum()`. The arena is taken from the first
+element, empty iterators panic.
 
 ```rust,ignore
-use oximo_expr::sum;
-let total = sum(vars.iter().zip(coeffs.iter()).map(|(x, c)| *c * *x));
+let total: Expr = vars.iter().copied().sum();
 ```
 
-Accumulates an iterator of `Expr` into a single linear expression.
+For coefficient-weighted sums (`sum_{i} c_i * e_i`) use the `dot` helper:
+
+```rust,ignore
+use oximo_expr::dot;
+let total = dot(&vars, &coeffs);
+```
+
+For sums indexed by an `oximo-core` `Set`, prefer `oximo_core::sum_over`.
 
 ### `extract_linear`
 

--- a/crates/oximo-expr/src/lib.rs
+++ b/crates/oximo-expr/src/lib.rs
@@ -13,6 +13,6 @@ pub use arena::{ExprArena, ExprId, ExprNode, ParamId, VarId};
 pub use eval::{EvalContext, EvalError, evaluate};
 pub use handle::Expr;
 pub use linear::{LinearTerms, extract_linear};
-pub use ops::sum;
+pub use ops::dot;
 pub use simplify::simplify;
 pub use visit::{Visitor, walk};

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -137,12 +137,20 @@ impl<'a, 'b> std::iter::Sum<&'b Expr<'a>> for Expr<'a> {
 
 /// Dot product of expressions with scalar coefficients: `sum_{i} c_i * e_i`.
 ///
+/// Accepts anything that derefs to a slice: `Vec<Expr>`, `[Expr; N]`,
+/// `&[Expr]` for the first argument. `Vec<f64>`, `[f64; N]`, `&[f64]` for
+/// the second.
+///
 /// # Panics
-/// Panics if `exprs` is empty (the result needs an arena handle).
-pub fn dot<'a, I, J>(exprs: I, coeffs: J) -> Expr<'a>
-where
-    I: IntoIterator<Item = Expr<'a>>,
-    J: IntoIterator<Item = f64>,
-{
-    exprs.into_iter().zip(coeffs).map(|(e, c)| c * e).sum()
+/// Panics if `exprs` and `coeffs` have different lengths, or if `exprs`
+/// is empty (the result needs an arena handle).
+pub fn dot<'a>(exprs: &[Expr<'a>], coeffs: &[f64]) -> Expr<'a> {
+    assert_eq!(
+        exprs.len(),
+        coeffs.len(),
+        "dot: length mismatch (exprs.len() = {}, coeffs.len() = {})",
+        exprs.len(),
+        coeffs.len(),
+    );
+    exprs.iter().zip(coeffs).map(|(e, c)| *c * *e).sum()
 }

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -137,9 +137,8 @@ impl<'a, 'b> std::iter::Sum<&'b Expr<'a>> for Expr<'a> {
 
 /// Dot product of expressions with scalar coefficients: `sum_{i} c_i * e_i`.
 ///
-/// Accepts anything that derefs to a slice: `Vec<Expr>`, `[Expr; N]`,
-/// `&[Expr]` for the first argument. `Vec<f64>`, `[f64; N]`, `&[f64]` for
-/// the second.
+/// Both arguments are slices. Pass owned containers by reference:
+/// `&vec`, `vec.as_slice()`, or `&array`.
 ///
 /// # Panics
 /// Panics if `exprs` and `coeffs` have different lengths, or if `exprs`

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -118,16 +118,31 @@ impl_scalar_ops!(f64);
 impl_scalar_ops!(i32);
 
 // -----------------------------------------------------------------------------
-// Sum support for `iter.sum::<Expr>()` would be nice but requires a starting
-// value tied to the arena. Provide a free function instead.
+// std::iter::Sum: the first element of the iterator carries the arena handle,
+// so no external zero is required.
 // -----------------------------------------------------------------------------
 
-/// Sum a non-empty iterator of expressions sharing the same arena.
+impl<'a> std::iter::Sum for Expr<'a> {
+    fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
+        let first = iter.next().expect("Expr::sum on empty iterator");
+        iter.fold(first, |acc, e| acc + e)
+    }
+}
+
+impl<'a, 'b> std::iter::Sum<&'b Expr<'a>> for Expr<'a> {
+    fn sum<I: Iterator<Item = &'b Expr<'a>>>(iter: I) -> Self {
+        iter.copied().sum()
+    }
+}
+
+/// Dot product of expressions with scalar coefficients: `sum_{i} c_i * e_i`.
 ///
 /// # Panics
-/// Panics if the iterator is empty.
-pub fn sum<'a, I: IntoIterator<Item = Expr<'a>>>(iter: I) -> Expr<'a> {
-    let mut it = iter.into_iter();
-    let first = it.next().expect("oximo_expr::sum on empty iterator");
-    it.fold(first, |acc, e| acc + e)
+/// Panics if `exprs` is empty (the result needs an arena handle).
+pub fn dot<'a, I, J>(exprs: I, coeffs: J) -> Expr<'a>
+where
+    I: IntoIterator<Item = Expr<'a>>,
+    J: IntoIterator<Item = f64>,
+{
+    exprs.into_iter().zip(coeffs).map(|(e, c)| c * e).sum()
 }

--- a/crates/oximo-expr/tests/arithmetic.rs
+++ b/crates/oximo-expr/tests/arithmetic.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 
-use oximo_expr::{Expr, ExprArena, ExprNode, VarId, evaluate, extract_linear};
+use oximo_expr::{Expr, ExprArena, ExprNode, VarId, dot, evaluate, extract_linear};
 
 fn make_var(arena: &RefCell<ExprArena>, idx: u32) -> Expr<'_> {
     Expr::from_var(arena, VarId(idx))
@@ -74,6 +74,35 @@ fn negation_flips_coefficients() {
     let mut sorted = terms.coeffs;
     sorted.sort_by_key(|(v, _)| v.0);
     assert_eq!(sorted, vec![(VarId(0), -2.0), (VarId(1), -3.0)]);
+}
+
+#[test]
+fn dot_computes_weighted_sum() {
+    let arena = RefCell::new(ExprArena::new());
+    let xs: Vec<_> = (0..3).map(|i| make_var(&arena, i)).collect();
+    let weights = [2.0, 3.0, 5.0];
+    let result = dot(&xs, &weights);
+    let terms = extract_linear(&arena.borrow(), result.id).expect("linear");
+    let mut sorted = terms.coeffs;
+    sorted.sort_by_key(|(v, _)| v.0);
+    assert_eq!(sorted, vec![(VarId(0), 2.0), (VarId(1), 3.0), (VarId(2), 5.0)]);
+}
+
+#[test]
+#[should_panic(expected = "dot: length mismatch")]
+fn dot_panics_on_length_mismatch() {
+    let arena = RefCell::new(ExprArena::new());
+    let xs: Vec<_> = (0..3).map(|i| make_var(&arena, i)).collect();
+    let weights = [2.0, 3.0];
+    let _ = dot(&xs, &weights);
+}
+
+#[test]
+#[should_panic(expected = "Expr::sum on empty iterator")]
+fn dot_panics_on_empty() {
+    let xs: Vec<Expr> = Vec::new();
+    let coeffs: Vec<f64> = Vec::new();
+    let _ = dot(&xs, &coeffs);
 }
 
 #[test]

--- a/crates/oximo-expr/tests/arithmetic.rs
+++ b/crates/oximo-expr/tests/arithmetic.rs
@@ -80,7 +80,7 @@ fn negation_flips_coefficients() {
 fn large_sum_extracts_correctly() {
     let arena = RefCell::new(ExprArena::new());
     let vars: Vec<_> = (0..100).map(|i| make_var(&arena, i)).collect();
-    let total = oximo_expr::sum(vars.iter().copied());
+    let total: Expr = vars.iter().copied().sum();
     let terms = extract_linear(&arena.borrow(), total.id).expect("linear");
     assert_eq!(terms.constant, 0.0);
     assert_eq!(terms.coeffs.len(), 100);

--- a/crates/oximo-gurobi/README.md
+++ b/crates/oximo-gurobi/README.md
@@ -57,9 +57,8 @@ let weights = [3.0, 4.0, 2.0, 5.0];
 let values  = [10.0, 12.0, 5.0, 14.0];
 
 let xs: Vec<_> = (0..4).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-let weight_sum = sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x));
-m.constraint("cap", weight_sum.le(7.0));
-m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+m.constraint("cap", dot(&xs, &weights).le(7.0));
+m.maximize(dot(&xs, &values));
 
 let result = Gurobi.solve(&m, &GurobiOptions::default())?;
 println!("status = {:?}", result.status);

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -124,13 +124,35 @@ let _y = m.indexed_var("y", &routes)
     .build();
 ```
 
+### Summing over sets
+
+`sum_over(&set, |k| expr)` reads as `sum_{k in set} expr(k)`. The closure
+receives the index as a typed value via `FromIndexKey`. Built-in impls cover
+`i64`, `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to arity 4.
+State the shape in the closure-arg annotation.
+
+```rust,ignore
+// Single sum: sum_{i in items} weights[i] * x[i]
+let total_weight = sum_over(&items, |i: usize| weights[i] * x[i]);
+m.constraint("cap", total_weight.le(capacity));
+
+// Double sum, flat: sum_{(p,q) in P*M} c[p,q] * x[p,q]
+let total_cost = sum_over(&(&plants * &markets), |(p, q): (String, String)| {
+    c[(&p, &q)] * x[(p, q)]
+});
+
+// Coefficient-weighted sum on paired Vecs: sum_{i} w_i * x_i
+let weight_sum = dot(&xs, &weights);
+
+// Freeform iterator -> use Iterator::sum.
+let active = (0..n).filter(|&i| online[i]).map(|i| x[i]).sum::<Expr>();
+```
+
 ### Rule-style constraints
 
-`Model::add_constraints_over` is a closure that receives the index as a typed
-value via `FromIndexKey`.
-
-Built-in impls cover `i64`, `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to
-arity 4. State the shape in the closure-arg annotation.
+`Model::add_constraints_over` is the constraint equivalent of `sum_over`, a
+closure receives the index as a typed value and returns one constraint per
+set element.
 
 ```rust,ignore
 // Scalar set: one constraint per period.
@@ -139,24 +161,13 @@ m.add_constraints_over("setup", &periods, |t: usize| {
     (x[t] - capacity * s[t]).le(0.0)
 });
 
-// Tuple set: destructure inline.
+// Tuple set: destructure inline. Inner `sum_over` builds the LHS expression.
 m.add_constraints_over("supply", &plants, |p: String| {
-    sum(markets.iter().map(|q| x[(&p, q)])).le(supply_of(&p))
+    sum_over(&markets, |q: String| x[(&p, q)]).le(supply_of(&p))
 });
 
 // Want the raw key? Annotate as IndexKey (clones once per iteration).
 m.add_constraints_over("c", &set, |k: IndexKey| x[&k].le(1.0));
-```
-
-### Summing over sets
-
-```rust,ignore
-// Linear-fastpath aware: `sum` collapses to a single Linear arena node.
-let total_weight = sum(items.iter().map(|k| {
-    let i: usize = FromIndexKey::from_index_key(&k);
-    weights[i] * x[i]
-}));
-m.constraint("cap", total_weight.le(capacity));
 ```
 
 ## Solving

--- a/crates/oximo/examples/lot_sizing.rs
+++ b/crates/oximo/examples/lot_sizing.rs
@@ -80,10 +80,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     m.add_constraints_over("setup", &periods, |t: usize| (x[t] - capacity * s[t]).le(0.0));
     m.constraint("safety_stock", h[T - 1].ge(safety_stock));
 
-    let cost = sum(periods.iter().map(|k| {
-        let t: usize = FromIndexKey::from_index_key(&k);
-        prod_cost[t] * x[t] + setup_cost * s[t] + hold_cost * h[t]
-    }));
+    let cost =
+        sum_over(&periods, |t: usize| prod_cost[t] * x[t] + setup_cost * s[t] + hold_cost * h[t]);
     m.minimize(cost);
 
     #[cfg(feature = "gurobi")]

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -109,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //    <=>  y[v] - sum_vv y[vv] >= 1 - |reactants|
     for &(rx, prod, reactants) in logicc {
         let n = reactants.len() as f64;
-        let reactant_sum = sum(reactants.iter().map(|&vv| y[CHEMICALS[vv]]));
+        let reactant_sum = sum_over(reactants, |vv: usize| y[CHEMICALS[vv]]);
         m.constraint(format!("leq_{rx}"), (y[CHEMICALS[prod]] - reactant_sum).ge(1.0 - n));
     }
 

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -25,9 +25,8 @@ fn knapsack_milp() {
 
     let m = Model::new("knapsack");
     let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    let weight_sum = sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x));
-    m.constraint("cap", weight_sum.le(15.0));
-    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(15.0));
+    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -63,9 +62,8 @@ fn milp_warm_start_finds_optimum() {
     let xs: Vec<_> = (0..weights.len())
         .map(|i| m.var(format!("x{i}")).binary().initial(warm_start[i]).build())
         .collect();
-    let weight_sum = sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x));
-    m.constraint("cap", weight_sum.le(15.0));
-    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(15.0));
+    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -137,9 +135,8 @@ fn mip_gap_accepted_and_solves() {
     let values = [10.0, 12.0, 5.0, 14.0, 3.0];
     let m = oximo_core::Model::new("ks");
     let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    let ws = xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x);
-    m.constraint("cap", sum(ws).le(8.0));
-    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(8.0));
+    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
     let opts = HighsOptions::default().mip_gap(0.5).verbose(false);
     let result = Highs.solve(&m, &opts).unwrap();
     assert!(
@@ -339,10 +336,10 @@ fn mps_columns_nonzero_count() {
     let m = Model::new("dense");
     let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).lb(0.0).build()).collect();
     for i in 0..5usize {
-        let row = oximo::prelude::sum(xs.iter().copied());
+        let row = xs.iter().copied().sum::<Expr>();
         m.constraint(format!("c{i}"), row.le(10.0));
     }
-    m.minimize(oximo::prelude::sum(xs.iter().copied()));
+    m.minimize(xs.iter().copied().sum::<Expr>());
 
     let s = oximo::io::to_mps_string(&m).unwrap();
 

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -25,8 +25,8 @@ fn knapsack_milp() {
 
     let m = Model::new("knapsack");
     let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(15.0));
-    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
+    m.constraint("cap", dot(&xs, &weights).le(15.0));
+    m.maximize(dot(&xs, &values));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -62,8 +62,8 @@ fn milp_warm_start_finds_optimum() {
     let xs: Vec<_> = (0..weights.len())
         .map(|i| m.var(format!("x{i}")).binary().initial(warm_start[i]).build())
         .collect();
-    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(15.0));
-    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
+    m.constraint("cap", dot(&xs, &weights).le(15.0));
+    m.maximize(dot(&xs, &values));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -135,8 +135,8 @@ fn mip_gap_accepted_and_solves() {
     let values = [10.0, 12.0, 5.0, 14.0, 3.0];
     let m = oximo_core::Model::new("ks");
     let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(8.0));
-    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
+    m.constraint("cap", dot(&xs, &weights).le(8.0));
+    m.maximize(dot(&xs, &values));
     let opts = HighsOptions::default().mip_gap(0.5).verbose(false);
     let result = Highs.solve(&m, &opts).unwrap();
     assert!(

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -43,9 +43,8 @@ fn gams_knapsack_milp() {
 
     let m = Model::new("knapsack");
     let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    let weight_sum = sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x));
-    m.constraint("cap", weight_sum.le(15.0));
-    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(15.0));
+    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -71,8 +70,8 @@ fn gams_mip_gap_option() {
     let values = [10.0, 12.0, 5.0, 14.0, 3.0];
     let m = Model::new("ks");
     let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", sum(xs.iter().zip(weights.iter()).map(|(x, w)| *w * *x)).le(8.0));
-    m.maximize(sum(xs.iter().zip(values.iter()).map(|(x, v)| *v * *x)));
+    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(8.0));
+    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
 
     let result = Gams::new().solve(&m, &GamsOptions::default().mip_gap(0.5)).unwrap();
     assert!(

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -43,8 +43,8 @@ fn gams_knapsack_milp() {
 
     let m = Model::new("knapsack");
     let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(15.0));
-    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
+    m.constraint("cap", dot(&xs, &weights).le(15.0));
+    m.maximize(dot(&xs, &values));
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -70,8 +70,8 @@ fn gams_mip_gap_option() {
     let values = [10.0, 12.0, 5.0, 14.0, 3.0];
     let m = Model::new("ks");
     let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(xs.iter().copied(), weights.iter().copied()).le(8.0));
-    m.maximize(dot(xs.iter().copied(), values.iter().copied()));
+    m.constraint("cap", dot(&xs, &weights).le(8.0));
+    m.maximize(dot(&xs, &values));
 
     let result = Gams::new().solve(&m, &GamsOptions::default().mip_gap(0.5)).unwrap();
     assert!(


### PR DESCRIPTION
## Description

This PR adds a new `sum_over` API that makes math-flavored sums without macros.

Before this, building sums over indexed variables required visible iterator plumbing:

```rust
let lhs = sum(markets.iter().map(|j| x[(p.clone(), j)]));
```

The `.iter().map(...)` boilerplate and key clones make it hard to read the mathematical structure. The goal was to recover something close to $\sum_{q \in M} x[p, q]$ without introducing macros.

We add two new functions:
1. `sum_over(&domain, |k| expr)`, which is the equivalent for sums of the existing `add_constraints_over` API.
2. `dot(&[Expr], &[f64])`, which is a shorthand for paired-data weighted sums: $\sum_{i} c_{i} \cdot e_{i}$.

And we removed `oximo_expr::sum` since the `iter::Sum` impl replaces the iterator use case, `sum_over` covers the indexed use case, and `dot` covers the weighted-pair use case.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)