### PR TITLE
Return multiple solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ m.constraint("c3", x.le(y + 2.0));
 m.maximize(3.0 * x + 4.0 * y);
 
 let result = Highs.solve(&m, &HighsOptions::default())?;
-println!("obj = {:?}", result.objective);   // 34.0
+println!("obj = {:?}", result.objective());   // 34.0
 println!("x   = {:?}", result.value_of(x)); // 6.0
 println!("y   = {:?}", result.value_of(y)); // 4.0
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -239,9 +239,9 @@ let result = Baron::new().solve(&m, &BaronOptions::default())?;
 let result = Highs.solve(&m, &HighsOptions::default())?;
 
 match result.status {
-    SolverStatus::Optimal => println!("optimal: {}", result.objective.unwrap()),
+    SolverStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
     SolverStatus::Infeasible => println!("infeasible"),
-    SolverStatus::TimeLimit => println!("time limit, best = {:?}", result.objective),
+    SolverStatus::TimeLimit => println!("time limit, best = {:?}", result.objective()),
     _ => {}
 }
 

--- a/crates/oximo-baron/README.md
+++ b/crates/oximo-baron/README.md
@@ -53,7 +53,7 @@ m.maximize((one + x).log() + 2.0 * y);
 
 let result = Baron::new().solve(&m, &BaronOptions::default())?;
 println!("status = {:?}", result.status);
-println!("obj    = {:?}", result.objective);
+println!("obj    = {:?}", result.objective());
 ```
 
 Run the bundled example:

--- a/crates/oximo-baron/src/options.rs
+++ b/crates/oximo-baron/src/options.rs
@@ -407,6 +407,13 @@ mod tests {
     }
 
     #[test]
+    fn solution_pool_does_not_override_user_verbosity() {
+        let bar = render(&BaronOptions::default().num_sol(5).verbose(false));
+        assert!(bar.contains("PrLevel: 0;"), "{bar}");
+        assert!(!bar.contains("PrLevel: 1;"), "{bar}");
+    }
+
+    #[test]
     fn newly_added_options_emit_correctly() {
         let o = BaronOptions::default()
             .target(1.5)

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -6,7 +6,7 @@ use std::{fs, io};
 
 use oximo_core::{Constraint, Domain, Model, Objective, ObjectiveSense, Sense, VarId, Variable};
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
-use oximo_solver::{SolverError, SolverResult, SolverStatus};
+use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
 use rustc_hash::FxHashMap;
 
 use crate::BaronOptions;
@@ -40,7 +40,7 @@ pub fn solve(
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
     let sense = model.objective().as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
-    let bar = build_bar(model, opts)?;
+    let (bar, var_order) = build_bar(model, opts)?;
 
     // - Temp directory. Combine a timestamp with a per-process atomic counter so
     //   concurrent invocations never share a directory.
@@ -118,14 +118,16 @@ pub fn solve(
     let tim = fs::read_to_string(&tim_path)
         .map_err(|e| SolverError::Backend(format!("cannot read times file: {e}")))?;
     let res = fs::read_to_string(tmp_dir.join(RES_NAME)).unwrap_or_default();
-    let result = parse_solution(&tim, &res, sense, elapsed, raw_log);
+    let result = parse_solution(&tim, &res, sense, elapsed, raw_log, &var_order);
 
     let _ = fs::remove_dir_all(&tmp_dir);
     Ok(result)
 }
 
-/// Build the full `.bar` file text for `model`.
-fn build_bar(model: &Model, opts: &BaronOptions) -> Result<String, SolverError> {
+/// Build the full `.bar` file text for `model`, returning it alongside the
+/// variable declaration order (see [`write_var_declarations`]) used to decode
+/// BARON's numeric solution-pool blocks.
+fn build_bar(model: &Model, opts: &BaronOptions) -> Result<(String, Vec<VarId>), SolverError> {
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
@@ -133,19 +135,24 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<String, SolverError> 
 
     let mut bar = String::with_capacity(4096);
     write_options(&mut bar, opts, RES_NAME, TIM_NAME);
-    write_var_declarations(&mut bar, &vars)?;
+    let var_order = write_var_declarations(&mut bar, &vars)?;
     write_bounds(&mut bar, &vars);
     write_equations(&mut bar, &arena, &constraints)?;
     write_objective(&mut bar, &arena, objective.as_ref())?;
     write_starting_point(&mut bar, &vars);
-    Ok(bar)
+    Ok((bar, var_order))
 }
 
 // - .bar writers
 
 /// Emit the `BINARY_VARIABLES` / `INTEGER_VARIABLES` / `POSITIVE_VARIABLES` /
 /// `VARIABLES` declaration sections.
-fn write_var_declarations(bar: &mut String, vars: &[Variable]) -> Result<(), SolverError> {
+///
+/// Returns the variable `VarId`s in the order they are declared (binary,
+/// integer, positive, free). BARON numbers variables 1-based in this order, so
+/// the result maps "Variable no. `k`" back to a `VarId` when parsing the
+/// enumerated solution pool.
+fn write_var_declarations(bar: &mut String, vars: &[Variable]) -> Result<Vec<VarId>, SolverError> {
     let (mut bin, mut int, mut pos, mut free) = (Vec::new(), Vec::new(), Vec::new(), Vec::new());
     for v in vars {
         match v.domain {
@@ -170,7 +177,8 @@ fn write_var_declarations(bar: &mut String, vars: &[Variable]) -> Result<(), Sol
     write_var_section(bar, "POSITIVE_VARIABLES", &pos);
     write_var_section(bar, "VARIABLES", &free);
     writeln!(bar).unwrap();
-    Ok(())
+    let order = bin.iter().chain(&int).chain(&pos).chain(&free).map(|v| v.id).collect();
+    Ok(order)
 }
 
 fn write_var_section(bar: &mut String, header: &str, vars: &[&Variable]) {
@@ -505,6 +513,7 @@ fn parse_solution(
     sense: ObjectiveSense,
     elapsed: std::time::Duration,
     raw_log: Option<String>,
+    var_order: &[VarId],
 ) -> SolverResult {
     let tokens: Vec<&str> = tim.split_whitespace().collect();
     let int_at = |i: usize| tokens.get(i).and_then(|s| s.parse::<i64>().ok());
@@ -527,14 +536,21 @@ fn parse_solution(
         ObjectiveSense::Maximize => lower,
     };
 
-    let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
-    if has_sol && nodeopt != Some(-3) {
-        parse_results(res, &mut primal);
+    let mut solutions = if has_sol && nodeopt != Some(-3) {
+        parse_results(res, var_order, sense)
+    } else {
+        Vec::new()
+    };
+
+    // BARON prints each solution's exact objective. Only when the status says a
+    // solution exists but no primal block was parsed do we fall back to the times
+    // file so `result_count` still reflects that a solution exists.
+    if has_sol && solutions.is_empty() {
+        solutions.push(SolutionPoint { primal: FxHashMap::default(), objective });
     }
 
     SolverResult {
-        objective: if has_sol { objective } else { None },
-        primal: if has_sol { primal } else { FxHashMap::default() },
+        solutions,
         dual: FxHashMap::default(),
         reduced_costs: FxHashMap::default(),
         status,
@@ -571,39 +587,119 @@ fn map_status(solver_status: i64, model_status: i64) -> SolverStatus {
     }
 }
 
-/// Extract the primal solution from BARON's results file.
+/// Parse the primal solutions from BARON's results file (`res.lst`), best first.
 ///
-/// The variable block follows a `"The best solution found"` header (then two
-/// lines). Each entry line is `name <bound> value ...`; we recover the `VarId`
-/// from the digits in the synthetic `x{i}` name and read the value from the
-/// third whitespace column.
-fn parse_results(res: &str, primal: &mut FxHashMap<VarId, f64>) {
-    let mut lines = res.lines();
-    let mut found = false;
-    for line in lines.by_ref() {
-        if line.trim_start().starts_with("The best solution found") {
-            found = true;
+/// When BARON enumerates a pool (`NumSol > 1`) it prints the distinct points
+/// after `*** Normal completion ***` as numeric blocks (see
+/// [`parse_solution_pool`]). Each has its own objective, but in the order it
+/// found them. We need to sort the pool by objective per the
+/// optimization `sense`, so index `0` is the incumbent.
+fn parse_results(res: &str, var_order: &[VarId], sense: ObjectiveSense) -> Vec<SolutionPoint> {
+    let mut pool = parse_solution_pool(res, var_order);
+    if pool.is_empty() {
+        return parse_best_table(res).into_iter().collect();
+    }
+    pool.sort_by(|a, b| {
+        let ord = match sense {
+            ObjectiveSense::Maximize => b.objective.partial_cmp(&a.objective),
+            ObjectiveSense::Minimize => a.objective.partial_cmp(&b.objective),
+        };
+        ord.unwrap_or(std::cmp::Ordering::Equal)
+    });
+    pool
+}
+
+/// Parse the enumerated solution pool BARON prints after
+/// `*** Normal completion ***`:
+///
+/// ```text
+///  >>> Objective value is:        <obj>
+///  >>> Corresponding solution vector is:
+///  >>> Variable no.       Value
+///  >>>      1             <v1>
+///  >>>      2             <v2>
+/// ```
+///
+/// one block per distinct point, best first. Variable numbers are 1-based
+/// positions in the `.bar` declaration order, so `var_order[k - 1]` is the
+/// `VarId` for "Variable no. `k`". Only the post-completion region is scanned.
+///
+/// Returns empty when BARON printed no pool (e.g. a time-limited run).
+fn parse_solution_pool(res: &str, var_order: &[VarId]) -> Vec<SolutionPoint> {
+    let Some(pos) = res.find("Normal completion") else {
+        return Vec::new();
+    };
+    let strip = |l: &str| l.trim_start().trim_start_matches(">>>").trim().to_string();
+
+    let mut out: Vec<SolutionPoint> = Vec::new();
+    let mut last_obj: Option<f64> = None;
+    let mut lines = res[pos..].lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let t = strip(line);
+        if t.starts_with("Objective value is") {
+            last_obj = t.rsplit(':').next().and_then(parse_baron_float);
+        } else if t.starts_with("Corresponding dual solution")
+            || t.starts_with("The best solution found")
+        {
             break;
+        } else if t.starts_with("Corresponding solution vector") {
+            let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
+            while let Some(peek) = lines.peek() {
+                let p = strip(peek);
+                if p.is_empty()
+                    || p.starts_with("Objective value is")
+                    || p.starts_with("Corresponding")
+                    || p.starts_with("The best solution found")
+                {
+                    break;
+                }
+                lines.next();
+                let parts: Vec<&str> = p.split_whitespace().collect();
+                if let (Some(k), Some(val)) = (
+                    parts.first().and_then(|s| s.parse::<usize>().ok()),
+                    parts.get(1).and_then(|s| parse_baron_float(s)),
+                ) {
+                    if (1..=var_order.len()).contains(&k) {
+                        primal.insert(var_order[k - 1], val);
+                    }
+                }
+            }
+            if !primal.is_empty() {
+                out.push(SolutionPoint { primal, objective: last_obj });
+            }
         }
     }
-    if !found {
-        return;
-    }
-    // Skip the two header lines between the banner and the variable rows.
-    lines.next();
-    lines.next();
-    for line in lines {
-        if line.trim().is_empty() {
+    out
+}
+
+/// Parse the single `"The best solution found is:"` table: rows of
+/// `x{VarId} xlo xbest xup`, with the value in the third whitespace column and a
+/// trailing `"... objective value of: X"` line. Returns `None` when the banner
+/// is absent.
+fn parse_best_table(res: &str) -> Option<SolutionPoint> {
+    let pos = res.find("The best solution found")?;
+    let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
+    let mut objective = None;
+    let mut started = false;
+    for line in res[pos..].lines().skip(1) {
+        if line.contains("objective value of") {
+            objective = line.split_whitespace().last().and_then(parse_baron_float);
             break;
         }
         let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 3 {
-            continue;
+        if let (Some(&p0), Some(&p2)) = (parts.first(), parts.get(2)) {
+            if let (Some(idx), Some(val)) = (extract_index(p0), parse_baron_float(p2)) {
+                primal.insert(VarId(idx), val);
+                started = true;
+                continue;
+            }
         }
-        if let (Some(idx), Some(val)) = (extract_index(parts[0]), parse_baron_float(parts[2])) {
-            primal.insert(VarId(idx), val);
+        if started {
+            break;
         }
     }
+    (!primal.is_empty() || objective.is_some()).then_some(SolutionPoint { primal, objective })
 }
 
 /// Recover the variable index from a synthetic `x{i}` name by reading its digits.
@@ -613,13 +709,22 @@ fn extract_index(name: &str) -> Option<u32> {
     digits.parse().ok()
 }
 
-/// Parse a BARON-formatted float, tolerating its infinity sentinels.
+/// Parse a BARON-formatted float, tolerating its infinity sentinels and the
+/// leading-decimal-point form it prints for values in `(-1, 1)` (e.g. `-.9999`).
 fn parse_baron_float(s: &str) -> Option<f64> {
     match s.trim() {
         "" => None,
         "inf" | "Inf" | "+inf" | "+Inf" => Some(f64::INFINITY),
         "-inf" | "-Inf" => Some(f64::NEG_INFINITY),
-        other => other.parse().ok(),
+        other => {
+            if let Some(rest) = other.strip_prefix("-.") {
+                format!("-0.{rest}").parse().ok()
+            } else if let Some(rest) = other.strip_prefix('.') {
+                format!("0.{rest}").parse().ok()
+            } else {
+                other.parse().ok()
+            }
+        }
     }
 }
 
@@ -630,7 +735,7 @@ mod tests {
     use super::*;
 
     fn render(model: &Model) -> String {
-        build_bar(model, &BaronOptions::default()).expect("build_bar")
+        build_bar(model, &BaronOptions::default()).expect("build_bar").0
     }
 
     #[test]
@@ -835,37 +940,91 @@ mod tests {
     fn parse_tim_picks_objective_by_sense() {
         // name ncon nvar a b lower upper solver model c iters nodeopt ... wall
         let tim = "m 1 2 0 0 1.5 9.5 1 1 0 42 7 0 0 0.42";
-        let r = parse_solution(tim, "", ObjectiveSense::Minimize, std::time::Duration::ZERO, None);
+        let r =
+            parse_solution(tim, "", ObjectiveSense::Minimize, std::time::Duration::ZERO, None, &[]);
         assert_eq!(r.status, SolverStatus::Optimal);
-        assert_eq!(r.objective, Some(9.5)); // upper bound for minimize
+        assert_eq!(r.objective(), Some(9.5)); // upper bound for minimize
         assert_eq!(r.iterations, 42); // branch-and-reduce iterations from tim[10]
-        let r = parse_solution(tim, "", ObjectiveSense::Maximize, std::time::Duration::ZERO, None);
-        assert_eq!(r.objective, Some(1.5)); // lower bound for maximize
+        let r =
+            parse_solution(tim, "", ObjectiveSense::Maximize, std::time::Duration::ZERO, None, &[]);
+        assert_eq!(r.objective(), Some(1.5)); // lower bound for maximize
     }
 
     #[test]
     fn parse_res_extracts_primal() {
-        let mut primal = FxHashMap::default();
         let res = "\
 junk line
 The best solution found is:
 
-  name        lower        value
-  x0          0.0          1.25
-  x1          0.0          3.50
+  variable     xlo      xbest    xup
+  x0           0.0      1.25     10
+  x1           0.0      3.50     10
 
+The above solution has an objective value of:    0.0
 ";
-        parse_results(res, &mut primal);
-        assert_eq!(primal.get(&VarId(0)), Some(&1.25));
-        assert_eq!(primal.get(&VarId(1)), Some(&3.5));
+        let blocks = parse_results(res, &[VarId(0), VarId(1)], ObjectiveSense::Minimize);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].primal.get(&VarId(0)), Some(&1.25));
+        assert_eq!(blocks[0].primal.get(&VarId(1)), Some(&3.5));
+    }
+
+    #[test]
+    fn parse_res_extracts_multiple_solutions() {
+        let res = "\
+                         *** Normal completion ***
+
+ >>> Objective value is:           0.0000000000000000000000
+ >>> Corresponding solution vector is:
+ >>> Variable no.              Value
+ >>>       1             1.0000000010231691049967
+ >>>       2             1.0000000010231691049967
+
+ >>> Objective value is:           0.0000000000000000000000
+ >>> Corresponding solution vector is:
+ >>> Variable no.              Value
+ >>>       1            -.99999999996972754878755
+ >>>       2            0.99999999997690125486116
+
+ >>> Corresponding dual solution vector is:
+ >>> Variable no.              Marginal
+ >>>       1             0.0000000000000000000000
+
+The best solution found is:
+
+  variable     xlo      xbest                          xup
+  x0           -2       1.00000000102316910499667e+00  2
+  x1           -2       1.00000000102316910499667e+00  2
+
+The above solution has an objective value of:  0.0000000000000000000000
+";
+        let blocks = parse_results(res, &[VarId(0), VarId(1)], ObjectiveSense::Minimize);
+        assert_eq!(blocks.len(), 2, "expected two solution blocks: {blocks:?}");
+        assert!((blocks[0].primal[&VarId(0)] - 1.0).abs() < 1e-6);
+        assert!((blocks[0].primal[&VarId(1)] - 1.0).abs() < 1e-6);
+        assert!((blocks[1].primal[&VarId(0)] + 1.0).abs() < 1e-6);
+        assert!((blocks[1].primal[&VarId(1)] - 1.0).abs() < 1e-6);
+        assert_eq!(blocks[1].objective, Some(0.0));
     }
 
     #[test]
     fn no_solution_node_minus_three_leaves_primal_empty() {
-        // solver=1 model=1 (optimal) but nodeopt = -3 => no solution vector.
+        // solver=1 model=1 (optimal) but nodeopt = -3 => no solution vector. We
+        // still surface a single point (objective known, variables unavailable).
         let tim = "m 1 1 0 0 0 0 1 1 0 0 -3 0 0 0.01";
         let res = "The best solution found is:\n\n\n  x0  0  9.9\n";
-        let r = parse_solution(tim, res, ObjectiveSense::Minimize, std::time::Duration::ZERO, None);
-        assert!(r.primal.is_empty(), "nodeopt -3 must skip primal: {:?}", r.primal);
+        let r = parse_solution(
+            tim,
+            res,
+            ObjectiveSense::Minimize,
+            std::time::Duration::ZERO,
+            None,
+            &[VarId(0)],
+        );
+        assert_eq!(r.result_count(), 1);
+        assert!(
+            r.solution(0).unwrap().primal.is_empty(),
+            "nodeopt -3 must skip primal: {:?}",
+            r.solution(0)
+        );
     }
 }

--- a/crates/oximo-gams/README.md
+++ b/crates/oximo-gams/README.md
@@ -56,7 +56,7 @@ m.maximize(3.0 * x + 4.0 * y);
 
 let result = Gams::new().solve(&m, &GamsOptions::default())?;
 println!("status = {:?}", result.status);
-println!("obj    = {:?}", result.objective);
+println!("obj    = {:?}", result.objective());
 ```
 
 Run the bundled example:

--- a/crates/oximo-gams/src/solver_options.rs
+++ b/crates/oximo-gams/src/solver_options.rs
@@ -36,6 +36,9 @@ pub enum GamsSolverConfig {
     Xpress(GamsXpressOptions),
     /// Any solver selectable by name with no typed option file.
     Named(GamsSolver),
+    /// A solver selected by name with raw option-file lines written verbatim to
+    /// `<solver>.opt`. Use for options oximo has no typed field for.
+    Raw(GamsSolver, Vec<String>),
 }
 
 impl GamsSolverConfig {
@@ -53,7 +56,7 @@ impl GamsSolverConfig {
             Self::Mosek(_) => "MOSEK",
             Self::Scip(_) => "SCIP",
             Self::Xpress(_) => "XPRESS",
-            Self::Named(s) => s.name(),
+            Self::Named(s) | Self::Raw(s, _) => s.name(),
         }
     }
 
@@ -74,6 +77,12 @@ impl GamsSolverConfig {
             Self::Scip(o) => o.write(buf),
             Self::Xpress(o) => o.write(buf),
             Self::Named(_) => false,
+            Self::Raw(_, lines) => {
+                for line in lines {
+                    writeln!(buf, "{line}").unwrap();
+                }
+                !lines.is_empty()
+            }
         }
     }
 
@@ -92,8 +101,8 @@ impl GamsSolverConfig {
 /// emit: `LP` / `MIP` / `NLP` / `MINLP` / `QCP` / `MIQCP`. `None` means the
 /// name is unrecognized and cannot be validated.
 ///
-/// Transcribed from the GAMS solver/model-type matrix (other model types —
-/// `MCP`, `MPEC`, `CNS`, `DNLP`, `EMP`, stochastic — are omitted because oximo
+/// Transcribed from the GAMS solver/model-type matrix (other model types
+/// (`MCP`, `MPEC`, `CNS`, `DNLP`, `EMP`, stochastic) are omitted because oximo
 /// never emits them):
 /// - "GAMS Solver Manuals," GAMS Development Corporation.
 ///   <https://www.gams.com/latest/docs/S_MAIN.html#SOLVERS_MODEL_TYPES> (accessed May 14, 2026).
@@ -141,6 +150,14 @@ fn kv_eq(buf: &mut String, key: &str, val: impl std::fmt::Display) {
     writeln!(buf, "{key} = {val}").unwrap();
 }
 
+/// Append verbatim option-file lines. Returns `true` if any were written.
+fn write_raw(buf: &mut String, raw: &[String]) -> bool {
+    for line in raw {
+        writeln!(buf, "{line}").unwrap();
+    }
+    !raw.is_empty()
+}
+
 // - BARON
 
 /// Options for the BARON global solver.
@@ -148,6 +165,8 @@ fn kv_eq(buf: &mut String, key: &str, val: impl std::fmt::Display) {
 /// Reference: <https://www.gams.com/latest/docs/S_BARON.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsBaronOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     /// Max wall-clock time in seconds (`MaxTime`)
     pub max_time: Option<f64>,
     /// Max branch-and-reduce iterations (`MaxIter`)
@@ -191,7 +210,8 @@ impl GamsBaronOptions {
         w!("NumLoc", self.num_loc);
         w!("NumSol", self.num_sol);
         w!("CutOff", self.cut_off);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -220,6 +240,8 @@ pub enum GamsCbcCuts {
 /// Reference: <https://www.gams.com/latest/docs/S_CBC.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsCbcOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     pub threads: Option<u32>,
     /// Relative MIP gap (`optcr`)
     pub mip_rel_gap: Option<f64>,
@@ -278,7 +300,8 @@ impl GamsCbcOptions {
             kv(buf, "heuristics", i32::from(h));
             n += 1;
         }
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -304,6 +327,8 @@ pub enum GamsCplexMipEmphasis {
 /// Reference: <https://www.gams.com/latest/docs/S_CPLEX.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsCplexOptions {
+    /// Extra option-file lines written verbatim (options without a typed field),
+    pub raw: Vec<String>,
     pub threads: Option<u32>,
     /// Relative MIP gap (`epgap`)
     pub mip_rel_gap: Option<f64>,
@@ -371,7 +396,8 @@ impl GamsCplexOptions {
         w!("eprhs", self.feasibility_tol);
         w!("epopt", self.optimality_tol);
         w!("lpmethod", self.lp_method);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -395,6 +421,8 @@ pub enum GamsGurobiMipFocus {
 /// Reference: <https://www.gams.com/latest/docs/S_GUROBI.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsGurobiOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     pub threads: Option<u32>,
     /// Relative MIP gap (`mipgap`)
     pub mip_rel_gap: Option<f64>,
@@ -455,7 +483,8 @@ impl GamsGurobiOptions {
         w!("feasibilitytol", self.feasibility_tol);
         w!("intfeastol", self.int_feas_tol);
         w!("optimalitytol", self.optimality_tol);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -484,6 +513,8 @@ pub enum GamsHighsSolver {
 /// Reference: <https://www.gams.com/latest/docs/S_HIGHS.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsHighsOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     pub threads: Option<u32>,
     /// Relative MIP gap (`mip_rel_gap`)
     pub mip_rel_gap: Option<f64>,
@@ -542,7 +573,8 @@ impl GamsHighsOptions {
         w!("primal_feasibility_tolerance", self.primal_feasibility_tol);
         w!("dual_feasibility_tolerance", self.dual_feasibility_tol);
         w!("optimality_tolerance", self.optimality_tol);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -571,6 +603,8 @@ pub enum GamsIpoptMuStrategy {
 /// Reference: <https://www.gams.com/latest/docs/S_IPOPT.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsIpoptOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     /// Max iterations (`max_iter`)
     pub max_iter: Option<u32>,
     /// Primary optimality tolerance (`tol`)
@@ -633,7 +667,8 @@ impl GamsIpoptOptions {
             );
             n += 1;
         }
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -659,6 +694,8 @@ pub enum GamsKnitroAlgorithm {
 /// Reference: <https://www.gams.com/latest/docs/S_KNITRO.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsKnitroOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     pub algorithm: Option<GamsKnitroAlgorithm>,
     /// Max iterations (`maxit`)
     pub max_iter: Option<u32>,
@@ -713,7 +750,8 @@ impl GamsKnitroOptions {
         w!("mip_maxnodes", self.mip_max_nodes);
         w!("mip_opt_gap_rel", self.mip_rel_gap);
         w!("mip_opt_gap_abs", self.mip_abs_gap);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -724,6 +762,8 @@ impl GamsKnitroOptions {
 /// Reference: <https://www.gams.com/latest/docs/S_MOSEK.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsMosekOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     /// Threads (`MSK_IPAR_NUM_THREADS`)
     pub threads: Option<u32>,
     /// Relative MIP gap (`MSK_DPAR_MIO_TOL_REL_GAP`)
@@ -764,7 +804,8 @@ impl GamsMosekOptions {
         w!("MSK_DPAR_INTPNT_TOL_DFEAS", self.dual_feas_tol);
         w!("MSK_DPAR_MIO_TOL_FEAS", self.mio_feas_tol);
         w!("MSK_DPAR_MIO_TOL_ABS_RELAX_INT", self.int_relax_tol);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -775,6 +816,8 @@ impl GamsMosekOptions {
 /// Reference: <https://www.gams.com/latest/docs/S_SCIP.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsScipOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     /// Max nodes (`limits/nodes`)
     pub node_limit: Option<i64>,
     /// Relative MIP gap (`limits/gap`)
@@ -812,7 +855,8 @@ impl GamsScipOptions {
         w!("numerics/dualfeastol", self.dual_feas_tol);
         w!("presolving/maxrounds", self.presolve_rounds);
         w!("separating/maxroundsroot", self.sep_rounds_root);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -823,6 +867,8 @@ impl GamsScipOptions {
 /// Reference: <https://www.gams.com/latest/docs/S_XPRESS.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsXpressOptions {
+    /// Extra option-file lines written verbatim (options without a typed field).
+    pub raw: Vec<String>,
     pub threads: Option<u32>,
     /// Relative MIP gap (`mipRelStop`)
     pub mip_rel_gap: Option<f64>,
@@ -868,7 +914,8 @@ impl GamsXpressOptions {
         w!("optimalityTol", self.optimality_tol);
         w!("mipTol", self.mip_tol);
         w!("defaultAlg", self.lp_algorithm);
-        n > 0
+        let extra = write_raw(buf, &self.raw);
+        n > 0 || extra
     }
 }
 
@@ -1040,6 +1087,36 @@ mod tests {
         let mut buf = String::new();
         assert!(!cfg.write_opt_file(&mut buf));
         assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn raw_lines_are_written_verbatim() {
+        // Per-struct `raw` is appended after the typed options.
+        let cfg = GamsSolverConfig::Cplex(GamsCplexOptions {
+            mip_rel_gap: Some(0.01),
+            raw: vec!["solnpool out.gdx".into(), "solnpoolpop 2".into()],
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("epgap 0.01"), "typed option missing:\n{buf}");
+        assert!(buf.contains("solnpool out.gdx"), "raw line missing:\n{buf}");
+        assert!(buf.contains("solnpoolpop 2"), "raw line missing:\n{buf}");
+
+        // `raw` alone still triggers the option file.
+        let cfg = GamsSolverConfig::Gurobi(GamsGurobiOptions {
+            raw: vec!["solnpool out.gdx".into()],
+            ..Default::default()
+        });
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert!(buf.contains("solnpool out.gdx"), "raw line missing:\n{buf}");
+
+        // The `Raw` variant writes the same verbatim lines for a named solver.
+        let cfg = GamsSolverConfig::Raw(GamsSolver::Xpress, vec!["miptol 1e-6".into()]);
+        let mut buf = String::new();
+        assert!(cfg.write_opt_file(&mut buf));
+        assert_eq!(buf, "miptol 1e-6\n");
     }
 
     #[test]

--- a/crates/oximo-gams/src/solver_options.rs
+++ b/crates/oximo-gams/src/solver_options.rs
@@ -327,7 +327,7 @@ pub enum GamsCplexMipEmphasis {
 /// Reference: <https://www.gams.com/latest/docs/S_CPLEX.html>
 #[derive(Clone, Debug, Default)]
 pub struct GamsCplexOptions {
-    /// Extra option-file lines written verbatim (options without a typed field),
+    /// Extra option-file lines written verbatim (options without a typed field).
     pub raw: Vec<String>,
     pub threads: Option<u32>,
     /// Relative MIP gap (`epgap`)

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -310,7 +310,11 @@ fn parseoximo_solution(
 /// dumped with `gdxdump` and parsed for the model's `v{i}` variable levels.
 ///
 /// Returns the points best-first by `sense`, empty when no pool was written.
-fn read_solution_pool(tmp_dir: &Path, gams_exec: &str, sense: ObjectiveSense) -> Vec<SolutionPoint> {
+fn read_solution_pool(
+    tmp_dir: &Path,
+    gams_exec: &str,
+    sense: ObjectiveSense,
+) -> Vec<SolutionPoint> {
     let gdxdump = gdxdump_path(gams_exec);
     let Ok(entries) = fs::read_dir(tmp_dir) else {
         return Vec::new();
@@ -342,7 +346,7 @@ fn read_solution_pool(tmp_dir: &Path, gams_exec: &str, sense: ObjectiveSense) ->
     members
 }
 
-/// `gdxdump` lives beside the `gams` executable. 
+/// `gdxdump` lives beside the `gams` executable.
 /// Fall back to `PATH` when only a bare command name is known.
 fn gdxdump_path(gams_exec: &str) -> PathBuf {
     let exe = if cfg!(windows) { "gdxdump.exe" } else { "gdxdump" };

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write as FmtWrite;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
@@ -11,7 +12,7 @@ use oximo_core::{
     Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
-use oximo_solver::{SolverError, SolverResult, SolverStatus};
+use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
 use rustc_hash::FxHashMap;
 
 use crate::GamsOptions;
@@ -43,8 +44,9 @@ pub fn solve(
     let vars = model.variables();
     let constraints = model.constraints();
     let objective = model.try_objective().map_err(SolverError::Core)?;
+    let sense = objective.sense;
 
-    let sense_kw = match objective.sense {
+    let sense_kw = match sense {
         ObjectiveSense::Minimize => "minimizing",
         ObjectiveSense::Maximize => "maximizing",
     };
@@ -164,7 +166,17 @@ pub fn solve(
     let result = if sol_path.exists() {
         let content = fs::read_to_string(&sol_path)
             .map_err(|e| SolverError::Backend(format!("cannot read solution file: {e}")))?;
-        parseoximo_solution(&content, elapsed, raw_log)
+        let mut result = parseoximo_solution(&content, elapsed, raw_log);
+        // If a sub-solver wrote a solution pool (e.g. CPLEX `solnpool`), surface
+        // every pooled point. The model itself emits no GDX, so any pool GDX in
+        // the run directory came from the user's option file.
+        if result.status.has_solution() {
+            let pool = read_solution_pool(&tmp_dir, gams_exec, sense);
+            if !pool.is_empty() {
+                result.solutions = pool;
+            }
+        }
+        result
     } else {
         // No solution file. GAMS must have failed before the Solve statement
         // (compilation error, license error, etc.).  Fall back to the listing.
@@ -275,9 +287,12 @@ fn parseoximo_solution(
     let status = map_status(modelstat.unwrap_or(13), solvestat.unwrap_or(0));
     let has_sol = status.has_solution();
 
+    // The PUT solution file holds only the incumbent. `solve` augments this with
+    // a sub-solver solution pool (if one was written) read from the run dir's GDX.
+    let solutions =
+        if has_sol { vec![SolutionPoint { primal, objective: obj_val }] } else { Vec::new() };
     SolverResult {
-        objective: if has_sol { obj_val } else { None },
-        primal: if has_sol { primal } else { FxHashMap::default() },
+        solutions,
         dual: if has_sol { dual } else { FxHashMap::default() },
         reduced_costs: if has_sol { reduced_costs } else { FxHashMap::default() },
         status,
@@ -285,6 +300,100 @@ fn parseoximo_solution(
         iterations: 0,
         raw_log,
     }
+}
+
+/// Read a sub-solver solution pool from the GAMS run directory.
+///
+/// A sub-solver `solnpool` option (CPLEX/Gurobi/Xpress) writes each alternative
+/// solution to its own GDX file plus an index GDX. oximo's generated model emits
+/// no GDX of its own, so every `*.gdx` in `tmp_dir` belongs to the pool. Each is
+/// dumped with `gdxdump` and parsed for the model's `v{i}` variable levels.
+///
+/// Returns the points best-first by `sense`, empty when no pool was written.
+fn read_solution_pool(tmp_dir: &Path, gams_exec: &str, sense: ObjectiveSense) -> Vec<SolutionPoint> {
+    let gdxdump = gdxdump_path(gams_exec);
+    let Ok(entries) = fs::read_dir(tmp_dir) else {
+        return Vec::new();
+    };
+    let mut members: Vec<SolutionPoint> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("gdx") {
+            continue;
+        }
+        let Ok(out) = std::process::Command::new(&gdxdump).arg(&path).output() else {
+            continue;
+        };
+        if !out.status.success() {
+            continue;
+        }
+        let dump = String::from_utf8_lossy(&out.stdout);
+        if let Some(pt) = parse_pool_member(&dump) {
+            members.push(pt);
+        }
+    }
+    members.sort_by(|a, b| {
+        let ord = match sense {
+            ObjectiveSense::Maximize => b.objective.partial_cmp(&a.objective),
+            ObjectiveSense::Minimize => a.objective.partial_cmp(&b.objective),
+        };
+        ord.unwrap_or(std::cmp::Ordering::Equal)
+    });
+    members
+}
+
+/// `gdxdump` lives beside the `gams` executable. 
+/// Fall back to `PATH` when only a bare command name is known.
+fn gdxdump_path(gams_exec: &str) -> PathBuf {
+    let exe = if cfg!(windows) { "gdxdump.exe" } else { "gdxdump" };
+    match Path::new(gams_exec).parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => dir.join(exe),
+        _ => PathBuf::from("gdxdump"),
+    }
+}
+
+/// Parse one pool member's `gdxdump` text into a [`SolutionPoint`].
+///
+/// Each model variable is dumped as `<type> Variable v{i} /L <level> /;` (or an
+/// empty record `/ /` for a default-zero level). The objective variable `v_obj`
+/// carries the point's objective. Returns `None` for a GDX with no `v{i}`
+/// symbols (e.g. the pool index file).
+fn parse_pool_member(dump: &str) -> Option<SolutionPoint> {
+    let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
+    let mut objective: Option<f64> = None;
+    for line in dump.lines() {
+        let Some(pos) = line.find("Variable ") else {
+            continue;
+        };
+        let rest = &line[pos + "Variable ".len()..];
+        let name_end = rest.find(|c: char| c.is_whitespace() || c == '/').unwrap_or(rest.len());
+        let name = &rest[..name_end];
+        if name == "v_obj" {
+            objective = Some(parse_gdx_level(line));
+        } else if let Some(idx) = name.strip_prefix('v').and_then(|d| d.parse::<u32>().ok()) {
+            primal.insert(VarId(idx), parse_gdx_level(line));
+        }
+    }
+    if primal.is_empty() { None } else { Some(SolutionPoint { primal, objective }) }
+}
+
+/// Extract the `L` (level) field from a `gdxdump` variable record line, e.g.
+/// `binary Variable v0 /L 1 /;` -> `1.0`. An empty record (`/ /`) or a missing
+/// `L` field means the default level of `0.0`.
+fn parse_gdx_level(line: &str) -> f64 {
+    let (Some(start), Some(end)) = (line.find('/'), line.rfind('/')) else {
+        return 0.0;
+    };
+    if end <= start {
+        return 0.0;
+    }
+    let mut tokens = line[start + 1..end].split_whitespace();
+    while let Some(tok) = tokens.next() {
+        if tok == "L" {
+            return tokens.next().map_or(0.0, |v| v.trim_end_matches(',').parse().unwrap_or(0.0));
+        }
+    }
+    0.0
 }
 
 /// Map GAMS model-status to `SolverStatus`.

--- a/crates/oximo-gurobi/README.md
+++ b/crates/oximo-gurobi/README.md
@@ -62,7 +62,7 @@ m.maximize(dot(&xs, &values));
 
 let result = Gurobi.solve(&m, &GurobiOptions::default())?;
 println!("status = {:?}", result.status);
-println!("obj    = {:?}", result.objective);
+println!("obj    = {:?}", result.objective());
 ```
 
 Run the bundled example:

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -2,9 +2,11 @@ use std::time::Instant;
 
 use grb::expr::LinExpr;
 use grb::prelude::*;
-use oximo_core::{ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, VarId};
-use oximo_expr::{ExprArena, ExprId, LinearTerms, extract_linear};
-use oximo_solver::{SolverError, SolverResult, SolverStatus};
+use oximo_core::{
+    Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable,
+};
+use oximo_expr::{ExprArena, ExprId, extract_linear};
+use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
 use rustc_hash::FxHashMap;
 
 use crate::GurobiOptions;
@@ -40,70 +42,13 @@ pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, Solver
     let env = Env::new("").map_err(|e| SolverError::Backend(format!("Gurobi env: {e}")))?;
     let mut grb_model = grb::Model::with_env("oximo", &env).map_err(map_grb_err)?;
 
-    let mut gurobi_vars = Vec::with_capacity(vars.len());
-    for (i, v) in vars.iter().enumerate() {
-        let vtype = match v.domain {
-            Domain::Real => VarType::Continuous,
-            Domain::Integer => VarType::Integer,
-            Domain::Binary => VarType::Binary,
-            Domain::SemiContinuous { .. } => VarType::SemiCont,
-            Domain::SemiInteger { .. } => VarType::SemiInt,
-        };
-        // `add_var!` expands the f64 bounds with an `as f64` cast.
-        #[allow(clippy::unnecessary_cast)]
-        let gvar = add_var!(grb_model, vtype, bounds: v.lb..v.ub, name: &format!("x{i}"))
-            .map_err(map_grb_err)?;
-        gurobi_vars.push(gvar);
-        if let Some(val) = v.initial {
-            grb_model.set_obj_attr(attr::Start, &gvar, val).map_err(map_grb_err)?;
-        }
-    }
+    let gurobi_vars = add_variables(&mut grb_model, &vars)?;
 
-    let arena_ref: &ExprArena = &arena;
-
-    // Linear fast path per constraint. We fall back to the general lowering only
-    // for those that need it. Keep linear constraints tracked so duals/Pi can
-    // still be reported in the LP/MILP case.
-    let con_lin_terms: Vec<Option<LinearTerms>> =
-        constraints.iter().map(|c| extract_linear(arena_ref, c.lhs)).collect();
-
-    let mut gurobi_constrs: Vec<Option<grb::Constr>> = Vec::with_capacity(constraints.len());
+    // Aux-variable counter shared by the constraint and objective lowering so the
+    // synthetic variable names stay unique across both.
     let mut aux_counter = 0_u32;
-
-    for (c_id, (c, lin)) in constraints.iter().zip(con_lin_terms).enumerate() {
-        if let Some(t) = lin {
-            let adjusted_rhs = c.rhs - t.constant;
-            let mut expr = LinExpr::new();
-            for (v, co) in t.coeffs {
-                expr.add_term(co, gurobi_vars[v.index()]);
-            }
-            let name = format!("c{c_id}");
-            let constr = match c.sense {
-                Sense::Le => {
-                    grb_model.add_constr(&name, c!(expr <= adjusted_rhs)).map_err(map_grb_err)?
-                }
-                Sense::Ge => {
-                    grb_model.add_constr(&name, c!(expr >= adjusted_rhs)).map_err(map_grb_err)?
-                }
-                Sense::Eq => {
-                    grb_model.add_constr(&name, c!(expr == adjusted_rhs)).map_err(map_grb_err)?
-                }
-            };
-            gurobi_constrs.push(Some(constr));
-        } else {
-            add_nonlinear_constraint(
-                &arena,
-                c.lhs,
-                c.sense,
-                c.rhs,
-                c_id,
-                &mut grb_model,
-                &gurobi_vars,
-                &mut aux_counter,
-            )?;
-            gurobi_constrs.push(None);
-        }
-    }
+    let gurobi_constrs =
+        add_constraints(&arena, &constraints, &mut grb_model, &gurobi_vars, &mut aux_counter)?;
 
     let obj_constant = set_objective(
         &arena,
@@ -129,23 +74,98 @@ pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, Solver
     let elapsed = started.elapsed();
 
     let status = map_status(&grb_model)?;
-    let (primal, reduced_costs, dual) =
-        collect_solution(&status, kind, &grb_model, &gurobi_vars, &gurobi_constrs);
-
-    let objective_value = grb_model.get_attr(attr::ObjVal).ok().map(|v| v + obj_constant);
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let iterations = grb_model.get_attr(attr::IterCount).unwrap_or(0.0) as u64;
+    let (solutions, reduced_costs, dual) = collect_solution(
+        &status,
+        kind,
+        &mut grb_model,
+        &gurobi_vars,
+        &gurobi_constrs,
+        obj_constant,
+    );
 
     Ok(SolverResult {
         status,
-        objective: objective_value,
-        primal,
+        solutions,
         dual,
         reduced_costs,
         solve_time: elapsed,
         iterations,
         raw_log: None,
     })
+}
+
+/// Add one Gurobi variable per model variable, in `VarId` order, applying its
+/// domain, bounds, and any warm-start value.
+fn add_variables(
+    grb_model: &mut grb::Model,
+    vars: &[Variable],
+) -> Result<Vec<grb::Var>, SolverError> {
+    let mut gurobi_vars = Vec::with_capacity(vars.len());
+    for (i, v) in vars.iter().enumerate() {
+        let vtype = match v.domain {
+            Domain::Real => VarType::Continuous,
+            Domain::Integer => VarType::Integer,
+            Domain::Binary => VarType::Binary,
+            Domain::SemiContinuous { .. } => VarType::SemiCont,
+            Domain::SemiInteger { .. } => VarType::SemiInt,
+        };
+        // `add_var!` expands the f64 bounds with an `as f64` cast.
+        #[allow(clippy::unnecessary_cast)]
+        let gvar = add_var!(grb_model, vtype, bounds: v.lb..v.ub, name: &format!("x{i}"))
+            .map_err(map_grb_err)?;
+        gurobi_vars.push(gvar);
+        if let Some(val) = v.initial {
+            grb_model.set_obj_attr(attr::Start, &gvar, val).map_err(map_grb_err)?;
+        }
+    }
+    Ok(gurobi_vars)
+}
+
+/// Add every model constraint, returning a per-constraint handle:
+/// `Some` for a linear row (whose dual/`Pi` can be reported later),
+/// `None` for one routed through the nonlinear lowering.
+/// Each constraint takes the linear fast path when its LHS is linear
+/// and falls back to the general lowering otherwise.
+fn add_constraints(
+    arena: &ExprArena,
+    constraints: &[Constraint],
+    grb_model: &mut grb::Model,
+    gurobi_vars: &[grb::Var],
+    aux_counter: &mut u32,
+) -> Result<Vec<Option<grb::Constr>>, SolverError> {
+    let mut gurobi_constrs: Vec<Option<grb::Constr>> = Vec::with_capacity(constraints.len());
+    for (c_id, c) in constraints.iter().enumerate() {
+        if let Some(t) = extract_linear(arena, c.lhs) {
+            let adjusted_rhs = c.rhs - t.constant;
+            let mut expr = LinExpr::new();
+            for (v, co) in t.coeffs {
+                expr.add_term(co, gurobi_vars[v.index()]);
+            }
+            let name = format!("c{c_id}");
+            let constr = match c.sense {
+                Sense::Le => grb_model.add_constr(&name, c!(expr <= adjusted_rhs)),
+                Sense::Ge => grb_model.add_constr(&name, c!(expr >= adjusted_rhs)),
+                Sense::Eq => grb_model.add_constr(&name, c!(expr == adjusted_rhs)),
+            }
+            .map_err(map_grb_err)?;
+            gurobi_constrs.push(Some(constr));
+        } else {
+            add_nonlinear_constraint(
+                arena,
+                c.lhs,
+                c.sense,
+                c.rhs,
+                c_id,
+                grb_model,
+                gurobi_vars,
+                aux_counter,
+            )?;
+            gurobi_constrs.push(None);
+        }
+    }
+    Ok(gurobi_constrs)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -222,44 +242,40 @@ fn set_objective(
     Ok(0.0)
 }
 
+/// Build `(solutions, reduced_costs, dual)` from a solved Gurobi model.
+///
+/// `solutions` holds every point in Gurobi's solution pool, best first (index 0
+/// is the incumbent). The pool is populated automatically during a MIP solve,
+/// set `PoolSearchMode`/`PoolSolutions` (via [`crate::GurobiOptions`]) to force
+/// Gurobi to enumerate alternative optima. Duals and reduced costs apply to
+/// the single LP optimum and are returned only for `LP` models.
 fn collect_solution(
     status: &SolverStatus,
     kind: ModelKind,
-    model: &grb::Model,
+    model: &mut grb::Model,
     vars: &[grb::Var],
     constrs: &[Option<grb::Constr>],
-) -> (FxHashMap<VarId, f64>, FxHashMap<VarId, f64>, FxHashMap<ConstraintId, f64>) {
+    obj_constant: f64,
+) -> (Vec<SolutionPoint>, FxHashMap<VarId, f64>, FxHashMap<ConstraintId, f64>) {
     // `has_solution` only flags Optimal/Feasible, but Gurobi often holds an
-    // incumbent on TimeLimit/IterationLimit/NodeLimit too.
+    // incumbent (SolCount > 0) on TimeLimit/IterationLimit/NodeLimit too.
     let sol_count = model.get_attr(attr::SolCount).unwrap_or(0);
-    if sol_count <= 0 && !status.has_solution() {
-        return (FxHashMap::default(), FxHashMap::default(), FxHashMap::default());
+    let n = if sol_count > 0 { sol_count } else { i32::from(status.has_solution()) };
+    if n == 0 {
+        return (Vec::new(), FxHashMap::default(), FxHashMap::default());
     }
 
-    let primal_vals = model.get_obj_attr_batch(attr::X, vars.iter().copied()).ok();
-    let primal = primal_vals
-        .map(|v| {
-            v.into_iter()
-                .enumerate()
-                .map(|(i, val)| (VarId(u32::try_from(i).unwrap()), val))
-                .collect()
-        })
-        .unwrap_or_default();
+    let solutions = collect_pool(model, vars, obj_constant, n);
 
     // Skip retrieval of duals and reduced costs for any model
     // class where Gurobi will either return zeros or refuse the attribute.
     if !matches!(kind, ModelKind::LP) {
-        return (primal, FxHashMap::default(), FxHashMap::default());
+        return (solutions, FxHashMap::default(), FxHashMap::default());
     }
 
-    let rc_vals = model.get_obj_attr_batch(attr::RC, vars.iter().copied()).ok();
-    let reduced_costs = rc_vals
-        .map(|v| {
-            v.into_iter()
-                .enumerate()
-                .map(|(i, val)| (VarId(u32::try_from(i).unwrap()), val))
-                .collect()
-        })
+    let reduced_costs = model
+        .get_obj_attr_batch(attr::RC, vars.iter().copied())
+        .map(|v| index_map(&v))
         .unwrap_or_default();
 
     let mut dual = FxHashMap::default();
@@ -271,7 +287,46 @@ fn collect_solution(
         }
     }
 
-    (primal, reduced_costs, dual)
+    (solutions, reduced_costs, dual)
+}
+
+/// Collect the `n` pooled primal points, best first.
+fn collect_pool(
+    model: &mut grb::Model,
+    vars: &[grb::Var],
+    obj_constant: f64,
+    n: i32,
+) -> Vec<SolutionPoint> {
+    // Single point (and the only path for LP/continuous models):
+    // read the incumbent directly via `X` / `ObjVal`.
+    if n <= 1 {
+        let primal = model
+            .get_obj_attr_batch(attr::X, vars.iter().copied())
+            .map(|v| index_map(&v))
+            .unwrap_or_default();
+        let objective = model.get_attr(attr::ObjVal).ok().map(|v| v + obj_constant);
+        return vec![SolutionPoint { primal, objective }];
+    }
+
+    // A MIP solution pool. Gurobi sorts it best-first.
+    // `SolutionNumber` selects which one `Xn` / `PoolObjVal` report.
+    let mut out = Vec::with_capacity(usize::try_from(n).unwrap_or(0));
+    for k in 0..n {
+        if model.set_param(grb::param::SolutionNumber, k).is_err() {
+            break;
+        }
+        let Ok(vals) = model.get_obj_attr_batch(attr::Xn, vars.iter().copied()) else {
+            break;
+        };
+        let objective = model.get_attr(attr::PoolObjVal).ok().map(|v| v + obj_constant);
+        out.push(SolutionPoint { primal: index_map(&vals), objective });
+    }
+    out
+}
+
+/// Map a dense per-variable value array (in `VarId` order) to a sparse map.
+fn index_map(vals: &[f64]) -> FxHashMap<VarId, f64> {
+    vals.iter().enumerate().map(|(i, &val)| (VarId(u32::try_from(i).unwrap()), val)).collect()
 }
 
 fn map_status(model: &grb::Model) -> Result<SolverStatus, SolverError> {

--- a/crates/oximo-gurobi/tests/nonlinear.rs
+++ b/crates/oximo-gurobi/tests/nonlinear.rs
@@ -28,7 +28,7 @@ fn qp_min_sum_of_squares() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
-    let obj = r.objective.expect("obj");
+    let obj = r.objective().expect("obj");
     assert!(close(obj, 0.5, 1e-4), "obj = {obj}");
 }
 
@@ -43,7 +43,7 @@ fn nlp_with_sin_objective() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
-    let primal_x = r.primal.get(&VarId(0)).copied().expect("primal");
+    let primal_x = r.value(VarId(0)).expect("primal");
     assert!(close(primal_x, 1.0, 0.1), "x = {primal_x}");
 }
 
@@ -57,9 +57,9 @@ fn nlp_with_abs_objective() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
-    let primal_x = r.primal.get(&VarId(0)).copied().expect("primal");
+    let primal_x = r.value(VarId(0)).expect("primal");
     assert!(close(primal_x, 2.0, 1e-3), "x = {primal_x}");
-    let obj = r.objective.expect("obj");
+    let obj = r.objective().expect("obj");
     assert!(close(obj, 0.0, 1e-3), "obj = {obj}");
 }
 
@@ -75,7 +75,7 @@ fn minlp_binary_with_log() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
-    let obj = r.objective.expect("obj");
+    let obj = r.objective().expect("obj");
     assert!(close(obj, 0.0, 1e-3), "obj = {obj}");
 }
 
@@ -93,7 +93,7 @@ fn div_by_linear_denominator() {
 
     let sol = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&sol);
-    let yv = sol.primal.get(&VarId(1)).copied().expect("primal y");
+    let yv = sol.value(VarId(1)).expect("primal y");
     assert!(close(yv, 3.0, 1e-4), "y = {yv}");
 }
 
@@ -110,7 +110,7 @@ fn div_by_negative_denominator() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
-    let dv = r.primal.get(&VarId(1)).copied().expect("primal d");
+    let dv = r.value(VarId(1)).expect("primal d");
     assert!(close(dv, -4.0, 1e-4), "d = {dv}");
 }
 
@@ -125,7 +125,7 @@ fn div_constant_numerator() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
-    let dv = r.primal.get(&VarId(0)).copied().expect("primal d");
+    let dv = r.value(VarId(0)).expect("primal d");
     assert!(close(dv, 3.0, 1e-4), "d = {dv}");
 }
 
@@ -142,7 +142,7 @@ fn div_by_quadratic_denominator() {
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
-    let yv = r.primal.get(&VarId(1)).copied().expect("primal y");
+    let yv = r.value(VarId(1)).expect("primal y");
     assert!(close(yv, 2.0, 1e-3), "y = {yv}");
 }
 

--- a/crates/oximo-highs/README.md
+++ b/crates/oximo-highs/README.md
@@ -38,7 +38,7 @@ m.maximize(3.0 * x + 4.0 * y);
 
 let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
 assert_eq!(result.status, SolverStatus::Optimal);
-println!("obj = {}", result.objective.unwrap()); // 34.0
+println!("obj = {}", result.objective().unwrap()); // 34.0
 println!("x   = {}", result.value_of(x).unwrap()); // 6.0
 println!("y   = {}", result.value_of(y).unwrap()); // 4.0
 ```

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -5,7 +5,7 @@ use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, Sense, VarId};
 use oximo_expr::{
     ExprArena, ExprId, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,
 };
-use oximo_solver::{SolverError, SolverResult, SolverStatus};
+use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
 use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
@@ -135,10 +135,14 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
     let objective_value =
         if status.has_solution() { Some(solved.objective_value() + obj_constant) } else { None };
 
+    let solutions = if status.has_solution() {
+        vec![SolutionPoint { primal, objective: objective_value }]
+    } else {
+        Vec::new()
+    };
     Ok(SolverResult {
         status,
-        objective: objective_value,
-        primal,
+        solutions,
         dual,
         reduced_costs,
         solve_time: elapsed,
@@ -289,7 +293,7 @@ mod tests {
         assert_eq!(res.status, SolverStatus::Optimal);
         assert!((res.value_of(x).unwrap() - 0.5).abs() < 1e-6);
         assert!((res.value_of(y).unwrap() - 0.5).abs() < 1e-6);
-        assert!((res.objective.unwrap() - 0.5).abs() < 1e-6);
+        assert!((res.objective().unwrap() - 0.5).abs() < 1e-6);
     }
 
     #[test]
@@ -306,7 +310,7 @@ mod tests {
         assert_eq!(res.status, SolverStatus::Optimal);
         assert!((res.value_of(x0).unwrap() - 0.25).abs() < 1e-6);
         assert!((res.value_of(x1).unwrap() - 0.75).abs() < 1e-6);
-        assert!((res.objective.unwrap() - 1.875).abs() < 1e-6);
+        assert!((res.objective().unwrap() - 1.875).abs() < 1e-6);
     }
 
     #[test]
@@ -320,7 +324,7 @@ mod tests {
         let res = solve(&m, &HighsOptions::default()).unwrap();
         assert_eq!(res.status, SolverStatus::Optimal);
         assert!((res.value_of(x).unwrap() - 1.0).abs() < 1e-6);
-        assert!(res.objective.unwrap().abs() < 1e-6);
+        assert!(res.objective().unwrap().abs() < 1e-6);
     }
 
     #[test]

--- a/crates/oximo-solver/src/lib.rs
+++ b/crates/oximo-solver/src/lib.rs
@@ -7,6 +7,6 @@ pub mod solver;
 pub mod status;
 
 pub use options::{HasUniversal, UniversalOptions, UniversalOptionsExt};
-pub use result::SolverResult;
+pub use result::{SolutionPoint, SolverResult};
 pub use solver::Solver;
 pub use status::{SolverError, SolverStatus};

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -7,7 +7,7 @@ use crate::status::SolverStatus;
 
 /// A single primal point returned by a solver.
 ///
-/// Most solves yield one point, but a global solver asked to enumerate a
+/// Most solves yield one point, but a global solver asked to enumerate solutions
 /// may returns several. In a [`SolverResult`] the points live in [`SolverResult::solutions`].
 /// Index `0` is always the best/incumbent.
 #[derive(Clone, Debug, Default)]

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -5,36 +5,18 @@ use rustc_hash::FxHashMap;
 
 use crate::status::SolverStatus;
 
-/// A solver's final result on a model. `primal` and `dual` are sparse maps so a
-/// solver that does not return duals (e.g. MILP) can simply leave them empty.
-#[derive(Clone, Debug)]
-pub struct SolverResult {
-    pub status: SolverStatus,
-    pub objective: Option<f64>,
+/// A single primal point returned by a solver.
+///
+/// Most solves yield one point, but a global solver asked to enumerate a
+/// may returns several. In a [`SolverResult`] the points live in [`SolverResult::solutions`].
+/// Index `0` is always the best/incumbent.
+#[derive(Clone, Debug, Default)]
+pub struct SolutionPoint {
     pub primal: FxHashMap<VarId, f64>,
-    pub dual: FxHashMap<ConstraintId, f64>,
-    pub reduced_costs: FxHashMap<VarId, f64>,
-    pub solve_time: Duration,
-    pub iterations: u64,
-    pub raw_log: Option<String>,
+    pub objective: Option<f64>,
 }
 
-impl Default for SolverResult {
-    fn default() -> Self {
-        Self {
-            status: SolverStatus::NotSolved,
-            objective: None,
-            primal: FxHashMap::default(),
-            dual: FxHashMap::default(),
-            reduced_costs: FxHashMap::default(),
-            solve_time: Duration::ZERO,
-            iterations: 0,
-            raw_log: None,
-        }
-    }
-}
-
-impl SolverResult {
+impl SolutionPoint {
     /// Look up a primal value by `VarId`.
     pub fn value(&self, id: VarId) -> Option<f64> {
         self.primal.get(&id).copied()
@@ -52,10 +34,6 @@ impl SolverResult {
         }
     }
 
-    pub fn dual_of(&self, c: ConstraintId) -> Option<f64> {
-        self.dual.get(&c).copied()
-    }
-
     /// Look up the primal value for a specific index of an [`IndexedVar`].
     ///
     /// Returns `None` if `key` is not in the variable's set or the solver did
@@ -67,12 +45,137 @@ impl SolverResult {
     /// Iterate over primal values for all entries of an [`IndexedVar`].
     ///
     /// Yields `(&IndexKey, f64)` for every index whose primal value is present
-    /// in the solution. To keep only nonzero values (common for sparse
-    /// solutions) chain `.filter(|(_, v)| *v != 0.0)`.
+    /// in the solution.
     pub fn values_of<'iv, 'a>(
         &'iv self,
         var: &'iv IndexedVar<'a>,
     ) -> impl Iterator<Item = (&'iv IndexKey, f64)> + 'iv {
         var.iter().filter_map(|(k, e)| self.value_of(*e).map(|v| (k, v)))
+    }
+}
+
+/// A solver's final result on a model.
+///
+/// Primal points are held in `solutions` (index `0` is the best/incumbent,
+/// empty when no solution was found). `dual` and `reduced_costs` apply to the
+/// best continuous point and are sparse maps, so a solver that does not return
+/// duals (e.g. MILP) can simply leave them empty.
+#[derive(Clone, Debug)]
+pub struct SolverResult {
+    pub status: SolverStatus,
+    pub solutions: Vec<SolutionPoint>,
+    pub dual: FxHashMap<ConstraintId, f64>,
+    pub reduced_costs: FxHashMap<VarId, f64>,
+    pub solve_time: Duration,
+    pub iterations: u64,
+    pub raw_log: Option<String>,
+}
+
+impl Default for SolverResult {
+    fn default() -> Self {
+        Self {
+            status: SolverStatus::NotSolved,
+            solutions: Vec::new(),
+            dual: FxHashMap::default(),
+            reduced_costs: FxHashMap::default(),
+            solve_time: Duration::ZERO,
+            iterations: 0,
+            raw_log: None,
+        }
+    }
+}
+
+impl SolverResult {
+    /// The number of primal points the solver returned (`0` when infeasible or
+    /// unsolved).
+    pub fn result_count(&self) -> usize {
+        self.solutions.len()
+    }
+
+    /// The `i`-th primal point, where index `0` is the best/incumbent.
+    pub fn solution(&self, i: usize) -> Option<&SolutionPoint> {
+        self.solutions.get(i)
+    }
+
+    /// The best primal point, or `None` when no solution was found.
+    pub fn best(&self) -> Option<&SolutionPoint> {
+        self.solutions.first()
+    }
+
+    /// The objective value of the best solution, or `None` when none was found.
+    pub fn objective(&self) -> Option<f64> {
+        self.solutions.first().and_then(|s| s.objective)
+    }
+
+    /// The best solution's primal map, or `None` when no solution was found.
+    pub fn primal(&self) -> Option<&FxHashMap<VarId, f64>> {
+        self.solutions.first().map(|s| &s.primal)
+    }
+
+    /// Look up a primal value by `VarId` in the best solution.
+    pub fn value(&self, id: VarId) -> Option<f64> {
+        self.solutions.first().and_then(|s| s.value(id))
+    }
+
+    /// Look up the best solution's primal value for an `Expr` that points at a
+    /// `Var` node. Returns `None` for any expression that is not a single
+    /// variable.
+    pub fn value_of(&self, expr: Expr<'_>) -> Option<f64> {
+        self.solutions.first().and_then(|s| s.value_of(expr))
+    }
+
+    pub fn dual_of(&self, c: ConstraintId) -> Option<f64> {
+        self.dual.get(&c).copied()
+    }
+
+    /// Look up the best solution's primal value for a specific index of an
+    /// [`IndexedVar`].
+    pub fn value_of_idx<K: Into<IndexKey>>(&self, var: &IndexedVar<'_>, key: K) -> Option<f64> {
+        var.get(key).and_then(|e| self.value_of(e))
+    }
+
+    /// Iterate over the best solution's primal values for all entries of an
+    /// [`IndexedVar`]. Yields nothing when no solution was found.
+    pub fn values_of<'iv, 'a>(
+        &'iv self,
+        var: &'iv IndexedVar<'a>,
+    ) -> impl Iterator<Item = (&'iv IndexKey, f64)> + 'iv {
+        var.iter().filter_map(|(k, e)| self.value_of(*e).map(|v| (k, v)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_result_has_no_solution() {
+        let r = SolverResult::default();
+        assert_eq!(r.result_count(), 0);
+        assert!(r.best().is_none());
+        assert!(r.objective().is_none());
+        assert!(r.primal().is_none());
+        assert!(r.value(VarId(0)).is_none());
+        assert!(r.solution(0).is_none());
+    }
+
+    #[test]
+    fn best_is_solution_zero() {
+        let mut p0 = FxHashMap::default();
+        p0.insert(VarId(0), 1.5);
+        let mut p1 = FxHashMap::default();
+        p1.insert(VarId(0), 2.5);
+        let r = SolverResult {
+            status: SolverStatus::Optimal,
+            solutions: vec![
+                SolutionPoint { primal: p0, objective: Some(10.0) },
+                SolutionPoint { primal: p1, objective: Some(9.0) },
+            ],
+            ..Default::default()
+        };
+        assert_eq!(r.result_count(), 2);
+        assert_eq!(r.objective(), Some(10.0));
+        assert_eq!(r.value(VarId(0)), Some(1.5));
+        assert_eq!(r.solution(1).unwrap().value(VarId(0)), Some(2.5));
     }
 }

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -30,7 +30,7 @@ m.constraint("c3", x.le(y + 2.0));
 m.maximize(3.0 * x + 4.0 * y);
 
 let result = Highs.solve(&m, &HighsOptions::default())?;
-println!("obj = {:?}", result.objective);   // 34.0
+println!("obj = {:?}", result.objective());   // 34.0
 println!("x   = {:?}", result.value_of(x)); // 6.0
 println!("y   = {:?}", result.value_of(y)); // 4.0
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -249,9 +249,9 @@ let result = Baron::new().solve(&m, &BaronOptions::default())?;
 let result = Highs.solve(&m, &HighsOptions::default())?;
 
 match result.status {
-    SolverStatus::Optimal => println!("optimal: {}", result.objective.unwrap()),
+    SolverStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
     SolverStatus::Infeasible => println!("infeasible"),
-    SolverStatus::TimeLimit => println!("time limit, best = {:?}", result.objective),
+    SolverStatus::TimeLimit => println!("time limit, best = {:?}", result.objective()),
     _ => {}
 }
 

--- a/crates/oximo/examples/baron_robot.rs
+++ b/crates/oximo/examples/baron_robot.rs
@@ -25,11 +25,6 @@
 //! Run (requires a licensed BARON on PATH):
 //!   cargo run -p oximo --example baron_robot --features baron
 
-// TODO: BARON enumerates the distinct solutions (visible in the verbose log),
-// but oximo's `SolverResult` carries a single primal point, so this example reports
-// the best solution BARON returns. We need to modify the SolverResult/oximo-solver
-// to carry multiple primal points if we want to report all 14 solutions.
-
 #![allow(clippy::unreadable_literal)]
 
 #[cfg(feature = "baron")]
@@ -77,7 +72,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = Baron::new().solve(&m, &opts)?;
 
     println!("status = {:?}", result.status);
-    for (name, x) in [
+    println!("solutions found = {}", result.result_count());
+
+    // BARON enumerates the distinct solutions of this feasibility system,
+    // each is a separate point in `result.solutions`.
+    let vars = [
         ("x1", x1),
         ("x2", x2),
         ("x3", x3),
@@ -86,8 +85,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ("x6", x6),
         ("x7", x7),
         ("x8", x8),
-    ] {
-        println!("  {name} = {:?}", result.value_of(x));
+    ];
+    for i in 0..result.result_count() {
+        let sol = result.solution(i).expect("index < result_count");
+        println!("solution {}:", i + 1);
+        for (name, x) in vars {
+            println!("  {name} = {:?}", sol.value_of(x));
+        }
     }
     Ok(())
 }

--- a/crates/oximo/examples/lot_sizing.rs
+++ b/crates/oximo/examples/lot_sizing.rs
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\nLot-Sizing Result");
     println!("Status    : {:?}", result.status);
-    if let Some(obj) = result.objective {
+    if let Some(obj) = result.objective() {
         println!("Total cost: {obj:.2}");
     }
 

--- a/crates/oximo/examples/parametric_pricing.rs
+++ b/crates/oximo/examples/parametric_pricing.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let x1v = result.value_of(x1).unwrap_or(0.0);
         let x2v = result.value_of(x2).unwrap_or(0.0);
-        let profit = result.objective.unwrap_or(0.0);
+        let profit = result.objective().unwrap_or(0.0);
         println!(" {price:>4.1} | {x1v:>8.2} | {x2v:>8.2} | {profit:>7.2}");
     }
 

--- a/crates/oximo/examples/process_selection.rs
+++ b/crates/oximo/examples/process_selection.rs
@@ -67,7 +67,7 @@ mod model {
 
         let result = solver.solve(&m, opts)?;
 
-        if let Some(obj) = result.objective {
+        if let Some(obj) = result.objective() {
             println!("--- {label} ---");
             println!("status = {:?}", result.status);
             println!("profit = {obj:.4} M$/yr");

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -129,7 +129,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = Highs.solve(&m, &HighsOptions::default().verbose(true))?;
 
     println!("Status : {:?}", result.status);
-    if let Some(obj) = result.objective {
+    if let Some(obj) = result.objective() {
         println!(
             "Acetone (y06, ch3coch3): {}",
             if (obj - 1.0).abs() < 1e-6 { "Synthesizable" } else { "Not synthesizable" }

--- a/crates/oximo/examples/transport.rs
+++ b/crates/oximo/examples/transport.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = solver.solve(&m, &HighsOptions::default().verbose(true))?;
 
     println!("status    = {:?}", result.status);
-    println!("objective = {:?}", result.objective);
+    println!("objective = {:?}", result.objective());
     println!("x = {:?}", result.value_of(x));
     println!("y = {:?}", result.value_of(y));
     Ok(())

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -36,8 +36,8 @@ pub mod prelude {
     //! Glob-import target. Brings the modeling and solver surface into scope.
     pub use oximo_core::prelude::*;
     pub use oximo_solver::{
-        HasUniversal, Solver, SolverError, SolverResult, SolverStatus, UniversalOptions,
-        UniversalOptionsExt,
+        HasUniversal, SolutionPoint, Solver, SolverError, SolverResult, SolverStatus,
+        UniversalOptions, UniversalOptionsExt,
     };
 
     #[cfg(feature = "highs")]

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -98,7 +98,7 @@ fn knapsack_milp() {
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 47.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 47.0).abs() < 1e-6);
 }
 
 #[test]

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -19,6 +19,24 @@ fn lp_canonical() {
 }
 
 #[test]
+fn highs_multi_optima_returns_single_best() {
+    // A MILP with several optimal solutions.
+    // HiGHS has no solution pool, so the multi-solution API surfaces exactly one optimum.
+    let m = Model::new("multi");
+    let items = Set::range(0..4usize);
+    let x = m.indexed_var("x", &items).binary().build();
+    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
+    m.maximize(sum_over(&items, |i: usize| x[i]));
+
+    let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.result_count(), 1);
+    assert!((r.objective().unwrap() - 2.0).abs() < 1e-6);
+    let chosen: f64 = (0..4).filter_map(|i| r.value_of_idx(&x, i)).sum();
+    assert!((chosen - 2.0).abs() < 1e-6, "best is not an optimum: sum={chosen}");
+}
+
+#[test]
 fn param_coefficient_lp_rebinds_without_rebuild() {
     let m = Model::new("param_lp");
     let price = m.param("price", 3.0);

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -13,7 +13,7 @@ fn lp_canonical() {
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
 }
@@ -28,11 +28,11 @@ fn param_coefficient_lp_rebinds_without_rebuild() {
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(r.status, SolverStatus::Optimal);
-    assert!((r.objective.unwrap() - 30.0).abs() < 1e-6);
+    assert!((r.objective().unwrap() - 30.0).abs() < 1e-6);
 
     m.set_param(price, 5.0);
     let r2 = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert!((r2.objective.unwrap() - 50.0).abs() < 1e-6);
+    assert!((r2.objective().unwrap() - 50.0).abs() < 1e-6);
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn lp_initial_values_do_not_affect_optimum() {
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
 }
@@ -135,7 +135,7 @@ fn milp_warm_start_finds_optimum() {
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 47.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 47.0).abs() < 1e-6);
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn presolve_off_gives_correct_result() {
     m.maximize(3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().presolve(HighsPresolve::Off)).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
 }
@@ -175,7 +175,7 @@ fn ipm_method_gives_correct_result() {
     m.maximize(3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().method(HighsMethod::Ipm)).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
 }
@@ -191,7 +191,7 @@ fn threads_one_gives_correct_result() {
     m.maximize(3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().threads(1)).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
 }
@@ -212,7 +212,7 @@ fn mip_gap_accepted_and_solves() {
         "unexpected status: {:?}",
         result.status
     );
-    assert!(result.objective.unwrap() > 0.0);
+    assert!(result.objective().unwrap() > 0.0);
 }
 
 #[test]

--- a/crates/oximo/tests/solve_baron.rs
+++ b/crates/oximo/tests/solve_baron.rs
@@ -1,0 +1,38 @@
+//! Integration test for the BARON backend's multi-solution support.
+//!
+//! Shells out to a BARON installation, so compiled and run only with
+//! `--features baron`:
+//! ```
+//! cargo test -p oximo --features baron --test solve_baron
+//! ```
+
+#![cfg(feature = "baron")]
+
+use std::time::Duration;
+
+use oximo::BaronOptions;
+use oximo::prelude::*;
+use oximo::solvers::Baron;
+
+#[test]
+fn baron_enumerates_multiple_solutions() {
+    // A MILP with many feasible solutions. With `NumSol > 1`
+    // BARON enumerates distinct solutions, which the backend parses into the
+    // result's solution pool (best first).
+    let m = Model::new("multi");
+    let items = Set::range(0..4usize);
+    let x = m.indexed_var("x", &items).binary().build();
+    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
+    m.maximize(sum_over(&items, |i: usize| x[i]));
+
+    let opts = BaronOptions::default().num_sol(10).time_limit(Duration::from_secs(60));
+    let r = Baron::new().solve(&m, &opts).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert!(r.result_count() > 1, "expected multiple solutions, got {}", r.result_count());
+
+    assert!((r.objective().unwrap() - 2.0).abs() < 1e-4, "best obj={:?}", r.objective());
+    for s in &r.solutions {
+        let chosen: f64 = (0..4).filter_map(|i| s.value_of_idx(&x, i)).sum();
+        assert!(chosen <= 2.0 + 1e-4, "infeasible point: sum={chosen}");
+    }
+}

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -164,8 +164,8 @@ fn gams_multi_optima_returns_single_best() {
 #[test]
 fn gams_reads_cplex_solution_pool() {
     // Same multi-optima MILP. When the user enables CPLEX's `solnpool`, the
-    // sub-solver writes a pool of GDX files into the run directory. 
-    // The GAMS backend reads them back and surfaces every point, best first. 
+    // sub-solver writes a pool of GDX files into the run directory.
+    // The GAMS backend reads them back and surfaces every point, best first.
     // Requires a GAMS install with a licensed CPLEX.
     let m = Model::new("multi");
     let items = Set::range(0..4usize);
@@ -174,7 +174,11 @@ fn gams_reads_cplex_solution_pool() {
     m.maximize(sum_over(&items, |i: usize| x[i]));
 
     let cfg = GamsSolverConfig::Cplex(GamsCplexOptions {
-        raw: vec!["solnpool oximo_pool.gdx".into(), "solnpoolpop 2".into(), "populatelim 20".into()],
+        raw: vec![
+            "solnpool oximo_pool.gdx".into(),
+            "solnpoolpop 2".into(),
+            "populatelim 20".into(),
+        ],
         ..Default::default()
     });
     let opts = GamsOptions::default().solver(cfg).time_limit(Duration::from_secs(60));

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -31,7 +31,7 @@ fn gams_lp_canonical() {
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective());
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-4);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-4);
 }
@@ -48,7 +48,7 @@ fn gams_lp_duals_and_reduced_costs() {
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 5.0).abs() < 1e-6);
+    assert!((result.objective().unwrap() - 5.0).abs() < 1e-6);
 
     let d = result.dual_of(c).expect("dual missing for cap constraint");
     assert!((d.abs() - 1.0).abs() < 1e-6, "dual={d}");
@@ -86,7 +86,7 @@ fn gams_knapsack_milp() {
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 47.0).abs() < 1e-4, "obj={:?}", result.objective);
+    assert!((result.objective().unwrap() - 47.0).abs() < 1e-4, "obj={:?}", result.objective());
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn gams_mip_gap_option() {
         "unexpected status: {:?}",
         result.status
     );
-    assert!(result.objective.unwrap() > 0.0);
+    assert!(result.objective().unwrap() > 0.0);
 }
 
 /// Exercises the typed-options path: a `highs.opt` file is written with
@@ -139,5 +139,5 @@ fn gams_highs_opt_file_simplex() {
     }));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
-    assert!((result.objective.unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective);
+    assert!((result.objective().unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective());
 }

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use oximo::gams::{GamsHighsOptions, GamsHighsSolver, GamsSolverConfig};
+use oximo::gams::{GamsCplexOptions, GamsHighsOptions, GamsHighsSolver, GamsSolverConfig};
 use oximo::prelude::*;
 use oximo::solvers::Gams;
 
@@ -140,4 +140,55 @@ fn gams_highs_opt_file_simplex() {
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective());
+}
+
+#[test]
+fn gams_multi_optima_returns_single_best() {
+    // A MILP with several optimal solutions. Without a sub-solver pool option the
+    // GAMS bridge returns one optimum: exactly one valid point.
+    let m = Model::new("multi");
+    let items = Set::range(0..4usize);
+    let x = m.indexed_var("x", &items).binary().build();
+    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
+    m.maximize(sum_over(&items, |i: usize| x[i]));
+
+    let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
+    let r = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.result_count(), 1);
+    assert!((r.objective().unwrap() - 2.0).abs() < 1e-4);
+    let chosen: f64 = (0..4).filter_map(|i| r.value_of_idx(&x, i)).sum();
+    assert!((chosen - 2.0).abs() < 1e-4, "best is not an optimum: sum={chosen}");
+}
+
+#[test]
+fn gams_reads_cplex_solution_pool() {
+    // Same multi-optima MILP. When the user enables CPLEX's `solnpool`, the
+    // sub-solver writes a pool of GDX files into the run directory. 
+    // The GAMS backend reads them back and surfaces every point, best first. 
+    // Requires a GAMS install with a licensed CPLEX.
+    let m = Model::new("multi");
+    let items = Set::range(0..4usize);
+    let x = m.indexed_var("x", &items).binary().build();
+    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
+    m.maximize(sum_over(&items, |i: usize| x[i]));
+
+    let cfg = GamsSolverConfig::Cplex(GamsCplexOptions {
+        raw: vec!["solnpool oximo_pool.gdx".into(), "solnpoolpop 2".into(), "populatelim 20".into()],
+        ..Default::default()
+    });
+    let opts = GamsOptions::default().solver(cfg).time_limit(Duration::from_secs(60));
+    let r = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert!(r.result_count() > 1, "expected a solution pool, got {}", r.result_count());
+
+    assert!((r.objective().unwrap() - 2.0).abs() < 1e-4);
+    let mut prev = f64::INFINITY;
+    for s in &r.solutions {
+        let chosen: f64 = (0..4).filter_map(|i| s.value_of_idx(&x, i)).sum();
+        assert!(chosen <= 2.0 + 1e-6, "infeasible pool point: sum={chosen}");
+        let obj = s.objective.expect("pool point has an objective");
+        assert!(obj <= prev + 1e-9, "pool not ordered best-first");
+        prev = obj;
+    }
 }

--- a/crates/oximo/tests/solve_gurobi.rs
+++ b/crates/oximo/tests/solve_gurobi.rs
@@ -1,0 +1,37 @@
+//! Integration test for the Gurobi backend's multi-solution support.
+//!
+//! Links against a licensed Gurobi installation, so compiled and run only with
+//! `--features gurobi`.
+
+#![cfg(feature = "gurobi")]
+
+use oximo::GurobiOptions;
+use oximo::prelude::*;
+use oximo::solvers::Gurobi;
+
+#[test]
+fn gurobi_multi_optima_returns_pool() {
+    // A MILP with many feasible/optimal assignments (pick any 2 of 4). Gurobi's
+    // solution pool is requested with PoolSearchMode = 2 (find the n best) and
+    // surfaced through the multi-solution API, best first.
+    let m = Model::new("multi");
+    let items = Set::range(0..4usize);
+    let x = m.indexed_var("x", &items).binary().build();
+    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
+    m.maximize(sum_over(&items, |i: usize| x[i]));
+
+    let opts = GurobiOptions::default().pool_search_mode(2).pool_solutions(10);
+    let r = Gurobi.solve(&m, &opts).unwrap();
+    assert_eq!(r.status, SolverStatus::Optimal);
+    assert!(r.result_count() > 1, "expected a solution pool, got {}", r.result_count());
+
+    assert!((r.objective().unwrap() - 2.0).abs() < 1e-6);
+    let mut prev = f64::INFINITY;
+    for s in &r.solutions {
+        let chosen: f64 = (0..4).filter_map(|i| s.value_of_idx(&x, i)).sum();
+        assert!(chosen <= 2.0 + 1e-6, "infeasible pool point: sum={chosen}");
+        let obj = s.objective.expect("pool point has an objective");
+        assert!(obj <= prev + 1e-9, "pool not ordered best-first");
+        prev = obj;
+    }
+}


### PR DESCRIPTION
## Description

This PR adds functionality that lets the solver return multiple solutions.
`SolverResult` now implements `pub solutions: Vec<SolutionPoint>`, where `SolutionPoint` is a new Struct in oximo-solver.
I've also modified oximo-baron, oximo-gurobi, and oximo-gams to return multiple solutions when available.

For oximo-gams, I am considering creating a scraper that scrapes all options from all solvers, similar to what the grb crate does for Gurobi's docs (See https://github.com/ykrist/rust-grb/blob/master/build/scrape-docs.py). For now, I added a raw key that lets users pass whatever parameter is needed.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)