### PR TITLE
Add model report feature

### DIFF
--- a/crates/oximo-baron/src/lib.rs
+++ b/crates/oximo-baron/src/lib.rs
@@ -38,11 +38,15 @@ impl Baron {
     }
 }
 
+/// Display name for this backend; the single source for both [`Solver::name`]
+/// and the `solver_name` stamped on every [`SolverResult`].
+pub(crate) const NAME: &str = "BARON";
+
 impl Solver for Baron {
     type Options = BaronOptions;
 
     fn name(&self) -> &str {
-        "baron"
+        NAME
     }
 
     fn supports(&self, kind: ModelKind) -> bool {

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -565,6 +565,7 @@ fn parse_solution(
         solve_time: elapsed,
         iterations,
         raw_log,
+        solver_name: Some(crate::NAME.into()),
     }
 }
 

--- a/crates/oximo-gams/src/lib.rs
+++ b/crates/oximo-gams/src/lib.rs
@@ -42,11 +42,15 @@ impl Gams {
     }
 }
 
+/// Display name for this backend; the single source for both [`Solver::name`]
+/// and the `solver_name` stamped on every [`SolverResult`].
+pub(crate) const NAME: &str = "GAMS";
+
 impl Solver for Gams {
     type Options = GamsOptions;
 
     fn name(&self) -> &str {
-        "gams"
+        NAME
     }
 
     fn supports(&self, kind: ModelKind) -> bool {

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -162,7 +162,7 @@ pub fn solve(
     // Check the solution file before the exit code: GAMS may return a
     // non-zero exit on infeasible/unbounded models while still writing a
     // valid modelstat to the PUT file.
-    let result = if sol_path.exists() {
+    let mut result = if sol_path.exists() {
         let content = fs::read_to_string(&sol_path)
             .map_err(|e| SolverError::Backend(format!("cannot read solution file: {e}")))?;
         let mut result = parseoximo_solution(&content, elapsed, raw_log);
@@ -191,7 +191,18 @@ pub fn solve(
     };
 
     let _ = fs::remove_dir_all(&tmp_dir);
+    result.solver_name = Some(gams_solver_label(opts));
     Ok(result)
+}
+
+/// Backend label for the result: `GAMS/<sub-solver>` when a sub-solver is
+/// configured, otherwise just `GAMS`. When none is set, GAMS selects its own
+/// default solver for the model type, whose name we do not resolve here.
+fn gams_solver_label(opts: &GamsOptions) -> Cow<'static, str> {
+    match &opts.solver {
+        Some(cfg) => Cow::Owned(format!("{}/{}", crate::NAME, cfg.gams_name())),
+        None => Cow::Borrowed(crate::NAME),
+    }
 }
 
 /// Extract the compilation-error section from a GAMS `.lst` listing.
@@ -303,6 +314,7 @@ fn parseoximo_solution(
         solve_time: elapsed,
         iterations,
         raw_log,
+        solver_name: Some(crate::NAME.into()),
     }
 }
 
@@ -878,6 +890,16 @@ mod tests {
         let r = parseoximo_solution(content, std::time::Duration::ZERO, None);
         assert_eq!(r.status, SolverStatus::Optimal);
         assert_eq!(r.iterations, 42);
+    }
+
+    #[test]
+    fn solver_label_names_subsolver() {
+        use crate::solver_options::{GamsCplexOptions, GamsSolverConfig};
+        let opts =
+            GamsOptions::default().solver(GamsSolverConfig::Cplex(GamsCplexOptions::default()));
+        assert_eq!(gams_solver_label(&opts).as_ref(), "GAMS/CPLEX");
+        // No sub-solver configured: GAMS picks its own default, so just "GAMS".
+        assert_eq!(gams_solver_label(&GamsOptions::default()).as_ref(), "GAMS");
     }
 
     #[test]

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Write as FmtWrite;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;

--- a/crates/oximo-gurobi/src/lib.rs
+++ b/crates/oximo-gurobi/src/lib.rs
@@ -14,11 +14,15 @@ use oximo_solver::{Solver, SolverError, SolverResult};
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Gurobi;
 
+/// Display name for this backend; the single source for both [`Solver::name`]
+/// and the `solver_name` stamped on every [`SolverResult`].
+pub(crate) const NAME: &str = "Gurobi";
+
 impl Solver for Gurobi {
     type Options = GurobiOptions;
 
     fn name(&self) -> &str {
-        "gurobi"
+        NAME
     }
 
     fn supports(&self, kind: ModelKind) -> bool {

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -93,6 +93,7 @@ pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, Solver
         solve_time: elapsed,
         iterations,
         raw_log: None,
+        solver_name: Some(crate::NAME.into()),
     })
 }
 

--- a/crates/oximo-highs/src/lib.rs
+++ b/crates/oximo-highs/src/lib.rs
@@ -17,11 +17,15 @@ use oximo_solver::{Solver, SolverError, SolverResult};
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Highs;
 
+/// Display name for this backend; the single source for both [`Solver::name`]
+/// and the `solver_name` stamped on every [`SolverResult`].
+pub(crate) const NAME: &str = "HiGHS";
+
 impl Solver for Highs {
     type Options = HighsOptions;
 
     fn name(&self) -> &str {
-        "highs"
+        NAME
     }
 
     fn supports(&self, kind: ModelKind) -> bool {

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -148,6 +148,7 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
         solve_time: elapsed,
         iterations: 0,
         raw_log: None,
+        solver_name: Some(crate::NAME.into()),
     })
 }
 

--- a/crates/oximo-solver/src/lib.rs
+++ b/crates/oximo-solver/src/lib.rs
@@ -7,6 +7,6 @@ pub mod solver;
 pub mod status;
 
 pub use options::{HasUniversal, UniversalOptions, UniversalOptionsExt};
-pub use result::{SolutionPoint, SolverResult};
+pub use result::{ModelReport, SolutionPoint, SolverResult};
 pub use solver::Solver;
 pub use status::{SolverError, SolverStatus};

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
 use std::time::Duration;
 
-use oximo_core::{ConstraintId, Expr, ExprNode, IndexKey, IndexedVar, VarId};
+use oximo_core::{
+    ConstraintId, Expr, ExprNode, IndexKey, IndexedVar, Model, ObjectiveSense, VarId,
+};
 use rustc_hash::FxHashMap;
 
 use crate::status::SolverStatus;
@@ -69,6 +72,7 @@ pub struct SolverResult {
     pub solve_time: Duration,
     pub iterations: u64,
     pub raw_log: Option<String>,
+    pub solver_name: Option<Cow<'static, str>>,
 }
 
 impl Default for SolverResult {
@@ -81,6 +85,7 @@ impl Default for SolverResult {
             solve_time: Duration::ZERO,
             iterations: 0,
             raw_log: None,
+            solver_name: None,
         }
     }
 }
@@ -142,6 +147,93 @@ impl SolverResult {
     ) -> impl Iterator<Item = (&'iv IndexKey, f64)> + 'iv {
         var.iter().filter_map(|(k, e)| self.value_of(*e).map(|v| (k, v)))
     }
+
+    /// A human-readable, model-aware summary of this result.
+    ///
+    /// It lists the solver, model kind and sense, status,
+    /// objective and work counters, then every variable's value
+    /// (with its reduced cost when the solver returned duals) and every
+    /// constraint's dual.
+    pub fn report<'a>(&'a self, model: &'a Model) -> ModelReport<'a> {
+        ModelReport { result: self, model }
+    }
+}
+
+/// A printable, model-aware summary of a [`SolverResult`]. Created by
+/// [`SolverResult::report`].
+#[derive(Debug)]
+pub struct ModelReport<'a> {
+    result: &'a SolverResult,
+    model: &'a Model,
+}
+
+/// Format a value with up to six decimals, trimming trailing zeros so whole
+/// numbers render as `5` rather than `5.000000`.
+fn num(x: f64) -> String {
+    let s = format!("{x:.6}");
+    let trimmed = s.trim_end_matches('0').trim_end_matches('.');
+    if trimmed.is_empty() || trimmed == "-0" { "0".to_owned() } else { trimmed.to_owned() }
+}
+
+impl std::fmt::Display for ModelReport<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let r = self.result;
+        let m = self.model;
+
+        let sense = {
+            let obj = m.objective();
+            match obj.as_ref().map(|o| o.sense) {
+                Some(ObjectiveSense::Minimize) => "minimize",
+                Some(ObjectiveSense::Maximize) => "maximize",
+                None => "no objective",
+            }
+        };
+
+        writeln!(f, "solution summary")?;
+        writeln!(f, "  solver     : {}", r.solver_name.as_deref().unwrap_or("(unknown)"))?;
+        writeln!(f, "  model      : {}  ({:?}, {sense})", m.name, m.kind())?;
+        writeln!(f, "  status     : {:?}", r.status)?;
+        writeln!(f, "  solutions  : {}", r.result_count())?;
+        match r.objective() {
+            Some(v) => writeln!(f, "  objective  : {}", num(v))?,
+            None => writeln!(f, "  objective  : (none)")?,
+        }
+        writeln!(f, "  solve time : {:?}", r.solve_time)?;
+        writeln!(f, "  iterations : {}", r.iterations)?;
+
+        // Variables
+        let vars = m.variables();
+        writeln!(f, "\nvariables ({})", vars.len())?;
+        if let Some(best) = r.best() {
+            let width = vars.iter().map(|v| v.name.len()).max().unwrap_or(0);
+            let show_rc = !r.reduced_costs.is_empty();
+            for v in vars.iter() {
+                let val = best.value(v.id).map_or_else(|| "n/a".to_owned(), num);
+                match (show_rc, r.reduced_costs.get(&v.id)) {
+                    (true, Some(rc)) => {
+                        writeln!(f, "  {:<width$} = {val}   (reduced cost {})", v.name, num(*rc))?;
+                    }
+                    _ => writeln!(f, "  {:<width$} = {val}", v.name)?,
+                }
+            }
+        } else {
+            writeln!(f, "  (no primal solution)")?;
+        }
+
+        // Constraint duals, only when the solver returned any
+        if !r.dual.is_empty() {
+            let cons = m.constraints();
+            writeln!(f, "\nconstraints ({})", cons.len())?;
+            let width = cons.iter().map(|c| c.name.len()).max().unwrap_or(0);
+            for (i, c) in cons.iter().enumerate() {
+                let id = ConstraintId(u32::try_from(i).expect("constraint index fits u32"));
+                let d = r.dual_of(id).map_or_else(|| "n/a".to_owned(), num);
+                writeln!(f, "  {:<width$}  dual = {d}", c.name)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -177,5 +269,36 @@ mod tests {
         assert_eq!(r.objective(), Some(10.0));
         assert_eq!(r.value(VarId(0)), Some(1.5));
         assert_eq!(r.solution(1).unwrap().value(VarId(0)), Some(2.5));
+    }
+
+    #[test]
+    fn report_renders_sections() {
+        use oximo_core::Relate;
+
+        let m = Model::new("toy");
+        let x = m.var("x").lb(0.0).build();
+        let c = m.constraint("c", x.le(5.0));
+        m.maximize(x);
+
+        let mut primal = FxHashMap::default();
+        primal.insert(x.var_id().unwrap(), 5.0);
+        let mut dual = FxHashMap::default();
+        dual.insert(c, 1.0);
+
+        let r = SolverResult {
+            status: SolverStatus::Optimal,
+            solutions: vec![SolutionPoint { primal, objective: Some(5.0) }],
+            dual,
+            solver_name: Some("TestSolver".into()),
+            ..Default::default()
+        };
+
+        let out = r.report(&m).to_string();
+        assert!(out.contains("solver     : TestSolver"), "{out}");
+        assert!(out.contains("status     : Optimal"), "{out}");
+        assert!(out.contains("objective  : 5"), "{out}");
+        assert!(out.contains("(LP, maximize)"), "{out}");
+        assert!(out.contains("x = 5"), "{out}");
+        assert!(out.contains("dual = 1"), "{out}");
     }
 }

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     //! Glob-import target. Brings the modeling and solver surface into scope.
     pub use oximo_core::prelude::*;
     pub use oximo_solver::{
-        HasUniversal, SolutionPoint, Solver, SolverError, SolverResult, SolverStatus,
+        HasUniversal, ModelReport, SolutionPoint, Solver, SolverError, SolverResult, SolverStatus,
         UniversalOptions, UniversalOptionsExt,
     };
 


### PR DESCRIPTION
## Description

This PR adds a QoL improvement by adding a model report feature for easy printing. `SolverResult` now has a `solver_name`, and all the backends now implement `const NAME`. We need to use Cow because of GAMS' solvers.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/23