### PR TITLE
Add support for `Param`

### DIFF
--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -28,9 +28,8 @@ const BAR_NAME: &str = "problem.bar";
 /// # Errors
 ///
 /// Returns [`SolverError`] on constructs BARON's `.bar` format cannot represent
-/// (`sin`/`cos`, symbolic parameters, semicontinuous/semi-integer variables), a
-/// missing BARON executable, a BARON run that produced no times file, or I/O
-/// failures.
+/// (`sin`/`cos`, semicontinuous/semi-integer variables), a missing BARON
+/// executable, a BARON run that produced no times file, or I/O failures.
 ///
 /// # Panics
 ///
@@ -364,11 +363,7 @@ fn write_bar_expr(bar: &mut String, arena: &ExprArena, id: ExprId) -> Result<(),
     match arena.get(id) {
         ExprNode::Const(c) => write!(bar, "{}", fmt(*c)).unwrap(),
         ExprNode::Var(v) => write!(bar, "x{}", v.index()).unwrap(),
-        ExprNode::Param(_) => {
-            return Err(SolverError::Backend(
-                "BARON backend does not support symbolic parameters".into(),
-            ));
-        }
+        ExprNode::Param(p) => write!(bar, "{}", fmt(arena.param_value(*p))).unwrap(),
         ExprNode::Linear { coeffs, constant } => {
             let t = LinearTerms { coeffs: coeffs.clone(), constant: *constant };
             write!(bar, "(").unwrap();

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -1,6 +1,6 @@
 use std::cell::{Ref, RefCell};
 
-use oximo_expr::{Expr, ExprArena, ExprClass, VarId, classify};
+use oximo_expr::{Expr, ExprArena, ExprClass, ParamId, VarId, classify};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
@@ -9,6 +9,7 @@ use crate::domain::Domain;
 use crate::error::{Error, Result};
 use crate::indexed::IndexedVar;
 use crate::objective::{Objective, ObjectiveSense};
+use crate::param::Parameter;
 use crate::set::{FromIndexKey, IndexKey, Set};
 use crate::var::{VarBuilder, Variable};
 
@@ -39,6 +40,8 @@ pub struct Model {
     pub(crate) arena: RefCell<ExprArena>,
     pub(crate) variables: RefCell<Vec<Variable>>,
     pub(crate) var_names: RefCell<FxHashMap<SmolStr, VarId>>,
+    pub(crate) parameters: RefCell<Vec<Parameter>>,
+    pub(crate) param_names: RefCell<FxHashMap<SmolStr, ParamId>>,
     pub(crate) constraints: RefCell<Vec<Constraint>>,
     pub(crate) constraint_names: RefCell<FxHashMap<SmolStr, ConstraintId>>,
     pub(crate) objective: RefCell<Option<Objective>>,
@@ -50,6 +53,7 @@ impl std::fmt::Debug for Model {
         f.debug_struct("Model")
             .field("name", &self.name)
             .field("vars", &self.variables.borrow().len())
+            .field("params", &self.parameters.borrow().len())
             .field("constraints", &self.constraints.borrow().len())
             .field("has_objective", &self.objective.borrow().is_some())
             .finish()
@@ -63,6 +67,8 @@ impl Model {
             arena: RefCell::new(ExprArena::new()),
             variables: RefCell::new(Vec::new()),
             var_names: RefCell::new(FxHashMap::default()),
+            parameters: RefCell::new(Vec::new()),
+            param_names: RefCell::new(FxHashMap::default()),
             constraints: RefCell::new(Vec::new()),
             constraint_names: RefCell::new(FxHashMap::default()),
             objective: RefCell::new(None),
@@ -161,6 +167,82 @@ impl Model {
         let v = &mut vars[id.index()];
         v.lb = lb;
         v.ub = ub;
+    }
+
+    // Parameters
+
+    /// Register a named scalar parameter initialized to `value`, returning an
+    /// [`Expr`] handle that references it symbolically.
+    ///
+    /// A parameter behaves like a constant coefficient (`param * var` is linear),
+    /// but stays symbolic in the expression tree so it can be re-bound with
+    /// [`Self::set_param`] / [`Self::set_param_id`] between solves without
+    /// rebuilding the model.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a parameter with the same name is already registered.
+    pub fn param<'a>(&'a self, name: impl Into<SmolStr>, value: f64) -> Expr<'a> {
+        let name = name.into();
+        assert!(
+            !self.param_names.borrow().contains_key(&name),
+            "parameter name {name:?} already registered"
+        );
+        let (id, node) = {
+            let mut a = self.arena.borrow_mut();
+            let id = a.new_param(value);
+            (id, a.param(id))
+        };
+        self.parameters.borrow_mut().push(Parameter { id, name: name.clone() });
+        self.param_names.borrow_mut().insert(name, id);
+        *self.cached_kind.borrow_mut() = None;
+        Expr::new(node, &self.arena)
+    }
+
+    /// Re-bind the parameter referenced by handle `p` to `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `p` is not a bare parameter handle (see [`Self::param`]).
+    pub fn set_param(&self, p: Expr<'_>, value: f64) {
+        let id = p.param_id().expect("Model::set_param expects a single-parameter expression");
+        self.set_param_id(id, value);
+    }
+
+    /// Re-bind parameter `id` to `value`. Takes effect on the next solve.
+    ///
+    /// The value is stored only in the expression arena (its single source of
+    /// truth); extraction and evaluation read it from there.
+    pub fn set_param_id(&self, id: ParamId, value: f64) {
+        self.arena.borrow_mut().set_param_value(id, value);
+        *self.cached_kind.borrow_mut() = None;
+    }
+
+    /// Current value bound to parameter `id`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` was not produced by [`Self::param`] on this model.
+    pub fn param_value(&self, id: ParamId) -> f64 {
+        self.arena.borrow().param_value(id)
+    }
+
+    /// Current value of the parameter referenced by handle `p`, or `None` if
+    /// `p` is not a bare parameter handle.
+    pub fn param_value_of(&self, p: Expr<'_>) -> Option<f64> {
+        p.param_id().map(|id| self.param_value(id))
+    }
+
+    pub fn parameter_id(&self, name: &str) -> Option<ParamId> {
+        self.param_names.borrow().get(name).copied()
+    }
+
+    pub fn parameters(&self) -> Ref<'_, Vec<Parameter>> {
+        self.parameters.borrow()
+    }
+
+    pub fn num_parameters(&self) -> usize {
+        self.parameters.borrow().len()
     }
 
     // Constraints
@@ -449,4 +531,73 @@ pub fn display_index_key(key: &IndexKey) -> String {
     let mut out = String::new();
     write_key_parts(&mut out, key);
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use oximo_expr::extract_linear;
+
+    use super::*;
+    use crate::constraint::Relate;
+
+    #[test]
+    fn param_times_var_keeps_model_linear() {
+        let m = Model::new("p");
+        let param = m.param("param", 4.0);
+        let x = m.var("x").lb(0.0).build();
+        m.minimize(param * x);
+        assert_eq!(m.kind(), ModelKind::LP);
+    }
+
+    #[test]
+    fn param_coeff_resolves_and_rebinds() {
+        let m = Model::new("p");
+        let param = m.param("param", 4.0);
+        let x = m.var("x").lb(0.0).build();
+        let obj = param * x;
+
+        let coeff = |m: &Model| {
+            let arena = m.arena();
+            extract_linear(&arena, obj.id).expect("linear").coeffs[0].1
+        };
+        assert!((coeff(&m) - 4.0).abs() < f64::EPSILON);
+
+        m.set_param(param, 9.0);
+        assert!((coeff(&m) - 9.0).abs() < f64::EPSILON);
+        assert_eq!(m.parameter_id("param"), Some(param.param_id().unwrap()));
+    }
+
+    #[test]
+    fn param_value_reads_live_arena_value() {
+        let m = Model::new("p");
+        let param = m.param("param", 4.0);
+        let id = param.param_id().unwrap();
+        assert!((m.param_value(id) - 4.0).abs() < f64::EPSILON);
+        assert!((m.param_value_of(param).unwrap() - 4.0).abs() < f64::EPSILON);
+
+        m.set_param(param, 7.5);
+        assert!((m.param_value(id) - 7.5).abs() < f64::EPSILON);
+
+        let x = m.var("x").build();
+        assert!(m.param_value_of(x).is_none());
+    }
+
+    #[test]
+    fn set_param_invalidates_kind_cache() {
+        let m = Model::new("p");
+        let p = m.param("p", 1.0);
+        let x = m.var("x").lb(0.0).build();
+        m.constraint("c", (p * x).le(10.0));
+        assert_eq!(m.kind(), ModelKind::LP);
+        m.set_param(p, 2.0);
+        assert_eq!(m.kind(), ModelKind::LP);
+    }
+
+    #[test]
+    #[should_panic(expected = "parameter name \"dup\" already registered")]
+    fn duplicate_param_name_panics() {
+        let m = Model::new("p");
+        let _a = m.param("dup", 1.0);
+        let _b = m.param("dup", 2.0);
+    }
 }

--- a/crates/oximo-core/src/param.rs
+++ b/crates/oximo-core/src/param.rs
@@ -1,15 +1,22 @@
 use oximo_expr::ParamId;
 use smol_str::SmolStr;
 
-/// Parameter metadata. Parameters are scalars referenced symbolically in
-/// expressions and re-bound between solves.
+/// Parameter identity (id + name). Parameters are scalars referenced
+/// symbolically in expressions and re-bound between solves.
+///
+/// The current numeric value lives in the model's expression arena 
+/// (the single source of truth) so re-binding does not have to
+/// keep two copies in sync. Read it with [`Model::param_value`] /
+/// [`Model::param_value_of`].
 ///
 /// For now, we support scalar parameters only.
 ///
 /// TODO: Add support for more parameters
+///
+/// [`Model::param_value`]: crate::Model::param_value
+/// [`Model::param_value_of`]: crate::Model::param_value_of
 #[derive(Clone, Debug)]
 pub struct Parameter {
     pub id: ParamId,
     pub name: SmolStr,
-    pub value: f64,
 }

--- a/crates/oximo-core/src/param.rs
+++ b/crates/oximo-core/src/param.rs
@@ -4,7 +4,7 @@ use smol_str::SmolStr;
 /// Parameter identity (id + name). Parameters are scalars referenced
 /// symbolically in expressions and re-bound between solves.
 ///
-/// The current numeric value lives in the model's expression arena 
+/// The current numeric value lives in the model's expression arena
 /// (the single source of truth) so re-binding does not have to
 /// keep two copies in sync. Read it with [`Model::param_value`] /
 /// [`Model::param_value_of`].

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -8,4 +8,4 @@ pub use crate::param::Parameter;
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
 pub use crate::sum::{SumDomain, sum_over};
 pub use crate::var::{VarBuilder, Variable};
-pub use oximo_expr::{Expr, ExprId, VarId, dot};
+pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};

--- a/crates/oximo-expr/src/arena.rs
+++ b/crates/oximo-expr/src/arena.rs
@@ -57,6 +57,7 @@ pub enum ExprNode {
 #[derive(Clone, Debug, Default)]
 pub struct ExprArena {
     nodes: Vec<ExprNode>,
+    param_values: Vec<f64>,
 }
 
 impl ExprArena {
@@ -65,7 +66,7 @@ impl ExprArena {
     }
 
     pub fn with_capacity(cap: usize) -> Self {
-        Self { nodes: Vec::with_capacity(cap) }
+        Self { nodes: Vec::with_capacity(cap), param_values: Vec::new() }
     }
 
     #[inline]
@@ -111,6 +112,51 @@ impl ExprArena {
 
     pub fn param(&mut self, p: ParamId) -> ExprId {
         self.push(ExprNode::Param(p))
+    }
+
+    /// Allocate a fresh parameter initialized to `value`, returning its
+    /// [`ParamId`]. Push a [`ExprNode::Param`] with [`Self::param`] to reference
+    /// it inside an expression.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of parameters exceeds `u32::MAX`.
+    pub fn new_param(&mut self, value: f64) -> ParamId {
+        let id = ParamId(u32::try_from(self.param_values.len()).expect("parameter arena overflow"));
+        self.param_values.push(value);
+        id
+    }
+
+    #[inline]
+    pub fn num_params(&self) -> usize {
+        self.param_values.len()
+    }
+
+    /// Current value bound to parameter `p`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `p` was not allocated by [`Self::new_param`] on this arena.
+    #[inline]
+    pub fn param_value(&self, p: ParamId) -> f64 {
+        self.param_values[p.index()]
+    }
+
+    /// Look up the value of `p`, returning `None` if `p` is out of range.
+    #[inline]
+    pub fn try_param_value(&self, p: ParamId) -> Option<f64> {
+        self.param_values.get(p.index()).copied()
+    }
+
+    /// Re-bind parameter `p` to `value`. Takes effect on the next extraction or
+    /// evaluation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `p` was not allocated by [`Self::new_param`] on this arena.
+    #[inline]
+    pub fn set_param_value(&mut self, p: ParamId, value: f64) {
+        self.param_values[p.index()] = value;
     }
 
     pub fn linear(&mut self, coeffs: Vec<(VarId, f64)>, constant: f64) -> ExprId {

--- a/crates/oximo-expr/src/classify.rs
+++ b/crates/oximo-expr/src/classify.rs
@@ -54,8 +54,8 @@ impl Degree {
 
 fn degree(arena: &ExprArena, id: ExprId) -> Degree {
     match arena.get(id) {
-        ExprNode::Const(_) => Degree::Zero,
-        ExprNode::Var(_) | ExprNode::Param(_) | ExprNode::Linear { .. } => Degree::One,
+        ExprNode::Const(_) | ExprNode::Param(_) => Degree::Zero,
+        ExprNode::Var(_) | ExprNode::Linear { .. } => Degree::One,
         ExprNode::Neg(inner) => degree(arena, *inner),
         ExprNode::Add(children) => {
             let mut d = Degree::Zero;

--- a/crates/oximo-expr/src/classify.rs
+++ b/crates/oximo-expr/src/classify.rs
@@ -205,4 +205,34 @@ mod tests {
         let m = a.push(ExprNode::Mul(smallvec![c, x]));
         assert_eq!(classify(&a, m), ExprClass::Linear);
     }
+
+    #[test]
+    fn param_alone_is_linear() {
+        let mut a = ExprArena::new();
+        let p = a.new_param(4.0);
+        let pn = a.param(p);
+        assert_eq!(classify(&a, pn), ExprClass::Linear);
+    }
+
+    #[test]
+    fn param_times_var_is_linear() {
+        let mut a = ExprArena::new();
+        let p = a.new_param(4.0);
+        let pn = a.param(p);
+        let x = var(&mut a, 0);
+        let m = a.push(ExprNode::Mul(smallvec![pn, x]));
+        assert_eq!(classify(&a, m), ExprClass::Linear);
+    }
+
+    #[test]
+    fn param_times_var_squared_is_quadratic() {
+        let mut a = ExprArena::new();
+        let p = a.new_param(4.0);
+        let pn = a.param(p);
+        let x = var(&mut a, 0);
+        let two = a.push(ExprNode::Const(2.0));
+        let sq = a.push(ExprNode::Pow(x, two));
+        let m = a.push(ExprNode::Mul(smallvec![pn, sq]));
+        assert_eq!(classify(&a, m), ExprClass::Quadratic);
+    }
 }

--- a/crates/oximo-expr/src/eval.rs
+++ b/crates/oximo-expr/src/eval.rs
@@ -34,7 +34,10 @@ pub fn evaluate<C: EvalContext>(arena: &ExprArena, id: ExprId, ctx: &C) -> Resul
     Ok(match arena.get(id) {
         ExprNode::Const(c) => *c,
         ExprNode::Var(v) => ctx.var(*v).ok_or(EvalError::UnboundVar(*v))?,
-        ExprNode::Param(p) => ctx.param(*p).ok_or(EvalError::UnboundParam(*p))?,
+        ExprNode::Param(p) => ctx
+            .param(*p)
+            .or_else(|| arena.try_param_value(*p))
+            .ok_or(EvalError::UnboundParam(*p))?,
         ExprNode::Add(children) => children
             .iter()
             .try_fold(0.0, |acc, c| Ok::<_, EvalError>(acc + evaluate(arena, *c, ctx)?))?,

--- a/crates/oximo-expr/src/handle.rs
+++ b/crates/oximo-expr/src/handle.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::arena::{ExprArena, ExprId, ExprNode, VarId};
+use crate::arena::{ExprArena, ExprId, ExprNode, ParamId, VarId};
 
 /// Lightweight handle to a node in an [`ExprArena`].
 ///
@@ -40,6 +40,15 @@ impl<'a> Expr<'a> {
     pub fn var_id(self) -> Option<VarId> {
         match self.arena.borrow().get(self.id) {
             ExprNode::Var(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    /// If this handle is a bare parameter, return its [`ParamId`].
+    /// `None` for compound expressions.
+    pub fn param_id(self) -> Option<ParamId> {
+        match self.arena.borrow().get(self.id) {
+            ExprNode::Param(id) => Some(*id),
             _ => None,
         }
     }

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -12,16 +12,22 @@ pub struct LinearTerms {
 
 /// Try to interpret `id` as a linear expression. Returns `None` for any
 /// nonlinear node (Mul of two non-constants, Pow, transcendentals, ...).
-fn as_linear(arena: &ExprArena, id: ExprId) -> Option<LinearTerms> {
+///
+/// When `resolve_params` is set, a [`ExprNode::Param`] folds to its current
+/// arena value and counts as a constant.
+fn as_linear(arena: &ExprArena, id: ExprId, resolve_params: bool) -> Option<LinearTerms> {
     match arena.get(id) {
         ExprNode::Const(c) => Some(LinearTerms { coeffs: Vec::new(), constant: *c }),
+        ExprNode::Param(p) if resolve_params => {
+            Some(LinearTerms { coeffs: Vec::new(), constant: arena.param_value(*p) })
+        }
         ExprNode::Var(v) => Some(LinearTerms { coeffs: vec![(*v, 1.0)], constant: 0.0 }),
         ExprNode::Linear { coeffs, constant } => {
             Some(LinearTerms { coeffs: coeffs.clone(), constant: *constant })
         }
         ExprNode::Neg(inner) => {
             let inner = *inner;
-            as_linear(arena, inner).map(|mut t| {
+            as_linear(arena, inner, resolve_params).map(|mut t| {
                 t.coeffs.iter_mut().for_each(|(_, c)| *c = -*c);
                 t.constant = -t.constant;
                 t
@@ -33,7 +39,7 @@ fn as_linear(arena: &ExprArena, id: ExprId) -> Option<LinearTerms> {
             let mut map: FxHashMap<VarId, f64> =
                 FxHashMap::with_capacity_and_hasher(children.len() * 4, FxBuildHasher);
             for child in children {
-                let t = as_linear(arena, child)?;
+                let t = as_linear(arena, child, resolve_params)?;
                 for (v, c) in t.coeffs {
                     *map.entry(v).or_insert(0.0) += c;
                 }
@@ -48,12 +54,13 @@ fn as_linear(arena: &ExprArena, id: ExprId) -> Option<LinearTerms> {
             let mut scalar = 1.0;
             let mut linear: Option<LinearTerms> = None;
             for child in children {
-                if let ExprNode::Const(c) = arena.get(child) {
-                    scalar *= c;
-                } else if linear.is_none() {
-                    linear = Some(as_linear(arena, child)?);
-                } else {
-                    return None;
+                match arena.get(child) {
+                    ExprNode::Const(c) => scalar *= c,
+                    ExprNode::Param(p) if resolve_params => scalar *= arena.param_value(*p),
+                    _ if linear.is_none() => {
+                        linear = Some(as_linear(arena, child, resolve_params)?);
+                    }
+                    _ => return None,
                 }
             }
             Some(match linear {
@@ -78,7 +85,7 @@ fn push_linear(arena: &mut ExprArena, mut t: LinearTerms) -> ExprId {
 /// Build `lhs + rhs`, preserving the linear fast-path when both sides are
 /// linear. Falls back to an n-ary `Add` node otherwise.
 pub(crate) fn add_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
-    if let (Some(lt), Some(rt)) = (as_linear(arena, lhs), as_linear(arena, rhs)) {
+    if let (Some(lt), Some(rt)) = (as_linear(arena, lhs, false), as_linear(arena, rhs, false)) {
         let mut map: FxHashMap<VarId, f64> =
             FxHashMap::with_capacity_and_hasher(lt.coeffs.len() + rt.coeffs.len(), FxBuildHasher);
         for (v, c) in lt.coeffs.into_iter().chain(rt.coeffs) {
@@ -102,14 +109,14 @@ pub(crate) fn sub_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
 /// stay on the linear fast-path. Otherwise produce a generic n-ary `Mul`.
 pub(crate) fn mul_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
     if let ExprNode::Const(c) = *arena.get(lhs) {
-        if let Some(mut t) = as_linear(arena, rhs) {
+        if let Some(mut t) = as_linear(arena, rhs, false) {
             t.coeffs.iter_mut().for_each(|(_, co)| *co *= c);
             t.constant *= c;
             return push_linear(arena, t);
         }
     }
     if let ExprNode::Const(c) = *arena.get(rhs) {
-        if let Some(mut t) = as_linear(arena, lhs) {
+        if let Some(mut t) = as_linear(arena, lhs, false) {
             t.coeffs.iter_mut().for_each(|(_, co)| *co *= c);
             t.constant *= c;
             return push_linear(arena, t);
@@ -124,7 +131,7 @@ pub(crate) fn mul_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
 pub(crate) fn div_into(arena: &mut ExprArena, num: ExprId, den: ExprId) -> ExprId {
     if let ExprNode::Const(c) = *arena.get(den) {
         if c != 0.0 {
-            if let Some(mut t) = as_linear(arena, num) {
+            if let Some(mut t) = as_linear(arena, num, false) {
                 let inv = 1.0 / c;
                 t.coeffs.iter_mut().for_each(|(_, co)| *co *= inv);
                 t.constant *= inv;
@@ -139,7 +146,7 @@ pub(crate) fn div_into(arena: &mut ExprArena, num: ExprId, den: ExprId) -> ExprI
 
 /// Build `-rhs`, preserving linearity.
 pub(crate) fn neg_into(arena: &mut ExprArena, rhs: ExprId) -> ExprId {
-    if let Some(mut t) = as_linear(arena, rhs) {
+    if let Some(mut t) = as_linear(arena, rhs, false) {
         t.coeffs.iter_mut().for_each(|(_, c)| *c = -*c);
         t.constant = -t.constant;
         return push_linear(arena, t);
@@ -149,8 +156,13 @@ pub(crate) fn neg_into(arena: &mut ExprArena, rhs: ExprId) -> ExprId {
 
 /// Snapshot the linear terms of `id`, if any. Used by solver backends to
 /// extract LP coefficients without walking the tree themselves.
+///
+/// Parameters are folded to their current arena values, so the returned
+/// coefficients reflect the latest [`ExprArena::set_param_value`] binding.
+///
+/// [`ExprArena::set_param_value`]: crate::ExprArena::set_param_value
 pub fn extract_linear(arena: &ExprArena, id: ExprId) -> Option<LinearTerms> {
-    as_linear(arena, id)
+    as_linear(arena, id, true)
 }
 
 /// A nonlinear residual summand: the existing arena node `id`, taken with a
@@ -174,7 +186,7 @@ pub struct SignedExpr {
 /// node, optionally negated). `LinearTerms` may have empty `coeffs` and
 /// `constant == 0.0` when the whole expression is purely nonlinear.
 pub fn split_linear(arena: &ExprArena, id: ExprId) -> (LinearTerms, Vec<SignedExpr>) {
-    if let Some(lt) = as_linear(arena, id) {
+    if let Some(lt) = as_linear(arena, id, true) {
         return (lt, Vec::new());
     }
     let mut lin = LinearTerms::default();
@@ -189,7 +201,7 @@ pub fn split_linear(arena: &ExprArena, id: ExprId) -> (LinearTerms, Vec<SignedEx
             }
             ExprNode::Neg(inner) => sign_stack.push((*inner, -sign)),
             _ => {
-                if let Some(mut t) = as_linear(arena, cur) {
+                if let Some(mut t) = as_linear(arena, cur, true) {
                     if (sign - 1.0).abs() > 0.0 {
                         t.coeffs.iter_mut().for_each(|(_, c)| *c *= sign);
                         t.constant *= sign;

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -223,3 +223,50 @@ pub fn split_linear(arena: &ExprArena, id: ExprId) -> (LinearTerms, Vec<SignedEx
     lin.coeffs.retain(|(_, c)| *c != 0.0);
     (lin, residual)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arena::{ExprArena, ExprNode, VarId};
+
+    #[test]
+    fn param_times_var_stays_symbolic_until_extracted() {
+        // Build `price * x` through the operator helper. The parameter must NOT
+        // be folded into a Linear node at build time (so it stays re-bindable)
+        let mut arena = ExprArena::new();
+        let pid = arena.new_param(3.0);
+        let price = arena.param(pid);
+        let xnode = arena.push(ExprNode::Var(VarId(0)));
+        let prod = mul_into(&mut arena, price, xnode);
+        assert!(matches!(arena.get(prod), ExprNode::Mul(_)));
+
+        let terms = extract_linear(&arena, prod).expect("linear");
+        assert_eq!(terms.coeffs, vec![(VarId(0), 3.0)]);
+        assert!(terms.constant.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn rebinding_param_updates_extracted_coeff() {
+        let mut arena = ExprArena::new();
+        let pid = arena.new_param(3.0);
+        let price = arena.param(pid);
+        let xnode = arena.push(ExprNode::Var(VarId(0)));
+        let prod = mul_into(&mut arena, price, xnode);
+
+        arena.set_param_value(pid, 10.0);
+        let terms = extract_linear(&arena, prod).expect("linear");
+        assert_eq!(terms.coeffs, vec![(VarId(0), 10.0)]);
+    }
+
+    #[test]
+    fn param_plus_var_resolves_constant() {
+        let mut arena = ExprArena::new();
+        let pid = arena.new_param(5.0);
+        let price = arena.param(pid);
+        let xnode = arena.push(ExprNode::Var(VarId(0)));
+        let sum = add_into(&mut arena, price, xnode);
+        let terms = extract_linear(&arena, sum).expect("linear");
+        assert_eq!(terms.coeffs, vec![(VarId(0), 1.0)]);
+        assert!((terms.constant - 5.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/oximo-expr/src/quadratic.rs
+++ b/crates/oximo-expr/src/quadratic.rs
@@ -108,7 +108,8 @@ fn mul_linear(a: &Poly, b: &Poly) -> Poly {
 }
 
 /// Recursively interpret `id` as a polynomial of degree `<= 2`. Returns `None`
-/// for anything of higher degree, transcendentals, division, or parameters.
+/// for anything of higher degree, transcendentals, or division. Parameters fold
+/// to their live arena value (a degree-0 constant).
 fn as_poly(arena: &ExprArena, id: ExprId) -> Option<Poly> {
     match arena.get(id) {
         ExprNode::Const(c) => Some(Poly::constant(*c)),
@@ -163,8 +164,8 @@ fn as_poly(arena: &ExprArena, id: ExprId) -> Option<Poly> {
                 _ => None,
             }
         }
-        ExprNode::Param(_)
-        | ExprNode::Div(_, _)
+        ExprNode::Param(p) => Some(Poly::constant(arena.param_value(*p))),
+        ExprNode::Div(_, _)
         | ExprNode::Sin(_)
         | ExprNode::Cos(_)
         | ExprNode::Exp(_)
@@ -179,12 +180,10 @@ fn as_poly(arena: &ExprArena, id: ExprId) -> Option<Poly> {
 ///
 /// `None` is returned for any expression `classify` would call
 /// `Nonlinear` (degree `> 2`, transcendentals, non-integer/negative powers,
-/// division), and also for expressions containing free [`ParamId`]s, which
-/// have no numeric value here.
+/// division). Parameters are folded to their current arena values, so a
+/// polynomial whose coefficients are parameters is still extracted.
 ///
 /// A purely linear (or constant) expression yields an empty `hessian`.
-///
-/// [`ParamId`]: crate::ParamId
 pub fn extract_quadratic(arena: &ExprArena, id: ExprId) -> Option<QuadraticTerms> {
     let poly = as_poly(arena, id)?;
 

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -599,11 +599,7 @@ fn write_gams_expr(gms: &mut String, arena: &ExprArena, id: ExprId, leading_spac
     match arena.get(id) {
         ExprNode::Const(c) => write!(gms, "{}", fmt(*c)).unwrap(),
         ExprNode::Var(v) => write!(gms, "v{}", v.index()).unwrap(),
-        ExprNode::Param(_) => {
-            // Since params not yet passed into GAMS emission, we emit a placeholder
-            // so downstream errors are clear.
-            write!(gms, "0 /* unsupported: param */").unwrap();
-        }
+        ExprNode::Param(p) => write!(gms, "{}", fmt(arena.param_value(*p))).unwrap(),
         ExprNode::Linear { coeffs, constant } => {
             let t = LinearTerms { coeffs: coeffs.clone(), constant: *constant };
             write!(gms, "(").unwrap();

--- a/crates/oximo-gurobi/src/nonlinear.rs
+++ b/crates/oximo-gurobi/src/nonlinear.rs
@@ -164,10 +164,11 @@ fn as_aux_var(lowered: LoweredExpr, ctx: &mut LoweringCtx<'_>) -> Result<Var, So
     }
 }
 
-/// True if `id` is a literal constant, returns the value if so.
+/// True if `id` is a literal constant or a parameter, returns the value if so.
 fn as_const(arena: &ExprArena, id: ExprId) -> Option<f64> {
     match arena.get(id) {
         ExprNode::Const(c) => Some(*c),
+        ExprNode::Param(p) => Some(arena.param_value(*p)),
         _ => None,
     }
 }
@@ -180,9 +181,7 @@ pub(crate) fn lower(
     match arena.get(id) {
         ExprNode::Const(c) => Ok(LoweredExpr::Linear(linear_constant(*c))),
         ExprNode::Var(v) => Ok(LoweredExpr::Linear(linear_from_var(grb_var(ctx, *v)))),
-        ExprNode::Param(_) => Err(SolverError::Backend(
-            "Param nodes are not supported by oximo-gurobi nonlinear lowering".into(),
-        )),
+        ExprNode::Param(p) => Ok(LoweredExpr::Linear(linear_constant(arena.param_value(*p)))),
         ExprNode::Linear { coeffs, constant } => {
             let mut e = linear_constant(*constant);
             for (v, c) in coeffs {

--- a/crates/oximo-io/src/nl/analyze.rs
+++ b/crates/oximo-io/src/nl/analyze.rs
@@ -130,7 +130,12 @@ fn validate(arena: &ExprArena, id: ExprId, nonfinite_strings: bool) -> Result<()
             Ok(())
         }
         ExprNode::Var(_) => Ok(()),
-        ExprNode::Param(_) => Err(IoError::UnsupportedNode("Param")),
+        ExprNode::Param(p) => {
+            if !nonfinite_strings && !arena.param_value(*p).is_finite() {
+                return Err(IoError::InvalidNumber);
+            }
+            Ok(())
+        }
         ExprNode::Neg(x)
         | ExprNode::Sin(x)
         | ExprNode::Cos(x)

--- a/crates/oximo-io/src/nl/emit_expr.rs
+++ b/crates/oximo-io/src/nl/emit_expr.rs
@@ -78,7 +78,7 @@ pub(crate) fn emit_expr<W: Write>(
             let idx = var_index.get(v).copied().expect("var missing from permutation");
             w.var(idx)?;
         }
-        ExprNode::Param(_) => return Err(IoError::UnsupportedNode("Param")),
+        ExprNode::Param(p) => w.num(arena.param_value(*p))?,
         ExprNode::Neg(x) => {
             w.op(16)?;
             emit_expr(w, arena, var_index, *x)?;

--- a/crates/oximo/examples/parametric_pricing.rs
+++ b/crates/oximo/examples/parametric_pricing.rs
@@ -1,0 +1,61 @@
+//! Parametric pricing: re-solving one model across many parameter values.
+//!
+//! A small workshop makes two products from a shared pool of labor and
+//! material. Product 2 sells at a fixed margin. Product 1's margin `p1` is a
+//! *market parameter* we do not control. We want the optimal product mix as
+//! `p1` sweeps over a range of market scenarios.
+//!
+//! The point of a [`Model::param`] is that it stays symbolic in the model: we
+//! build the LP once, then call [`Model::set_param`] between solves to
+//! re-bind `p1` without rebuilding any variables, constraints, or objective.
+//! Each solve reads the parameter's current value, so the coefficient on `x1`
+//! tracks the latest binding.
+//!
+//! References:
+//! - Dantzig, G. B. (1998). Linear Programming and Extensions. 
+//!   Princeton, NJ: Princeton University Press.
+//! - Hillier F. S., & Lieberman G. J. (2010). Introduction to Operations Research.
+//!   New York, NY: McGraw-Hill Higher Education.
+
+use oximo::prelude::*;
+use oximo::solvers::Highs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let m = Model::new("parametric_pricing");
+
+    // Per-unit margin of product 1: a market price we re-bind per scenario.
+    let p1 = m.param("p1", 0.0);
+
+    // Production quantities (units)
+    let x1 = m.var("x1").lb(0.0).build();
+    let x2 = m.var("x2").lb(0.0).build();
+
+    // Shared resources
+    m.constraint("labor", (2.0 * x1 + x2).le(100.0));
+    m.constraint("material", (x1 + 3.0 * x2).le(90.0));
+
+    // profit = p1 * x1 + 5 * x2  (product 2's margin is fixed at 5)
+    m.maximize(p1 * x1 + 5.0 * x2);
+
+    // The model kind is inferred and does not change as we re-bind `p1`.
+    assert_eq!(m.kind(), ModelKind::LP);
+    println!("model kind: {:?}  (param * var stays linear)\n", m.kind());
+
+    println!("  p1  |    x1    |    x2    |  profit");
+    println!("------+----------+----------+---------");
+
+    for price in [1.0, 1.6, 2.0, 5.0, 11.0] {
+        // Re-bind `p1` to the current price
+        m.set_param(p1, price);
+
+        let result = Highs.solve(&m, &HighsOptions::default())?;
+        assert_eq!(result.status, SolverStatus::Optimal);
+
+        let x1v = result.value_of(x1).unwrap_or(0.0);
+        let x2v = result.value_of(x2).unwrap_or(0.0);
+        let profit = result.objective.unwrap_or(0.0);
+        println!(" {price:>4.1} | {x1v:>8.2} | {x2v:>8.2} | {profit:>7.2}");
+    }
+
+    Ok(())
+}

--- a/crates/oximo/examples/parametric_pricing.rs
+++ b/crates/oximo/examples/parametric_pricing.rs
@@ -12,7 +12,7 @@
 //! tracks the latest binding.
 //!
 //! References:
-//! - Dantzig, G. B. (1998). Linear Programming and Extensions. 
+//! - Dantzig, G. B. (1998). Linear Programming and Extensions.
 //!   Princeton, NJ: Princeton University Press.
 //! - Hillier F. S., & Lieberman G. J. (2010). Introduction to Operations Research.
 //!   New York, NY: McGraw-Hill Higher Education.

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -19,6 +19,74 @@ fn lp_canonical() {
 }
 
 #[test]
+fn param_coefficient_lp_rebinds_without_rebuild() {
+    let m = Model::new("param_lp");
+    let price = m.param("price", 3.0);
+    let x = m.var("x").bounds(0.0, 10.0).build();
+    m.maximize(price * x);
+    assert_eq!(m.kind(), ModelKind::LP);
+
+    let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert!((r.objective.unwrap() - 30.0).abs() < 1e-6);
+
+    m.set_param(price, 5.0);
+    let r2 = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert!((r2.objective.unwrap() - 50.0).abs() < 1e-6);
+}
+
+#[test]
+fn param_coefficient_qp_rebinds() {
+    let m = Model::new("param_qp");
+    let t = m.param("t", 2.0);
+    let x = m.var("x").bounds(-10.0, 10.0).build();
+    m.minimize((x - t).powi(2));
+    assert_eq!(m.kind(), ModelKind::QP);
+
+    let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert!((r.value_of(x).unwrap() - 2.0).abs() < 1e-5);
+
+    m.set_param(t, 4.0);
+    let r2 = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert!((r2.value_of(x).unwrap() - 4.0).abs() < 1e-5);
+}
+
+#[cfg(feature = "io")]
+#[test]
+fn io_linear_writers_fold_param_coefficient() {
+    use oximo::io::{to_lp_string, to_mps_string};
+
+    let m = Model::new("io_param");
+    let cost = m.param("cost", 3.0);
+    let x = m.var("x").lb(0.0).build();
+    m.constraint("c", x.ge(2.0));
+    m.minimize(cost * x);
+
+    let mps = to_mps_string(&m).unwrap();
+    assert!(mps.contains("x         OBJ       3"), "got:\n{mps}");
+    assert!(to_lp_string(&m).is_ok());
+
+    m.set_param(cost, 5.0);
+    let mps2 = to_mps_string(&m).unwrap();
+    assert!(mps2.contains("x         OBJ       5"), "got:\n{mps2}");
+}
+
+#[cfg(feature = "io")]
+#[test]
+fn nl_writer_emits_param_in_nonlinear_term() {
+    use oximo::io::to_nl_string;
+
+    let m = Model::new("nl_param");
+    let k = m.param("k", 2.0);
+    let x = m.var("x").lb(0.0).build();
+    m.constraint("c", (k * x.powi(2)).le(10.0));
+    m.minimize(x);
+    let nl = to_nl_string(&m).unwrap();
+    assert!(!nl.is_empty());
+}
+
+#[test]
 fn knapsack_milp() {
     let weights = [3.0, 4.0, 2.0, 5.0, 1.0, 6.0, 7.0, 2.0];
     let values = [10.0, 12.0, 5.0, 14.0, 3.0, 18.0, 22.0, 6.0];


### PR DESCRIPTION
## Description

This PR adds support for `Param`, which allows users to define parameters that remain symbolic in the model but have a numeric value at solve time, enabling users to rerun the model without rebuilding any variables, constraints, or objective.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)