### PR TITLE
Add a new macro-based API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "ndarray",
  "num-traits",
  "oximo-expr",
+ "oximo-macros",
  "rayon",
  "rustc-hash",
  "smallvec",
@@ -570,6 +571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oximo-macros"
+version = "0.2.0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "oximo-solver"
 version = "0.2.0"
 dependencies = [
@@ -602,6 +613,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -835,6 +855,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "crates/oximo-expr",
+    "crates/oximo-macros",
     "crates/oximo-core",
     "crates/oximo-solver",
     "crates/oximo-highs",
@@ -26,6 +27,7 @@ authors = ["Germán Martín Heim <german.martin.heim@gmail.com>"]
 
 [workspace.dependencies]
 oximo-expr   = { path = "crates/oximo-expr",   version = "0.2.0" }
+oximo-macros = { path = "crates/oximo-macros", version = "0.2.0" }
 oximo-core   = { path = "crates/oximo-core",   version = "0.2.0" }
 oximo-solver = { path = "crates/oximo-solver", version = "0.2.0" }
 oximo-highs  = { path = "crates/oximo-highs",  version = "0.2.0" }
@@ -34,15 +36,18 @@ oximo-gurobi = { path = "crates/oximo-gurobi", version = "0.2.0" }
 oximo-gams   = { path = "crates/oximo-gams",   version = "0.2.0" }
 oximo-baron  = { path = "crates/oximo-baron",  version = "0.2.0" }
 
-rayon        = "1.12"
-smallvec     = "1.15"
-smol_str     = "0.3.6"
-rustc-hash   = "2.1"
-ndarray      = "0.17"
-thiserror    = "2.0"
-num-traits   = "0.2"
-highs        = "2.2"
-grb          = "3.0"
+rayon            = "1.12"
+syn              = { version = "2", features = ["full"] }
+quote            = "1"
+proc-macro2      = "1"
+proc-macro-crate = "3"
+smallvec         = "1.15"
+smol_str         = "0.3.6"
+rustc-hash       = "2.1"
+ndarray          = "0.17"
+thiserror        = "2.0"
+num-traits       = "0.2"
+highs            = "2.2"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ ndarray          = "0.17"
 thiserror        = "2.0"
 num-traits       = "0.2"
 highs            = "2.2"
+grb              = "3.0"    
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/oximo-baron/README.md
+++ b/crates/oximo-baron/README.md
@@ -44,12 +44,11 @@ use oximo::prelude::*;
 use oximo::solvers::Baron;
 
 let m = Model::new("box");
-let x = m.var("x").lb(0.1).ub(10.0).build();
-let y = m.var("y").lb(0.1).ub(10.0).build();
+variable!(m, 0.1 <= x <= 10.0);
+variable!(m, 0.1 <= y <= 10.0);
 
-m.constraint("c", (x + y).le(8.0));
-let one = Expr::constant(x.arena, 1.0);
-m.maximize((one + x).log() + 2.0 * y);
+constraint!(m, c, x + y <= 8.0);
+objective!(m, Max, (1.0 + x).log() + 2.0 * y);
 
 let result = Baron::new().solve(&m, &BaronOptions::default())?;
 println!("status = {:?}", result.status);

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -936,11 +936,10 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)] // SemiContinuous has no `variable!` syntax; uses the builder until 0.4.0
     fn semicontinuous_is_rejected() {
         let m = Model::new("semi");
-        let x = m.var("x").domain(Domain::SemiContinuous { threshold: 1.0 }).ub(10.0).build();
-        m.minimize(x);
+        variable!(m, x <= 10.0, SemiCont(1.0));
+        objective!(m, Min, x);
         let err = build_bar(&m, &BaronOptions::default()).unwrap_err();
         assert!(matches!(err, SolverError::Backend(_)));
     }

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -810,10 +810,10 @@ mod tests {
     #[test]
     fn lp_emits_minimize_and_positive_vars() {
         let m = Model::new("lp");
-        let x = m.var("x").lb(0.0).ub(10.0).build();
-        let y = m.var("y").lb(0.0).ub(10.0).build();
-        m.constraint("c", (x + y).le(5.0));
-        m.minimize(x + 2.0 * y);
+        variable!(m, 0.0 <= x <= 10.0);
+        variable!(m, 0.0 <= y <= 10.0);
+        constraint!(m, c, x + y <= 5.0);
+        objective!(m, Min, x + 2.0 * y);
         let bar = render(&m);
         assert!(bar.contains("POSITIVE_VARIABLES x0, x1;"), "{bar}");
         assert!(bar.contains("OBJ: minimize"), "{bar}");
@@ -825,8 +825,8 @@ mod tests {
     #[test]
     fn free_variable_emits_lower_and_upper_bounds() {
         let m = Model::new("free");
-        let x = m.var("x").lb(-5.0).ub(5.0).build();
-        m.minimize(x * x);
+        variable!(m, -5.0 <= x <= 5.0);
+        objective!(m, Min, x * x);
         let bar = render(&m);
         assert!(bar.contains("VARIABLES x0;"), "{bar}");
         assert!(bar.contains("LOWER_BOUNDS{"), "{bar}");
@@ -837,9 +837,8 @@ mod tests {
     #[test]
     fn nlp_emits_exp_and_log() {
         let m = Model::new("nlp");
-        let x = m.var("x").lb(0.1).ub(10.0).build();
-        let one = Expr::constant(x.arena, 1.0);
-        m.minimize((one + x).log() + x.exp());
+        variable!(m, 0.1 <= x <= 10.0);
+        objective!(m, Min, (1.0 + x).log() + x.exp());
         let bar = render(&m);
         assert!(bar.contains("log("), "{bar}");
         assert!(bar.contains("exp("), "{bar}");
@@ -848,12 +847,11 @@ mod tests {
     #[test]
     fn minlp_partitions_binary_integer_and_continuous() {
         let m = Model::new("minlp");
-        let b = m.var("b").binary().build();
-        let n = m.var("n").integer().lb(0.0).ub(5.0).build();
-        let y = m.var("y").lb(0.0).ub(10.0).build();
-        m.constraint("budget", (b + n + y).le(8.0));
-        let one = Expr::constant(y.arena, 1.0);
-        m.maximize((one + y).log() + 2.0 * b + n);
+        variable!(m, b, Bin);
+        variable!(m, 0.0 <= n <= 5.0, Int);
+        variable!(m, 0.0 <= y <= 10.0);
+        constraint!(m, budget, b + n + y <= 8.0);
+        objective!(m, Max, (1.0 + y).log() + 2.0 * b + n);
         let bar = render(&m);
         assert!(bar.contains("BINARY_VARIABLES x0;"), "{bar}");
         assert!(bar.contains("INTEGER_VARIABLES x1;"), "{bar}");
@@ -864,8 +862,8 @@ mod tests {
     #[test]
     fn abs_reformulated_as_square_root() {
         let m = Model::new("absbar");
-        let x = m.var("x").lb(-10.0).ub(10.0).build();
-        m.minimize(x.abs());
+        variable!(m, -10.0 <= x <= 10.0);
+        objective!(m, Min, x.abs());
         let bar = render(&m);
         // BARON has no abs(), reformulate |x| = (x^2)^(1/2).
         assert!(bar.contains(") ^ 2) ^ 0.5)"), "expected abs rewrite:\n{bar}");
@@ -875,8 +873,8 @@ mod tests {
     #[test]
     fn integer_power_uses_caret() {
         let m = Model::new("pow");
-        let x = m.var("x").lb(-10.0).ub(10.0).build();
-        m.minimize(x.powi(3));
+        variable!(m, -10.0 <= x <= 10.0);
+        objective!(m, Min, x.powi(3));
         let bar = render(&m);
         assert!(bar.contains(" ^ 3)"), "expected caret power:\n{bar}");
     }
@@ -884,9 +882,9 @@ mod tests {
     #[test]
     fn constant_base_uses_native_caret() {
         let m = Model::new("cbpow");
-        let x = m.var("x").lb(0.0).ub(5.0).build();
+        variable!(m, 0.0 <= x <= 5.0);
         let two = Expr::constant(x.arena, 2.0);
-        m.minimize(two.pow(x));
+        objective!(m, Min, two.pow(x));
         let bar = render(&m);
         assert!(bar.contains("2 ^ x0"), "expected native b^x:\n{bar}");
         assert!(!bar.contains("exp("), "constant base must not rewrite to exp/log:\n{bar}");
@@ -895,9 +893,9 @@ mod tests {
     #[test]
     fn variable_exponent_rewrites_to_exp_log() {
         let m = Model::new("vpow");
-        let x = m.var("x").lb(0.1).ub(10.0).build();
-        let y = m.var("y").lb(0.1).ub(10.0).build();
-        m.minimize(x.pow(y));
+        variable!(m, 0.1 <= x <= 10.0);
+        variable!(m, 0.1 <= y <= 10.0);
+        objective!(m, Min, x.pow(y));
         let bar = render(&m);
         assert!(bar.contains("exp("), "{bar}");
         assert!(bar.contains("log("), "{bar}");
@@ -907,10 +905,10 @@ mod tests {
     #[test]
     fn quadratic_constraint_keeps_rhs() {
         let m = Model::new("qcp");
-        let x = m.var("x").lb(0.0).ub(5.0).build();
-        let y = m.var("y").lb(0.0).ub(5.0).build();
-        m.constraint("xy", (x * y).le(4.0));
-        m.minimize(x + y);
+        variable!(m, 0.0 <= x <= 5.0);
+        variable!(m, 0.0 <= y <= 5.0);
+        constraint!(m, xy, x * y <= 4.0);
+        objective!(m, Min, x + y);
         let bar = render(&m);
         assert!(bar.contains("x0") && bar.contains("x1"), "{bar}");
         assert!(bar.contains("<= 4;"), "{bar}");
@@ -919,8 +917,8 @@ mod tests {
     #[test]
     fn feasibility_problem_minimizes_zero() {
         let m = Model::new("feas");
-        let x = m.var("x").lb(0.0).ub(1.0).build();
-        m.constraint("c", x.le(1.0));
+        variable!(m, 0.0 <= x <= 1.0);
+        constraint!(m, c, x <= 1.0);
         let bar = render(&m);
         assert!(bar.contains("OBJ: minimize 0;"), "{bar}");
     }
@@ -928,8 +926,8 @@ mod tests {
     #[test]
     fn sin_is_rejected() {
         let m = Model::new("trig");
-        let x = m.var("x").lb(-1.0).ub(1.0).build();
-        m.minimize(x.sin());
+        variable!(m, -1.0 <= x <= 1.0);
+        objective!(m, Min, x.sin());
         let err = build_bar(&m, &BaronOptions::default()).unwrap_err();
         match err {
             SolverError::Backend(msg) => assert!(msg.contains("sin"), "{msg}"),
@@ -938,6 +936,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // SemiContinuous has no `variable!` syntax; uses the builder until 0.4.0
     fn semicontinuous_is_rejected() {
         let m = Model::new("semi");
         let x = m.var("x").domain(Domain::SemiContinuous { threshold: 1.0 }).ub(10.0).build();
@@ -949,10 +948,10 @@ mod tests {
     #[test]
     fn constant_constraint_is_rejected() {
         let m = Model::new("constc");
-        let x = m.var("x").lb(0.0).ub(5.0).build();
+        variable!(m, 0.0 <= x <= 5.0);
         // x - x folds to a constant left-hand side, which BARON would reject.
-        m.constraint("trivial", (x - x).le(1.0));
-        m.minimize(x);
+        constraint!(m, trivial, x - x <= 1.0);
+        objective!(m, Min, x);
         let err = build_bar(&m, &BaronOptions::default()).unwrap_err();
         match err {
             SolverError::Backend(msg) => assert!(msg.contains("no variables"), "{msg}"),
@@ -963,8 +962,9 @@ mod tests {
     #[test]
     fn binary_fixed_to_one_emits_lower_bound() {
         let m = Model::new("fix1");
-        let b = m.var("b").binary().fix(1.0).build();
-        m.minimize(b);
+        variable!(m, b, Bin);
+        m.fix(b, 1.0);
+        objective!(m, Min, b);
         let bar = render(&m);
         assert!(bar.contains("BINARY_VARIABLES x0;"), "{bar}");
         // lb=1 differs from the binary default 0, so it must be emitted.
@@ -975,8 +975,9 @@ mod tests {
     #[test]
     fn binary_fixed_to_zero_emits_upper_bound() {
         let m = Model::new("fix0");
-        let b = m.var("b").binary().fix(0.0).build();
-        m.minimize(b);
+        variable!(m, b, Bin);
+        m.fix(b, 0.0);
+        objective!(m, Min, b);
         let bar = render(&m);
         // ub=0 differs from the binary default 1, so it must be emitted.
         assert!(bar.contains("UPPER_BOUNDS{"), "{bar}");
@@ -986,8 +987,9 @@ mod tests {
     #[test]
     fn starting_point_emitted_when_initial_set() {
         let m = Model::new("start");
-        let x = m.var("x").lb(0.0).ub(10.0).initial(3.5).build();
-        m.minimize(x * x);
+        variable!(m, 0.0 <= x <= 10.0);
+        m.set_initial(x, 3.5);
+        objective!(m, Min, x * x);
         let bar = render(&m);
         assert!(bar.contains("STARTING_POINT{"), "{bar}");
         assert!(bar.contains("x0: 3.5;"), "{bar}");

--- a/crates/oximo-core/Cargo.toml
+++ b/crates/oximo-core/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [dependencies]
 oximo-expr.workspace = true
+oximo-macros.workspace = true
 rayon.workspace = true
 smallvec.workspace = true
 smol_str.workspace = true
@@ -18,6 +19,9 @@ rustc-hash.workspace = true
 ndarray.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+oximo-expr.workspace = true
 
 [lints]
 workspace = true

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -26,27 +26,38 @@ use oximo_core::prelude::*;
 let m = Model::new("transport");
 
 // Scalar variables
-let x = m.var("x").lb(0.0).build();
-let y = m.var("y").lb(0.0).ub(10.0).build();
+variable!(m, x >= 0.0);
+variable!(m, 0.0 <= y <= 10.0);
 
-// Constraints
-m.constraint("c1", (x + 2.0 * y).le(14.0));
-m.constraint("c2", (3.0 * x - y).ge(0.0));
+// Constraints (incl. a two-sided range -> band_lo + band_hi)
+constraint!(m, c1, x + 2.0 * y <= 14.0);
+constraint!(m, c2, 3.0 * x - y >= 0.0);
+constraint!(m, band, 1.0 <= x + y <= 12.0);
 
 // Objective
-m.maximize(3.0 * x + 4.0 * y);
+objective!(m, Max, 3.0 * x + 4.0 * y);
 
 println!("kind = {:?}", m.kind()); // LP
 ```
 
-## Model
+## Modeling API
 
-`Model` uses interior mutability (`RefCell`) so the builder API takes `&self`. This lets you hold a `&Model` reference, build variables and constraints, and immediately use the returned `Expr` handles, no `&mut` threading required.
+The modeling surface is a set of macros: `variable!`, `constraint!`, `objective!`,
+`sum!`, and `param!`. Each expands to the underlying typed model operations,
+so there is no runtime cost and full compile-time type/borrow checking is preserved.
+
+> The older builder methods (`Model::var`/`indexed_var`/`constraint`/`minimize`/
+> `maximize`/`param`, free `sum_over`, `add_constraints_over`) are deprecated as
+> of 0.3.0 and scheduled for removal in 0.4.0. Prefer the macros.
+
+`Model` uses interior mutability (`RefCell`), so a macro can take `&m`, register
+variables/constraints, and the `variable!`-introduced bindings (`x`, `y`, ...) are
+locals you can use immediately.
 
 ```rust,ignore
 let m = Model::new("my_model");
-let x = m.var("x").lb(0.0).build(); // returns Expr<'_>
-m.constraint("cap", x.le(5.0));     // uses x while holding &m
+variable!(m, x >= 0.0);        // binds a local `x: Expr<'_>`
+constraint!(m, cap, x <= 5.0); // uses x while holding &m
 ```
 
 Names are unique per registry. Registering a duplicate variable or constraint name **panics**.
@@ -74,39 +85,38 @@ m.unfix_var(var_id, 0.0, 10.0); // restore bounds
 
 ## Variables
 
-### Scalar variable builder
+### Scalar variables
 
 ```rust,ignore
-let x = m.var("x")
-    .lb(0.0)              // lower bound (default: -inf)
-    .ub(10.0)             // upper bound (default: +inf)
-    .domain(Domain::Real) // explicit domain (default: Real)
-    .build();             // returns Expr<'_>
-
-// Shorthand domain setters:
-let b = m.var("b").binary().build();          // Domain::Binary, bounds [0, 1]
-let n = m.var("n").integer().lb(0.0).build(); // Domain::Integer
+variable!(m, x);                        // free (-inf, +inf)
+variable!(m, x >= 0.0);                 // lower bound only
+variable!(m, 0.0 <= x <= 10.0);         // both bounds
+variable!(m, b, Bin);                   // binary {0, 1}  (also Binary)
+variable!(m, 0.0 <= n <= 100.0, Int);   // general integer  (also Integer)
+variable!(m, s <= 10.0, SemiCont(2.0)); // semicontinuous: 0 or in [2, 10]
+variable!(m, t <= 5.0, SemiInt(1.0));   // semi-integer: 0 or integer in [1, 5]
 ```
 
-### Indexed variable builder
+### Indexed variables
 
-Creates one scalar variable per key in a `Set`, named `base[key]`.
+Creates one scalar variable per key in a `Set` (or range), named `base[key]`,
+and binds an `IndexedVar`.
 
 ```rust,ignore
 let i = Set::range(0..5);
-let x = m.indexed_var("x", &i)
-    .lb(0.0)
-    .integer()
-    .build(); // IndexedVar<'_>
+variable!(m, 0.0 <= x[k in i] <= 10.0);     // uniform bounds
+variable!(m, y[k in i] >= 0.0, Int);        // integer family
+variable!(m, z[a in rows, b in cols], Bin); // multi-index (Cartesian product)
 
 // Access by key (panics on missing key):
-let expr = x[2]; // or x["name"], x[(a, b)]
+let expr = x[2];  // single key (usize / "name" / (a, b))
+let e2 = z[a, b]; // inside the macros: multi-index sugar == z[(&a, &b)]
 
-// Per-key bounds:
-let x = m.indexed_var("x", &i)
-    .lb_by(|k: usize| lower_bounds[k])
-    .ub_by(|k: usize| upper_bounds[k])
-    .build();
+// Bounds may reference the index -> lowered to per-key bounds:
+variable!(m, lower[k] <= w[k in i] <= upper[k]);
+
+// Filtered family: keep only matching keys (no trivial elements built).
+variable!(m, d[(i, j) in rc if i == j] >= 0.0);
 ```
 
 ## Domain
@@ -138,32 +148,52 @@ let evens = i.filter(|k| k.as_i64().unwrap() % 2 == 0);
 
 ## Constraints
 
-### Single constraint
+`==`, `<=`, and `>=` are written directly, the macro intercepts the tokens, so
+these are real constraint operators.
 
 ```rust,ignore
-let c_id = m.constraint("name", expr.le(rhs)); // <=
-let c_id = m.constraint("name", expr.ge(rhs)); // >=
-let c_id = m.constraint("name", expr.eq(rhs)); // ==
+constraint!(m, name, lhs <= rhs);                  // named, also >= and ==
+constraint!(m, lhs >= rhs);                        // anonymous (auto-named _c0, _c1, ...)
+constraint!(m, band, 1.0 <= e <= 3.0);             // two-sided range -> band_lo + band_hi
+constraint!(m, name = format!("c_{k}"), e == rhs); // computed run-time name
 ```
 
-### Bulk, rule over a set
+### Indexed family over a set
 
 ```rust,ignore
-m.add_constraints_over("supply", &plants, |p: String| {
-    supply[&p].le(capacity[&p])
-});
+// One constraint per key, auto-named supply[seattle], ...
+constraint!(m, supply[p in plants], sum!(x[p, q] for q in markets) <= cap[p]);
 
-// Tuple sets, destructure inline:
-m.add_constraints_over("flow", &(&plants * &markets), |(p, m): (String, String)| {
-    x[(&p, &m)].le(capacity[&p])
-});
+// Multi-index family (multi-index access sugar: x[i, j]).
+constraint!(m, flow[i in 0..n, j in 0..m], x[i, j] >= 0.0);
+
+// Filtered family: only keys passing the guard.
+constraint!(m, diag[(i, j) in rc if i == j], x[i, j] <= 1.0);
+```
+
+### Summation
+
+`sum!(body for k in domain)` reads as `sum_{k in domain} body`. Nest with extra
+clauses and filter with a trailing `if`:
+
+```rust,ignore
+constraint!(m, cap, sum!(weights[i] * x[i] for i in items) <= capacity);
+objective!(m, Min, sum!(c[i, j] * x[i, j] for i in rows, j in cols));
+let evens = sum!(x[i] for i in items if i % 2 == 0); // filtered
 ```
 
 ## Objectives
 
 ```rust,ignore
-m.minimize(cost_expr);
-m.maximize(revenue_expr);
+objective!(m, Min, cost_expr);
+objective!(m, Max, revenue_expr);
+```
+
+## Parameters
+
+```rust,ignore
+param!(m, rate = 0.05);  // binds a re-bindable `rate: Expr<'_>`
+m.set_param(rate, 0.07); // change between solves without rebuilding
 ```
 
 ## Model kind

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -91,7 +91,7 @@ impl<'a, K> IndexedVar<'a, K> {
     }
 
     /// Zero-allocation typed index by integer coordinates.
-    /// On a dense family this maps straight to a flat offset with no 
+    /// On a dense family this maps straight to a flat offset with no
     /// `IndexKey` built. On a sparse family it falls back to building a key.
     ///
     /// # Panics

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -1,20 +1,35 @@
+use std::marker::PhantomData;
 use std::ops::Index;
 
 use oximo_expr::Expr;
 use rustc_hash::FxHashMap;
 
-use crate::set::IndexKey;
+use crate::set::{FromIndexKey, IndexKey};
 
-/// Sparse indexed variable: maps an `IndexKey` to a single-variable `Expr`.
+/// Sparse indexed variable: maps an `IndexKey` to a single-variable `Expr`,
+/// tagged with the key type `K` its domain decodes to.
 ///
-/// Constructed by [`crate::Model::indexed_var`]. Implements [`Index`] so
-/// `flow[idx]` returns the variable's expression handle directly.
-#[derive(Clone, Debug)]
-pub struct IndexedVar<'a> {
+/// Constructed by [`crate::Model::indexed_var`] or the `variable!` macro. `K` is
+/// a phantom marker, carried so the type of an indexed family is visible and
+/// typed iteration via [`Self::keys`] is possible.
+pub struct IndexedVar<'a, K = IndexKey> {
     pub(crate) entries: FxHashMap<IndexKey, Expr<'a>>,
+    pub(crate) _k: PhantomData<fn() -> K>,
 }
 
-impl<'a> IndexedVar<'a> {
+impl<'a, K> Clone for IndexedVar<'a, K> {
+    fn clone(&self) -> Self {
+        Self { entries: self.entries.clone(), _k: PhantomData }
+    }
+}
+
+impl<'a, K> std::fmt::Debug for IndexedVar<'a, K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexedVar").field("entries", &self.entries.len()).finish()
+    }
+}
+
+impl<'a, K> IndexedVar<'a, K> {
     pub fn len(&self) -> usize {
         self.entries.len()
     }
@@ -27,19 +42,26 @@ impl<'a> IndexedVar<'a> {
         self.entries.iter()
     }
 
-    pub fn get<K: Into<IndexKey>>(&self, key: K) -> Option<Expr<'a>> {
+    pub fn get<Q: Into<IndexKey>>(&self, key: Q) -> Option<Expr<'a>> {
         self.entries.get(&key.into()).copied()
     }
 }
 
-impl<'a, K: Into<IndexKey>> Index<K> for IndexedVar<'a> {
+impl<'a, K: FromIndexKey> IndexedVar<'a, K> {
+    /// Iterate the family's entries with each key decoded to the typed `K`.
+    pub fn keys(&self) -> impl Iterator<Item = (K, Expr<'a>)> + '_ {
+        self.entries.iter().map(|(k, e)| (K::from_index_key(k), *e))
+    }
+}
+
+impl<'a, K, Q: Into<IndexKey>> Index<Q> for IndexedVar<'a, K> {
     type Output = Expr<'a>;
-    fn index(&self, key: K) -> &Self::Output {
+    fn index(&self, key: Q) -> &Self::Output {
         self.entries.get(&key.into()).expect("IndexedVar: key not present")
     }
 }
 
-impl<'a> Index<&IndexKey> for IndexedVar<'a> {
+impl<'a, K> Index<&IndexKey> for IndexedVar<'a, K> {
     type Output = Expr<'a>;
     fn index(&self, key: &IndexKey) -> &Self::Output {
         self.entries.get(key).expect("IndexedVar: key not present")

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -4,66 +4,198 @@ use std::ops::Index;
 use oximo_expr::Expr;
 use rustc_hash::FxHashMap;
 
-use crate::set::{FromIndexKey, IndexKey};
+use crate::set::{Axis, FromIndexKey, IndexKey};
 
-/// Sparse indexed variable: maps an `IndexKey` to a single-variable `Expr`,
-/// tagged with the key type `K` its domain decodes to.
+/// Backing storage for an [`IndexedVar`].
+///
+/// `Dense` is used when the domain is a contiguous integer grid (a range, or a
+/// product of ranges). `Sparse` (string sets, sparse `from_ints`, or any
+/// `filter`ed family) keeps the original hash map.
+#[derive(Clone)]
+pub(crate) enum Storage<'a> {
+    Dense { data: Vec<Expr<'a>>, keys: Vec<IndexKey>, axes: Box<[Axis]> },
+    Sparse(FxHashMap<IndexKey, Expr<'a>>),
+}
+
+/// Indexed variable: maps an `IndexKey` to a single-variable `Expr`, tagged with
+/// the key type `K` its domain decodes to.
 ///
 /// Constructed by [`crate::Model::indexed_var`] or the `variable!` macro. `K` is
 /// a phantom marker, carried so the type of an indexed family is visible and
 /// typed iteration via [`Self::keys`] is possible.
+///
+/// When the domain is a contiguous integer range (or a Cartesian product of
+/// ranges) the family is stored densely (see [`Storage`]).
+/// String, sparse, and `filter`ed families fall back to a hash map.
 pub struct IndexedVar<'a, K = IndexKey> {
-    pub(crate) entries: FxHashMap<IndexKey, Expr<'a>>,
+    pub(crate) storage: Storage<'a>,
     pub(crate) _k: PhantomData<fn() -> K>,
 }
 
 impl<'a, K> Clone for IndexedVar<'a, K> {
     fn clone(&self) -> Self {
-        Self { entries: self.entries.clone(), _k: PhantomData }
+        Self { storage: self.storage.clone(), _k: PhantomData }
     }
 }
 
 impl<'a, K> std::fmt::Debug for IndexedVar<'a, K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IndexedVar").field("entries", &self.entries.len()).finish()
+        f.debug_struct("IndexedVar")
+            .field("len", &self.len())
+            .field("dense", &self.is_dense())
+            .finish()
     }
 }
 
 impl<'a, K> IndexedVar<'a, K> {
     pub fn len(&self) -> usize {
-        self.entries.len()
+        match &self.storage {
+            Storage::Dense { data, .. } => data.len(),
+            Storage::Sparse(m) => m.len(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.len() == 0
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&IndexKey, &Expr<'a>)> {
-        self.entries.iter()
+    /// Whether this family is stored densely (domain was a range or product of
+    /// ranges).
+    pub fn is_dense(&self) -> bool {
+        matches!(self.storage, Storage::Dense { .. })
+    }
+
+    /// Per-axis lengths when stored densely, else `None`.
+    pub fn shape(&self) -> Option<Box<[usize]>> {
+        match &self.storage {
+            Storage::Dense { axes, .. } => Some(axes.iter().map(|a| a.len).collect()),
+            Storage::Sparse(_) => None,
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&IndexKey, &Expr<'a>)> + '_ {
+        let it: Box<dyn Iterator<Item = (&IndexKey, &Expr<'a>)>> = match &self.storage {
+            Storage::Dense { data, keys, .. } => Box::new(keys.iter().zip(data.iter())),
+            Storage::Sparse(m) => Box::new(m.iter()),
+        };
+        it
     }
 
     pub fn get<Q: Into<IndexKey>>(&self, key: Q) -> Option<Expr<'a>> {
-        self.entries.get(&key.into()).copied()
+        match &self.storage {
+            Storage::Sparse(m) => m.get(&key.into()).copied(),
+            Storage::Dense { data, axes, .. } => {
+                grid_offset(axes, &key.into()).map(|off| data[off])
+            }
+        }
+    }
+
+    /// Zero-allocation typed index by integer coordinates.
+    /// On a dense family this maps straight to a flat offset with no 
+    /// `IndexKey` built. On a sparse family it falls back to building a key.
+    ///
+    /// # Panics
+    /// Panics if the coordinates are out of range/not present.
+    pub fn at<const N: usize>(&self, coords: [usize; N]) -> Expr<'a> {
+        *self.get_ref(&coords).expect("IndexedVar: coordinates not present")
+    }
+
+    /// Fallible form of [`Self::at`].
+    pub fn get_at<const N: usize>(&self, coords: [usize; N]) -> Option<Expr<'a>> {
+        self.get_ref(&coords).copied()
+    }
+
+    fn get_ref(&self, coords: &[usize]) -> Option<&Expr<'a>> {
+        match &self.storage {
+            Storage::Dense { data, axes, .. } => {
+                grid_offset_coords(axes, coords).map(|off| &data[off])
+            }
+            Storage::Sparse(m) => m.get(&coords_to_key(coords)),
+        }
     }
 }
 
 impl<'a, K: FromIndexKey> IndexedVar<'a, K> {
     /// Iterate the family's entries with each key decoded to the typed `K`.
     pub fn keys(&self) -> impl Iterator<Item = (K, Expr<'a>)> + '_ {
-        self.entries.iter().map(|(k, e)| (K::from_index_key(k), *e))
+        self.iter().map(|(k, e)| (K::from_index_key(k), *e))
     }
 }
 
 impl<'a, K, Q: Into<IndexKey>> Index<Q> for IndexedVar<'a, K> {
     type Output = Expr<'a>;
     fn index(&self, key: Q) -> &Self::Output {
-        self.entries.get(&key.into()).expect("IndexedVar: key not present")
+        match &self.storage {
+            Storage::Sparse(m) => m.get(&key.into()).expect("IndexedVar: key not present"),
+            Storage::Dense { data, axes, .. } => {
+                let off = grid_offset(axes, &key.into()).expect("IndexedVar: key not present");
+                &data[off]
+            }
+        }
     }
 }
 
 impl<'a, K> Index<&IndexKey> for IndexedVar<'a, K> {
     type Output = Expr<'a>;
     fn index(&self, key: &IndexKey) -> &Self::Output {
-        self.entries.get(key).expect("IndexedVar: key not present")
+        match &self.storage {
+            Storage::Sparse(m) => m.get(key).expect("IndexedVar: key not present"),
+            Storage::Dense { data, axes, .. } => {
+                let off = grid_offset(axes, key).expect("IndexedVar: key not present");
+                &data[off]
+            }
+        }
+    }
+}
+
+impl<'a, K, const N: usize> Index<[usize; N]> for IndexedVar<'a, K> {
+    type Output = Expr<'a>;
+    fn index(&self, coords: [usize; N]) -> &Self::Output {
+        self.get_ref(&coords).expect("IndexedVar: coordinates not present")
+    }
+}
+
+/// Position of a key value along one axis, or `None` if out of `[start, start+len)`.
+fn axis_index(a: &Axis, v: i64) -> Option<usize> {
+    let d = v.checked_sub(a.start)?;
+    let u = usize::try_from(d).ok()?;
+    (u < a.len).then_some(u)
+}
+
+/// Row-major flat offset (axis 0 outermost) of an `IndexKey` in a dense grid, or
+/// `None` if the key's shape does not match the axes or is out of range.
+pub(crate) fn grid_offset(axes: &[Axis], key: &IndexKey) -> Option<usize> {
+    match (axes, key) {
+        ([a], IndexKey::Int(v)) => axis_index(a, *v),
+        (axes, IndexKey::Tuple(parts)) if parts.len() == axes.len() => {
+            let mut off = 0usize;
+            for (a, p) in axes.iter().zip(parts.iter()) {
+                off = off * a.len + axis_index(a, p.as_i64()?)?;
+            }
+            Some(off)
+        }
+        _ => None,
+    }
+}
+
+/// Row-major flat offset from raw integer coordinates (key values).
+fn grid_offset_coords(axes: &[Axis], coords: &[usize]) -> Option<usize> {
+    if coords.len() != axes.len() {
+        return None;
+    }
+    let mut off = 0usize;
+    for (a, &c) in axes.iter().zip(coords) {
+        off = off * a.len + axis_index(a, i64::try_from(c).ok()?)?;
+    }
+    Some(off)
+}
+
+/// Build the `IndexKey` a coordinate array would hash to (sparse fallback for
+/// [`IndexedVar::get_ref`]).
+fn coords_to_key(coords: &[usize]) -> IndexKey {
+    if let [single] = coords {
+        IndexKey::from(*single)
+    } else {
+        IndexKey::Tuple(coords.iter().map(|&c| IndexKey::from(c)).collect())
     }
 }

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -170,7 +170,7 @@ pub(crate) fn grid_offset(axes: &[Axis], key: &IndexKey) -> Option<usize> {
         (axes, IndexKey::Tuple(parts)) if parts.len() == axes.len() => {
             let mut off = 0usize;
             for (a, p) in axes.iter().zip(parts.iter()) {
-                off = off * a.len + axis_index(a, p.as_i64()?)?;
+                off = off.checked_mul(a.len)?.checked_add(axis_index(a, p.as_i64()?)?)?;
             }
             Some(off)
         }

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -32,3 +32,5 @@ pub use var::{VarBuilder, Variable};
 // Re-export the expression handle so downstream code does not need a separate
 // `oximo-expr` import.
 pub use oximo_expr::{Expr, ExprArena, ExprId, ExprNode, ParamId, VarId, dot};
+
+pub use oximo_macros::{constraint, objective, param, sum, variable};

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -25,7 +25,7 @@ pub use indexed::IndexedVar;
 pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
-pub use set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
+pub use set::{FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};
 pub use sum::SumDomain;
 #[allow(deprecated)]
 pub use sum::sum_over;

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -1,6 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
+extern crate self as oximo_core;
+
+#[doc(hidden)]
+#[path = "macro_support.rs"]
+pub mod __macro_support;
 pub mod constraint;
 pub mod domain;
 pub mod error;

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -25,7 +25,7 @@ pub use indexed::IndexedVar;
 pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
-pub use set::{FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};
+pub use set::{Axis, FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};
 pub use sum::SumDomain;
 #[allow(deprecated)]
 pub use sum::sum_over;

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -26,7 +26,9 @@ pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
 pub use set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
-pub use sum::{SumDomain, sum_over};
+pub use sum::SumDomain;
+#[allow(deprecated)]
+pub use sum::sum_over;
 pub use var::{VarBuilder, Variable};
 
 // Re-export the expression handle so downstream code does not need a separate

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -74,7 +74,7 @@ impl<T: PrimInt> IntoSet for std::ops::RangeInclusive<T> {
     fn into_set(self) -> Set<usize> {
         let start = self.start().to_i64().expect("range start out of i64 range");
         let end = self.end().to_i64().expect("range end out of i64 range");
-        Set::dense_i64(start, end.checked_add(1).expect("range end out of i64 range"))
+        Set::dense_i64(start, end.checked_add(1).expect("inclusive range end overflows i64"))
     }
 }
 

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -7,7 +7,7 @@
 //! are re-exports of the real modeling surface plus a couple of helpers.
 
 pub use crate::constraint::Relate;
-pub use crate::set::{FromIndexKey, Set};
+pub use crate::set::{FromIndexKey, KeyCat, Set};
 pub use crate::sum::__sum_over as sum_over;
 pub use crate::sum::SumDomain;
 
@@ -22,27 +22,33 @@ use num_traits::PrimInt;
 
 /// Conversion into an owned [`Set`], used by the `variable!`/`constraint!`
 /// macros to turn an index domain (`i in 0..n`, `i in some_set`) into the
-/// [`Set`] that [`crate::Model::indexed_var`] expects. The macro always passes
+/// [`Set`] that [`crate::Model::indexed_var`] expects. The associated `Key` is
+/// the type the domain's keys decode to, so the macro can infer the closure
+/// parameter type. Integer ranges decode to `usize`. The macro always passes
 /// the domain by reference; the blanket impl for `&S` forwards through, so a
 /// domain that is itself a `&Set` (e.g. a function parameter) also works.
 pub trait IntoSet {
-    fn into_set(self) -> Set;
+    type Key;
+    fn into_set(self) -> Set<Self::Key>;
 }
 
-impl IntoSet for Set {
-    fn into_set(self) -> Set {
+impl<K> IntoSet for Set<K> {
+    type Key = K;
+    fn into_set(self) -> Set<K> {
         self
     }
 }
 
 impl<T: PrimInt> IntoSet for std::ops::Range<T> {
-    fn into_set(self) -> Set {
+    type Key = usize;
+    fn into_set(self) -> Set<usize> {
         Set::range(self)
     }
 }
 
 impl<T: PrimInt> IntoSet for std::ops::RangeInclusive<T> {
-    fn into_set(self) -> Set {
+    type Key = usize;
+    fn into_set(self) -> Set<usize> {
         let start = self.start().to_i64().expect("range start out of i64 range");
         let end = self.end().to_i64().expect("range end out of i64 range");
         Set::from_ints(start..=end)
@@ -50,19 +56,24 @@ impl<T: PrimInt> IntoSet for std::ops::RangeInclusive<T> {
 }
 
 impl<S: IntoSet + Clone> IntoSet for &S {
-    fn into_set(self) -> Set {
+    type Key = S::Key;
+    fn into_set(self) -> Set<S::Key> {
         (*self).clone().into_set()
     }
 }
 
-/// Normalize a macro index domain into an owned [`Set`].
-pub fn as_set<S: IntoSet>(s: S) -> Set {
+/// Normalize a macro index domain into an owned [`Set`], preserving its key type.
+pub fn as_set<S: IntoSet>(s: S) -> Set<S::Key> {
     s.into_set()
 }
 
-/// Cartesian product of two index domains. Used by the `variable!`/
-/// `constraint!` macros to combine multiple `pat in domain` clauses.
+/// Cartesian product of two index domains, composing their key types. Used by
+/// the `variable!`/`constraint!` macros to combine multiple `pat in domain`
+/// clauses.
 #[must_use]
-pub fn product(a: &Set, b: &Set) -> Set {
+pub fn product<A, B>(a: &Set<A>, b: &Set<B>) -> Set<<A as KeyCat<B>>::Out>
+where
+    A: KeyCat<B>,
+{
     Set::product(a, b)
 }

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -7,6 +7,7 @@
 //! are re-exports of the real modeling surface plus a couple of helpers.
 
 pub use crate::constraint::Relate;
+pub use crate::domain::Domain;
 pub use crate::set::{FromIndexKey, KeyCat, Set};
 pub use crate::sum::__sum_over as sum_over;
 pub use crate::sum::SumDomain;

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -1,0 +1,68 @@
+//! Runtime support items the `oximo-macros` procedural macros expand into.
+//!
+//! This module is NOT part of the stable public API. It exists so that the
+//! `variable!`/`constraint!`/`objective!`/`sum!`/`param!` macros have a
+//! fully-qualified path (`<crate>::__macro_support::...`) to reference
+//! regardless of how the user brought the macros into scope. Items here
+//! are re-exports of the real modeling surface plus a couple of helpers.
+
+pub use crate::constraint::Relate;
+pub use crate::set::{FromIndexKey, Set};
+pub use crate::sum::__sum_over as sum_over;
+pub use crate::sum::SumDomain;
+
+/// Typed key iterator over a sum/constraint domain. Backs the filtered form of
+/// the `sum!` macro (`sum!(.. for i in dom if cond)`), which iterates and skips
+/// non-matching keys rather than summing zero terms.
+pub fn keys_of<K, D: SumDomain<K> + ?Sized>(d: &D) -> impl Iterator<Item = K> + '_ {
+    d.keys()
+}
+
+use num_traits::PrimInt;
+
+/// Conversion into an owned [`Set`], used by the `variable!`/`constraint!`
+/// macros to turn an index domain (`i in 0..n`, `i in some_set`) into the
+/// [`Set`] that [`crate::Model::indexed_var`] expects. The macro always passes
+/// the domain by reference; the blanket impl for `&S` forwards through, so a
+/// domain that is itself a `&Set` (e.g. a function parameter) also works.
+pub trait IntoSet {
+    fn into_set(self) -> Set;
+}
+
+impl IntoSet for Set {
+    fn into_set(self) -> Set {
+        self
+    }
+}
+
+impl<T: PrimInt> IntoSet for std::ops::Range<T> {
+    fn into_set(self) -> Set {
+        Set::range(self)
+    }
+}
+
+impl<T: PrimInt> IntoSet for std::ops::RangeInclusive<T> {
+    fn into_set(self) -> Set {
+        let start = self.start().to_i64().expect("range start out of i64 range");
+        let end = self.end().to_i64().expect("range end out of i64 range");
+        Set::from_ints(start..=end)
+    }
+}
+
+impl<S: IntoSet + Clone> IntoSet for &S {
+    fn into_set(self) -> Set {
+        (*self).clone().into_set()
+    }
+}
+
+/// Normalize a macro index domain into an owned [`Set`].
+pub fn as_set<S: IntoSet>(s: S) -> Set {
+    s.into_set()
+}
+
+/// Cartesian product of two index domains. Used by the `variable!`/
+/// `constraint!` macros to combine multiple `pat in domain` clauses.
+#[must_use]
+pub fn product(a: &Set, b: &Set) -> Set {
+    Set::product(a, b)
+}

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -11,6 +11,16 @@ pub use crate::set::{FromIndexKey, KeyCat, Set};
 pub use crate::sum::__sum_over as sum_over;
 pub use crate::sum::SumDomain;
 
+/// Filter a [`Set`] by a typed predicate over its decoded keys. Backs the
+/// filtered family form `name[i in dom if cond]` of `variable!`/`constraint!`.
+pub fn filter_keys<K, F>(set: &Set<K>, mut pred: F) -> Set<K>
+where
+    K: FromIndexKey,
+    F: FnMut(K) -> bool,
+{
+    set.filter(|k| pred(K::from_index_key(k)))
+}
+
 /// Typed key iterator over a sum/constraint domain. Backs the filtered form of
 /// the `sum!` macro (`sum!(.. for i in dom if cond)`), which iterates and skips
 /// non-matching keys rather than summing zero terms.

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -61,7 +61,7 @@ impl<T: PrimInt> IntoSet for std::ops::RangeInclusive<T> {
     fn into_set(self) -> Set<usize> {
         let start = self.start().to_i64().expect("range start out of i64 range");
         let end = self.end().to_i64().expect("range end out of i64 range");
-        Set::from_ints(start..=end)
+        Set::dense_i64(start, end.checked_add(1).expect("range end out of i64 range"))
     }
 }
 

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -11,6 +11,13 @@ pub use crate::set::{FromIndexKey, KeyCat, Set};
 pub use crate::sum::__sum_over as sum_over;
 pub use crate::sum::SumDomain;
 
+/// Flatten already-collected `sum!` terms into one expression (a single n-ary
+/// `Add`).
+#[must_use]
+pub fn sum_terms<'a>(terms: Vec<oximo_expr::Expr<'a>>) -> oximo_expr::Expr<'a> {
+    terms.into_iter().sum()
+}
+
 /// Filter a [`Set`] by a typed predicate over its decoded keys. Backs the
 /// filtered family form `name[i in dom if cond]` of `variable!`/`constraint!`.
 pub fn filter_keys<K, F>(set: &Set<K>, mut pred: F) -> Set<K>

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -37,6 +37,11 @@ use num_traits::PrimInt;
 /// parameter type. Integer ranges decode to `usize`. The macro always passes
 /// the domain by reference; the blanket impl for `&S` forwards through, so a
 /// domain that is itself a `&Set` (e.g. a function parameter) also works.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid index domain for a `variable!`/`constraint!` family",
+    label = "not an index domain",
+    note = "use a `Set`, an integer range `a..b` / `a..=b`, or a reference to one"
+)]
 pub trait IntoSet {
     type Key;
     fn into_set(self) -> Set<Self::Key>;

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -1,4 +1,4 @@
-use std::cell::{Ref, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 
 use oximo_expr::{Expr, ExprArena, ExprClass, ParamId, VarId, classify};
 use rustc_hash::FxHashMap;
@@ -46,6 +46,9 @@ pub struct Model {
     pub(crate) constraint_names: RefCell<FxHashMap<SmolStr, ConstraintId>>,
     pub(crate) objective: RefCell<Option<Objective>>,
     cached_kind: RefCell<Option<ModelKind>>,
+    /// Monotonic counter for auto-naming anonymous constraints registered via
+    /// the `constraint!` macro.
+    auto_seq: Cell<u32>,
 }
 
 impl std::fmt::Debug for Model {
@@ -73,12 +76,20 @@ impl Model {
             constraint_names: RefCell::new(FxHashMap::default()),
             objective: RefCell::new(None),
             cached_kind: RefCell::new(None),
+            auto_seq: Cell::new(0),
         }
     }
 
     // Variables
 
     pub fn var(&self, name: impl Into<SmolStr>) -> VarBuilder<'_> {
+        self.__var(name)
+    }
+
+    /// Macro-facing entry point behind [`Self::var`]. Not part of the stable
+    /// public API; use the `variable!` macro (or `var`) instead.
+    #[doc(hidden)]
+    pub fn __var(&self, name: impl Into<SmolStr>) -> VarBuilder<'_> {
         VarBuilder {
             model: self,
             name: name.into(),
@@ -112,6 +123,17 @@ impl Model {
     }
 
     pub fn indexed_var<'a>(&'a self, name: impl Into<String>, set: &Set) -> IndexedVarBuilder<'a> {
+        self.__indexed_var(name, set)
+    }
+
+    /// Macro-facing entry point behind [`Self::indexed_var`]. Not part of the
+    /// stable public API; use the `variable!` macro instead.
+    #[doc(hidden)]
+    pub fn __indexed_var<'a>(
+        &'a self,
+        name: impl Into<String>,
+        set: &Set,
+    ) -> IndexedVarBuilder<'a> {
         IndexedVarBuilder {
             model: self,
             base_name: name.into(),
@@ -160,6 +182,18 @@ impl Model {
         v.ub = value;
     }
 
+    /// Set the initial (warm-start) value of a single-variable expression.
+    /// The macro API has no bound-style syntax for warm starts, so this is the
+    /// supported way to seed `variable!`-declared variables.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `e` is not a bare variable handle.
+    pub fn set_initial(&self, e: Expr<'_>, value: f64) {
+        let id = e.var_id().expect("Model::set_initial expects a single-variable expression");
+        self.variables.borrow_mut()[id.index()].initial = Some(value);
+    }
+
     /// Restore bounds on variable `id`. Pass `f64::NEG_INFINITY` / `f64::INFINITY`
     /// to restore an unbounded direction.
     pub fn unfix_var(&self, id: VarId, lb: f64, ub: f64) {
@@ -183,6 +217,13 @@ impl Model {
     ///
     /// Panics if a parameter with the same name is already registered.
     pub fn param<'a>(&'a self, name: impl Into<SmolStr>, value: f64) -> Expr<'a> {
+        self.__param(name, value)
+    }
+
+    /// Macro-facing entry point behind [`Self::param`]. Not part of the stable
+    /// public API; use the `param!` macro instead.
+    #[doc(hidden)]
+    pub fn __param<'a>(&'a self, name: impl Into<SmolStr>, value: f64) -> Expr<'a> {
         let name = name.into();
         assert!(
             !self.param_names.borrow().contains_key(&name),
@@ -254,6 +295,17 @@ impl Model {
     /// Panics if a constraint with the same name is already registered, or if
     /// the constraint count exceeds `u32::MAX`.
     pub fn constraint(&self, name: impl Into<SmolStr>, c: ConstraintExpr<'_>) -> ConstraintId {
+        self.__add_constraint(name, c)
+    }
+
+    /// Macro-facing entry point behind [`Self::constraint`]. Not part of the
+    /// stable public API; use the `constraint!` macro instead.
+    #[doc(hidden)]
+    pub fn __add_constraint(
+        &self,
+        name: impl Into<SmolStr>,
+        c: ConstraintExpr<'_>,
+    ) -> ConstraintId {
         let name = name.into();
         let mut by_name = self.constraint_names.borrow_mut();
         assert!(!by_name.contains_key(&name), "constraint name {name:?} already registered");
@@ -271,6 +323,22 @@ impl Model {
         id
     }
 
+    /// Register an anonymous constraint, deriving a unique name `_c{n}` from an
+    /// internal counter. Backs the name-less form of the `constraint!` macro.
+    #[doc(hidden)]
+    pub fn __add_constraint_auto(&self, c: ConstraintExpr<'_>) -> ConstraintId {
+        // Skip over any names a user may already have taken.
+        let name = loop {
+            let n = self.auto_seq.get();
+            self.auto_seq.set(n + 1);
+            let candidate: SmolStr = format!("_c{n}").into();
+            if !self.constraint_names.borrow().contains_key(&candidate) {
+                break candidate;
+            }
+        };
+        self.__add_constraint(name, c)
+    }
+
     /// Bulk-register constraints. Each entry is `(name, ConstraintExpr)`.
     /// Useful with `.par_iter().map(...).collect()` style construction.
     pub fn add_constraints<'a, I>(&'a self, items: I)
@@ -278,7 +346,7 @@ impl Model {
         I: IntoIterator<Item = (SmolStr, ConstraintExpr<'a>)>,
     {
         for (name, c) in items {
-            self.constraint(name, c);
+            self.__add_constraint(name, c);
         }
     }
 
@@ -300,6 +368,19 @@ impl Model {
     /// });
     /// ```
     pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, mut rule: F)
+    pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, rule: F)
+    where
+        K: FromIndexKey,
+        F: FnMut(K) -> ConstraintExpr<'a>,
+    {
+        self.__add_constraints_over(name_prefix, set, rule);
+    }
+
+    /// Macro-facing entry point behind [`Self::add_constraints_over`]. Backs the
+    /// indexed-family form of the `constraint!` macro. Not part of the stable
+    /// public API.
+    #[doc(hidden)]
+    pub fn __add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, mut rule: F)
     where
         K: FromIndexKey,
         F: FnMut(K) -> ConstraintExpr<'a>,
@@ -308,7 +389,7 @@ impl Model {
             let typed = K::from_index_key(&key);
             let c = rule(typed);
             let name: SmolStr = format_index_name(name_prefix, &key).into();
-            self.constraint(name, c);
+            self.__add_constraint(name, c);
         }
     }
 
@@ -327,10 +408,22 @@ impl Model {
     // Objective
 
     pub fn minimize(&self, expr: Expr<'_>) {
-        self.set_objective(expr, ObjectiveSense::Minimize);
+        self.__minimize(expr);
     }
 
     pub fn maximize(&self, expr: Expr<'_>) {
+        self.__maximize(expr);
+    }
+
+    /// Macro-facing entry point behind [`Self::minimize`]. Backs `objective!(m, Min, ..)`.
+    #[doc(hidden)]
+    pub fn __minimize(&self, expr: Expr<'_>) {
+        self.set_objective(expr, ObjectiveSense::Minimize);
+    }
+
+    /// Macro-facing entry point behind [`Self::maximize`]. Backs `objective!(m, Max, ..)`.
+    #[doc(hidden)]
+    pub fn __maximize(&self, expr: Expr<'_>) {
         self.set_objective(expr, ObjectiveSense::Maximize);
     }
 
@@ -493,7 +586,7 @@ impl<'a> IndexedVarBuilder<'a> {
             let scalar_name: SmolStr = format_index_name(&self.base_name, &key).into();
             let lb = self.lb_by.as_ref().map_or(self.lb, |f| f(&key));
             let ub = self.ub_by.as_ref().map_or(self.ub, |f| f(&key));
-            let expr = self.model.var(scalar_name).lb(lb).ub(ub).domain(self.domain).build();
+            let expr = self.model.__var(scalar_name).lb(lb).ub(ub).domain(self.domain).build();
             entries.insert(key, expr);
         }
         IndexedVar { entries }

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -82,6 +82,10 @@ impl Model {
 
     // Variables
 
+    #[deprecated(
+        since = "0.3.0",
+        note = "use the `variable!` macro, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn var(&self, name: impl Into<SmolStr>) -> VarBuilder<'_> {
         self.__var(name)
     }
@@ -122,6 +126,10 @@ impl Model {
         Expr::from_var(&self.arena, id)
     }
 
+    #[deprecated(
+        since = "0.3.0",
+        note = "use the `variable!` macro, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn indexed_var<'a>(&'a self, name: impl Into<String>, set: &Set) -> IndexedVarBuilder<'a> {
         self.__indexed_var(name, set)
     }
@@ -216,6 +224,10 @@ impl Model {
     /// # Panics
     ///
     /// Panics if a parameter with the same name is already registered.
+    #[deprecated(
+        since = "0.3.0",
+        note = "use the `param!` macro, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn param<'a>(&'a self, name: impl Into<SmolStr>, value: f64) -> Expr<'a> {
         self.__param(name, value)
     }
@@ -294,6 +306,10 @@ impl Model {
     ///
     /// Panics if a constraint with the same name is already registered, or if
     /// the constraint count exceeds `u32::MAX`.
+    #[deprecated(
+        since = "0.3.0",
+        note = "use the `constraint!` macro, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn constraint(&self, name: impl Into<SmolStr>, c: ConstraintExpr<'_>) -> ConstraintId {
         self.__add_constraint(name, c)
     }
@@ -367,7 +383,10 @@ impl Model {
     ///     (b[(t, n)] - b_min[t] * w[(t, n)]).ge(0.0)
     /// });
     /// ```
-    pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, mut rule: F)
+    #[deprecated(
+        since = "0.3.0",
+        note = "use the indexed-family form of the `constraint!` macro, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, rule: F)
     where
         K: FromIndexKey,
@@ -407,10 +426,18 @@ impl Model {
 
     // Objective
 
+    #[deprecated(
+        since = "0.3.0",
+        note = "use `objective!(m, Min, ..)`, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn minimize(&self, expr: Expr<'_>) {
         self.__minimize(expr);
     }
 
+    #[deprecated(
+        since = "0.3.0",
+        note = "use `objective!(m, Max, ..)`, the builder API is scheduled for removal in 0.4.0"
+    )]
     pub fn maximize(&self, expr: Expr<'_>) {
         self.__maximize(expr);
     }
@@ -627,6 +654,8 @@ pub fn display_index_key(key: &IndexKey) -> String {
 }
 
 #[cfg(test)]
+// exercises the builder API directly until its 0.4.0 removal
+#[allow(deprecated)] 
 mod tests {
     use oximo_expr::extract_linear;
 

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -419,6 +419,22 @@ impl Model {
         }
     }
 
+    /// Macro-facing entry point for a two-sided range family.
+    #[doc(hidden)]
+    pub fn __add_range_constraints_over<'a, K, F>(&'a self, name: &str, set: &Set<K>, mut rule: F)
+    where
+        K: FromIndexKey,
+        F: FnMut(K) -> (ConstraintExpr<'a>, ConstraintExpr<'a>),
+    {
+        let lo_prefix = format!("{name}_lo");
+        let hi_prefix = format!("{name}_hi");
+        for key in set {
+            let (lo, hi) = rule(K::from_index_key(&key));
+            self.__add_constraint(format_index_name(&lo_prefix, &key), lo);
+            self.__add_constraint(format_index_name(&hi_prefix, &key), hi);
+        }
+    }
+
     pub fn constraints(&self) -> Ref<'_, Vec<Constraint>> {
         self.constraints.borrow()
     }

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -655,7 +655,7 @@ pub fn display_index_key(key: &IndexKey) -> String {
 
 #[cfg(test)]
 // exercises the builder API directly until its 0.4.0 removal
-#[allow(deprecated)] 
+#[allow(deprecated)]
 mod tests {
     use oximo_expr::extract_linear;
 

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, Ref, RefCell};
+use std::marker::PhantomData;
 
 use oximo_expr::{Expr, ExprArena, ExprClass, ParamId, VarId, classify};
 use rustc_hash::FxHashMap;
@@ -130,18 +131,22 @@ impl Model {
         since = "0.3.0",
         note = "use the `variable!` macro, the builder API is scheduled for removal in 0.4.0"
     )]
-    pub fn indexed_var<'a>(&'a self, name: impl Into<String>, set: &Set) -> IndexedVarBuilder<'a> {
+    pub fn indexed_var<'a, K>(
+        &'a self,
+        name: impl Into<String>,
+        set: &Set<K>,
+    ) -> IndexedVarBuilder<'a, K> {
         self.__indexed_var(name, set)
     }
 
     /// Macro-facing entry point behind [`Self::indexed_var`]. Not part of the
     /// stable public API; use the `variable!` macro instead.
     #[doc(hidden)]
-    pub fn __indexed_var<'a>(
+    pub fn __indexed_var<'a, K>(
         &'a self,
         name: impl Into<String>,
-        set: &Set,
-    ) -> IndexedVarBuilder<'a> {
+        set: &Set<K>,
+    ) -> IndexedVarBuilder<'a, K> {
         IndexedVarBuilder {
             model: self,
             base_name: name.into(),
@@ -151,6 +156,7 @@ impl Model {
             lb_by: None,
             ub_by: None,
             domain: Domain::Real,
+            _k: PhantomData,
         }
     }
 
@@ -387,7 +393,7 @@ impl Model {
         since = "0.3.0",
         note = "use the indexed-family form of the `constraint!` macro, the builder API is scheduled for removal in 0.4.0"
     )]
-    pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, rule: F)
+    pub fn add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set<K>, rule: F)
     where
         K: FromIndexKey,
         F: FnMut(K) -> ConstraintExpr<'a>,
@@ -399,7 +405,7 @@ impl Model {
     /// indexed-family form of the `constraint!` macro. Not part of the stable
     /// public API.
     #[doc(hidden)]
-    pub fn __add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set, mut rule: F)
+    pub fn __add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set<K>, mut rule: F)
     where
         K: FromIndexKey,
         F: FnMut(K) -> ConstraintExpr<'a>,
@@ -521,7 +527,7 @@ impl Model {
 type BoundFn<'a> = Box<dyn Fn(&IndexKey) -> f64 + 'a>;
 
 #[must_use = "IndexedVarBuilder does nothing until you call .build()"]
-pub struct IndexedVarBuilder<'a> {
+pub struct IndexedVarBuilder<'a, K = IndexKey> {
     model: &'a Model,
     base_name: String,
     keys: Vec<IndexKey>,
@@ -530,9 +536,10 @@ pub struct IndexedVarBuilder<'a> {
     lb_by: Option<BoundFn<'a>>,
     ub_by: Option<BoundFn<'a>>,
     domain: Domain,
+    _k: PhantomData<fn() -> K>,
 }
 
-impl<'a> std::fmt::Debug for IndexedVarBuilder<'a> {
+impl<'a, K> std::fmt::Debug for IndexedVarBuilder<'a, K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IndexedVarBuilder")
             .field("base_name", &self.base_name)
@@ -546,7 +553,7 @@ impl<'a> std::fmt::Debug for IndexedVarBuilder<'a> {
     }
 }
 
-impl<'a> IndexedVarBuilder<'a> {
+impl<'a, K> IndexedVarBuilder<'a, K> {
     pub fn lb(mut self, v: f64) -> Self {
         self.lb = v;
         self
@@ -568,7 +575,7 @@ impl<'a> IndexedVarBuilder<'a> {
     /// .lb_by(|(p, q): (String, String)| floor_for(&p, &q))
     /// .lb_by(|i: usize| lower_bounds[i])
     /// ```
-    pub fn lb_by<K, F>(mut self, f: F) -> Self
+    pub fn lb_by<F>(mut self, f: F) -> Self
     where
         K: FromIndexKey,
         F: Fn(K) -> f64 + 'a,
@@ -584,7 +591,7 @@ impl<'a> IndexedVarBuilder<'a> {
     /// .ub_by(|(p, q): (String, String)| capacity_for(&p, &q))
     /// .ub_by(|i: usize| upper_bounds[i])
     /// ```
-    pub fn ub_by<K, F>(mut self, f: F) -> Self
+    pub fn ub_by<F>(mut self, f: F) -> Self
     where
         K: FromIndexKey,
         F: Fn(K) -> f64 + 'a,
@@ -607,7 +614,7 @@ impl<'a> IndexedVarBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> IndexedVar<'a> {
+    pub fn build(self) -> IndexedVar<'a, K> {
         let mut entries = FxHashMap::default();
         for key in self.keys {
             let scalar_name: SmolStr = format_index_name(&self.base_name, &key).into();
@@ -616,7 +623,7 @@ impl<'a> IndexedVarBuilder<'a> {
             let expr = self.model.__var(scalar_name).lb(lb).ub(ub).domain(self.domain).build();
             entries.insert(key, expr);
         }
-        IndexedVar { entries }
+        IndexedVar { entries, _k: PhantomData }
     }
 }
 

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -8,10 +8,10 @@ use smol_str::SmolStr;
 use crate::constraint::{Constraint, ConstraintExpr, ConstraintId};
 use crate::domain::Domain;
 use crate::error::{Error, Result};
-use crate::indexed::IndexedVar;
+use crate::indexed::{IndexedVar, Storage, grid_offset};
 use crate::objective::{Objective, ObjectiveSense};
 use crate::param::Parameter;
-use crate::set::{FromIndexKey, IndexKey, Set};
+use crate::set::{Axis, FromIndexKey, IndexKey, Set};
 use crate::var::{VarBuilder, Variable};
 
 /// The kind of mathematical program a `Model` represents.
@@ -151,6 +151,7 @@ impl Model {
             model: self,
             base_name: name.into(),
             keys: set.iter().collect(),
+            axes: set.axes().map(Box::from),
             lb: f64::NEG_INFINITY,
             ub: f64::INFINITY,
             lb_by: None,
@@ -531,6 +532,7 @@ pub struct IndexedVarBuilder<'a, K = IndexKey> {
     model: &'a Model,
     base_name: String,
     keys: Vec<IndexKey>,
+    axes: Option<Box<[Axis]>>,
     lb: f64,
     ub: f64,
     lb_by: Option<BoundFn<'a>>,
@@ -614,16 +616,45 @@ impl<'a, K> IndexedVarBuilder<'a, K> {
         self
     }
 
+    /// Register one scalar variable per key and return the [`IndexedVar`] handle.
+    ///
+    /// # Panics
+    /// Panics if a scalar variable name collides with one already registered.
     pub fn build(self) -> IndexedVar<'a, K> {
-        let mut entries = FxHashMap::default();
-        for key in self.keys {
-            let scalar_name: SmolStr = format_index_name(&self.base_name, &key).into();
-            let lb = self.lb_by.as_ref().map_or(self.lb, |f| f(&key));
-            let ub = self.ub_by.as_ref().map_or(self.ub, |f| f(&key));
-            let expr = self.model.__var(scalar_name).lb(lb).ub(ub).domain(self.domain).build();
-            entries.insert(key, expr);
-        }
-        IndexedVar { entries, _k: PhantomData }
+        let Self { model, base_name, keys, axes, lb, ub, lb_by, ub_by, domain, _k } = self;
+
+        let make = |key: &IndexKey| -> Expr<'a> {
+            let scalar_name: SmolStr = format_index_name(&base_name, key).into();
+            let lo = lb_by.as_ref().map_or(lb, |f| f(key));
+            let hi = ub_by.as_ref().map_or(ub, |f| f(key));
+            model.__var(scalar_name).lb(lo).ub(hi).domain(domain).build()
+        };
+
+        let storage = if let Some(axes) = axes {
+            // Dense grid: place each scalar at its computed row-major offset,
+            // so the storage cannot be silently mis-built if `Set` iteration
+            // vever changes.
+            let total = keys.len();
+            let mut data: Vec<Option<Expr<'a>>> = vec![None; total];
+            let mut kept: Vec<Option<IndexKey>> = vec![None; total];
+            for key in keys {
+                let expr = make(&key);
+                let off = grid_offset(&axes, &key).expect("dense grid key out of range");
+                data[off] = Some(expr);
+                kept[off] = Some(key);
+            }
+            let data = data.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
+            let kept = kept.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
+            Storage::Dense { data, keys: kept, axes }
+        } else {
+            let mut entries = FxHashMap::default();
+            for key in keys {
+                let expr = make(&key);
+                entries.insert(key, expr);
+            }
+            Storage::Sparse(entries)
+        };
+        IndexedVar { storage, _k: PhantomData }
     }
 }
 

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -6,7 +6,9 @@ pub use crate::model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
-pub use crate::sum::{SumDomain, sum_over};
+pub use crate::sum::SumDomain;
+#[allow(deprecated)]
+pub use crate::sum::sum_over;
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};
 

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -9,3 +9,5 @@ pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
 pub use crate::sum::{SumDomain, sum_over};
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};
+
+pub use oximo_macros::{constraint, objective, param, sum, variable};

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -301,6 +301,11 @@ where
 /// Type-level concatenation of index key types, mirroring the runtime tuple
 /// flattening in [`Set::product`]. The arity ceiling is 4, matching the
 /// [`FromIndexKey`]/`From<(...)>` tuple implementations.
+#[diagnostic::on_unimplemented(
+    message = "cannot form a Cartesian product index key from `{Self}` and `{Rhs}`",
+    label = "no product key for `{Self}` * `{Rhs}`",
+    note = "`&a * &b` composes scalar keys (`usize`/`i64`/`i32`/`String`) into flat tuples up to arity 4. A 5th axis or a non-scalar operand is unsupported"
+)]
 pub trait KeyCat<Rhs> {
     type Out;
 }
@@ -487,6 +492,12 @@ where
 ///     ...
 /// });
 /// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid index key type",
+    label = "cannot be decoded from an index key",
+    note = "index keys decode to `usize`, `i64`, `i32`, `String`, `IndexKey`, or a tuple of those up to arity 4",
+    note = "annotate the binding to one of these (e.g. `for k: usize in set`) or match the `Set`'s key type"
+)]
 pub trait FromIndexKey: Sized {
     fn from_index_key(k: &IndexKey) -> Self;
 }

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -385,6 +385,12 @@ impl From<&&str> for IndexKey {
     }
 }
 
+impl From<&&String> for IndexKey {
+    fn from(s: &&String) -> Self {
+        Self::Str(SmolStr::new(s.as_str()))
+    }
+}
+
 impl<A, B> From<(A, B)> for IndexKey
 where
     A: Into<IndexKey>,

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use std::ops::Mul;
 
 use num_traits::PrimInt;
@@ -14,53 +15,58 @@ use smol_str::SmolStr;
 /// Heap-allocated tuple key payload. Immutable after construction.
 pub type IndexTuple = Box<[IndexKey]>;
 
-/// A finite, ordered index set.
-///
-/// Supports integer ranges, string lists, and arbitrary tuple lists (built via
-/// [`Set::product`] / the `&a * &b` operator, or constructed directly).
+/// Runtime representation of a [`Set`]. The key type is tracked only at the type
+/// level (via [`Set`]'s phantom parameter), so the stored representation is
+/// identical for every `K` and carries no per-key type information.
 #[derive(Clone, Debug)]
-pub enum Set {
+enum SetRepr {
     Range(Vec<i64>),
     Strings(Vec<SmolStr>),
     Tuples(Vec<IndexTuple>),
 }
 
-impl Set {
-    /// Build an integer index set from a range over any primitive integer
-    /// type. Accepts `Range<i64>`, `Range<i32>`, `Range<usize>`, etc.
-    ///
-    /// The untyped literal form `Set::range(0..5)` defaults to `i32` and
-    /// works without annotation.
-    ///
-    /// # Panics
-    /// Panics if either range bound does not fit in `i64`.
-    pub fn range<T: PrimInt>(r: std::ops::Range<T>) -> Self {
-        let start = r.start.to_i64().expect("range start out of i64 range");
-        let end = r.end.to_i64().expect("range end out of i64 range");
-        Self::Range((start..end).collect())
+impl SetRepr {
+    fn len(&self) -> usize {
+        match self {
+            Self::Range(v) => v.len(),
+            Self::Strings(v) => v.len(),
+            Self::Tuples(v) => v.len(),
+        }
     }
+}
 
-    /// Build an integer index set from an iterator of any primitive integer
-    /// type. Useful when keys are sparse or computed (e.g. only even indices).
-    ///
-    /// # Panics
-    /// Panics if any element does not fit in `i64`.
-    pub fn from_ints<T, I>(iter: I) -> Self
-    where
-        T: PrimInt,
-        I: IntoIterator<Item = T>,
-    {
-        Self::Range(
-            iter.into_iter().map(|v| v.to_i64().expect("element out of i64 range")).collect(),
-        )
+// TODO: Simplify the following after removing the the builder API
+
+/// A finite, ordered index set, parameterized by the type `K` its keys decode to.
+///
+/// `K` is a phantom marker: the runtime representation is the same erased
+/// payload regardless of `K`, so carrying the key type costs nothing at runtime.
+/// It exists so the `variable!`/`constraint!`/`sum!` macros can infer the
+/// closure parameter type from the set instead of requiring an annotation.
+///
+/// Supports integer ranges (`K = usize`), string lists (`K = String`), and
+/// arbitrary tuple lists (built via [`Set::product`] / the `&a * &b` operator.
+pub struct Set<K = IndexKey> {
+    repr: SetRepr,
+    _k: PhantomData<fn() -> K>,
+}
+
+// Manual `Clone`/`Debug` so they hold for every `K`
+impl<K> Clone for Set<K> {
+    fn clone(&self) -> Self {
+        Self { repr: self.repr.clone(), _k: PhantomData }
     }
+}
 
-    pub fn strings<I, S>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<SmolStr>,
-    {
-        Self::Strings(iter.into_iter().map(Into::into).collect())
+impl<K> std::fmt::Debug for Set<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.repr, f)
+    }
+}
+
+impl<K> Set<K> {
+    fn from_repr(repr: SetRepr) -> Self {
+        Self { repr, _k: PhantomData }
     }
 
     /// Build a tuple set directly from an iterator of keys.
@@ -69,7 +75,64 @@ impl Set {
         I: IntoIterator<Item = T>,
         T: Into<IndexTuple>,
     {
-        Self::Tuples(iter.into_iter().map(Into::into).collect())
+        Self::from_repr(SetRepr::Tuples(iter.into_iter().map(Into::into).collect()))
+    }
+
+    /// Filter keys with a predicate. Preserves the original variant where
+    /// possible.
+    #[must_use]
+    pub fn filter<F>(&self, mut f: F) -> Self
+    where
+        F: FnMut(&IndexKey) -> bool,
+    {
+        let repr = match &self.repr {
+            SetRepr::Range(v) => {
+                SetRepr::Range(v.iter().copied().filter(|i| f(&IndexKey::Int(*i))).collect())
+            }
+            SetRepr::Strings(v) => SetRepr::Strings(
+                v.iter()
+                    .filter_map(|s| {
+                        let key = IndexKey::Str(s.clone());
+                        f(&key).then(|| s.clone())
+                    })
+                    .collect(),
+            ),
+            SetRepr::Tuples(v) => SetRepr::Tuples(
+                v.iter()
+                    .filter_map(|t| {
+                        let key = IndexKey::Tuple(t.clone());
+                        f(&key).then(|| match key {
+                            IndexKey::Tuple(owned) => owned,
+                            _ => unreachable!(),
+                        })
+                    })
+                    .collect(),
+            ),
+        };
+        Self::from_repr(repr)
+    }
+
+    pub fn len(&self) -> usize {
+        self.repr.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Whether the backing representation is the integer-range variant.
+    pub fn is_range(&self) -> bool {
+        matches!(self.repr, SetRepr::Range(_))
+    }
+
+    /// Whether the backing representation is the string-list variant.
+    pub fn is_strings(&self) -> bool {
+        matches!(self.repr, SetRepr::Strings(_))
+    }
+
+    /// Whether the backing representation is the tuple-list variant.
+    pub fn is_tuples(&self) -> bool {
+        matches!(self.repr, SetRepr::Tuples(_))
     }
 
     /// Cartesian product of two sets. Inner tuple keys are flattened so a
@@ -77,7 +140,11 @@ impl Set {
     ///
     /// # Panics
     /// Panics if `a.len() * b.len()` overflows `usize`.
-    pub fn product(a: &Set, b: &Set) -> Self {
+    #[must_use]
+    pub fn product<B>(a: &Set<K>, b: &Set<B>) -> Set<<K as KeyCat<B>>::Out>
+    where
+        K: KeyCat<B>,
+    {
         let a_len = a.len();
         let b_len = b.len();
         let total = a_len.checked_mul(b_len).expect("Set::product size overflow");
@@ -95,7 +162,7 @@ impl Set {
                     out.push(parts.into_boxed_slice());
                 }
             }
-            return Self::Tuples(out);
+            return Set::from_repr(SetRepr::Tuples(out));
         }
 
         let a_keys: Vec<IndexKey> = a.iter().collect();
@@ -109,51 +176,50 @@ impl Set {
                 parts.into_boxed_slice()
             })
             .collect();
-        Self::Tuples(out)
+        Set::from_repr(SetRepr::Tuples(out))
+    }
+}
+
+impl Set<usize> {
+    /// Build an integer index set from a range over any primitive integer
+    /// type. Accepts `Range<i64>`, `Range<i32>`, `Range<usize>`, etc.
+    ///
+    /// The keys decode to `usize`.
+    /// Negative elements are accepted into the payload but panic when
+    /// decoded to `usize`.
+    ///
+    /// # Panics
+    /// Panics if either range bound does not fit in `i64`.
+    #[must_use]
+    pub fn range<T: PrimInt>(r: std::ops::Range<T>) -> Self {
+        let start = r.start.to_i64().expect("range start out of i64 range");
+        let end = r.end.to_i64().expect("range end out of i64 range");
+        Self::from_repr(SetRepr::Range((start..end).collect()))
     }
 
-    /// Filter keys with a predicate. Preserves the original variant where
-    /// possible, filtered `Range`/`Strings` stay in their native variant.
-    pub fn filter<F>(&self, mut f: F) -> Self
+    /// Build an integer index set from an iterator of any primitive integer
+    /// type. Useful when keys are sparse or computed.
+    ///
+    /// # Panics
+    /// Panics if any element does not fit in `i64`.
+    pub fn from_ints<T, I>(iter: I) -> Self
     where
-        F: FnMut(&IndexKey) -> bool,
+        T: PrimInt,
+        I: IntoIterator<Item = T>,
     {
-        match self {
-            Self::Range(v) => {
-                Self::Range(v.iter().copied().filter(|i| f(&IndexKey::Int(*i))).collect())
-            }
-            Self::Strings(v) => Self::Strings(
-                v.iter()
-                    .filter_map(|s| {
-                        let key = IndexKey::Str(s.clone());
-                        f(&key).then(|| s.clone())
-                    })
-                    .collect(),
-            ),
-            Self::Tuples(v) => Self::Tuples(
-                v.iter()
-                    .filter_map(|t| {
-                        let key = IndexKey::Tuple(t.clone());
-                        f(&key).then(|| match key {
-                            IndexKey::Tuple(owned) => owned,
-                            _ => unreachable!(),
-                        })
-                    })
-                    .collect(),
-            ),
-        }
+        Self::from_repr(SetRepr::Range(
+            iter.into_iter().map(|v| v.to_i64().expect("element out of i64 range")).collect(),
+        ))
     }
+}
 
-    pub fn len(&self) -> usize {
-        match self {
-            Self::Range(v) => v.len(),
-            Self::Strings(v) => v.len(),
-            Self::Tuples(v) => v.len(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+impl Set<String> {
+    pub fn strings<I, S>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<SmolStr>,
+    {
+        Self::from_repr(SetRepr::Strings(iter.into_iter().map(Into::into).collect()))
     }
 }
 
@@ -172,11 +238,58 @@ fn make_tuple<I: IntoIterator<Item = IndexKey>>(items: I) -> IndexTuple {
     v.into_boxed_slice()
 }
 
-impl Mul<&Set> for &Set {
-    type Output = Set;
-    fn mul(self, rhs: &Set) -> Set {
+impl<A, B> Mul<&Set<B>> for &Set<A>
+where
+    A: KeyCat<B>,
+{
+    type Output = Set<<A as KeyCat<B>>::Out>;
+    fn mul(self, rhs: &Set<B>) -> Self::Output {
         Set::product(self, rhs)
     }
+}
+
+/// Type-level concatenation of index key types, mirroring the runtime tuple
+/// flattening in [`Set::product`]. The arity ceiling is 4, matching the
+/// [`FromIndexKey`]/`From<(...)>` tuple implementations.
+pub trait KeyCat<Rhs> {
+    type Out;
+}
+
+/// Marker for non-tuple ("scalar") index key types. Lets [`KeyCat`] distinguish
+/// the scalar base case from the tuple-extension cases without overlap.
+pub trait ScalarKey {}
+impl ScalarKey for usize {}
+impl ScalarKey for i32 {}
+impl ScalarKey for i64 {}
+impl ScalarKey for String {}
+impl ScalarKey for IndexKey {}
+
+impl<A: ScalarKey, B: ScalarKey> KeyCat<B> for A {
+    type Out = (A, B);
+}
+
+impl<A, B, C: ScalarKey> KeyCat<C> for (A, B) {
+    type Out = (A, B, C);
+}
+
+impl<A, B, C, D: ScalarKey> KeyCat<D> for (A, B, C) {
+    type Out = (A, B, C, D);
+}
+
+// Right-associated / tuple-on-the-right products (`a * (b * c)`,
+// `(a * b) * (c * d)`). The macros only ever left-fold with a scalar right
+// operand, but `Set::product` flattens both sides, so we keep manual
+// products associative up to the arity-4 ceiling.
+impl<A: ScalarKey, B, C> KeyCat<(B, C)> for A {
+    type Out = (A, B, C);
+}
+
+impl<A: ScalarKey, B, C, D> KeyCat<(B, C, D)> for A {
+    type Out = (A, B, C, D);
+}
+
+impl<A, B, C, D> KeyCat<(C, D)> for (A, B) {
+    type Out = (A, B, C, D);
 }
 
 /// A serializable index key from a [`Set`].
@@ -376,7 +489,7 @@ where
     }
 }
 
-impl<'a> IntoIterator for &'a Set {
+impl<'a, K> IntoIterator for &'a Set<K> {
     type Item = IndexKey;
     type IntoIter = SetIter<'a>;
     fn into_iter(self) -> Self::IntoIter {
@@ -384,16 +497,20 @@ impl<'a> IntoIterator for &'a Set {
     }
 }
 
-impl Set {
+impl<K> Set<K> {
     pub fn iter(&self) -> SetIter<'_> {
-        SetIter { set: self, pos: 0 }
+        SetIter { repr: &self.repr, pos: 0 }
     }
 
     pub fn par_iter(&self) -> impl ParallelIterator<Item = IndexKey> + '_ {
-        match self {
-            Self::Range(v) => v.par_iter().map(|i| IndexKey::Int(*i)).collect::<Vec<_>>(),
-            Self::Strings(v) => v.par_iter().map(|s| IndexKey::Str(s.clone())).collect::<Vec<_>>(),
-            Self::Tuples(v) => v.par_iter().map(|t| IndexKey::Tuple(t.clone())).collect::<Vec<_>>(),
+        match &self.repr {
+            SetRepr::Range(v) => v.par_iter().map(|i| IndexKey::Int(*i)).collect::<Vec<_>>(),
+            SetRepr::Strings(v) => {
+                v.par_iter().map(|s| IndexKey::Str(s.clone())).collect::<Vec<_>>()
+            }
+            SetRepr::Tuples(v) => {
+                v.par_iter().map(|t| IndexKey::Tuple(t.clone())).collect::<Vec<_>>()
+            }
         }
         .into_par_iter()
     }
@@ -401,17 +518,17 @@ impl Set {
 
 #[derive(Debug)]
 pub struct SetIter<'a> {
-    set: &'a Set,
+    repr: &'a SetRepr,
     pos: usize,
 }
 
 impl<'a> Iterator for SetIter<'a> {
     type Item = IndexKey;
     fn next(&mut self) -> Option<Self::Item> {
-        let out = match self.set {
-            Set::Range(v) => v.get(self.pos).copied().map(IndexKey::Int),
-            Set::Strings(v) => v.get(self.pos).cloned().map(IndexKey::Str),
-            Set::Tuples(v) => v.get(self.pos).cloned().map(IndexKey::Tuple),
+        let out = match self.repr {
+            SetRepr::Range(v) => v.get(self.pos).copied().map(IndexKey::Int),
+            SetRepr::Strings(v) => v.get(self.pos).cloned().map(IndexKey::Str),
+            SetRepr::Tuples(v) => v.get(self.pos).cloned().map(IndexKey::Tuple),
         };
         if out.is_some() {
             self.pos += 1;

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -360,6 +360,31 @@ impl From<&String> for IndexKey {
     }
 }
 
+// Reference conversions.
+impl From<&usize> for IndexKey {
+    fn from(v: &usize) -> Self {
+        Self::from(*v)
+    }
+}
+
+impl From<&i64> for IndexKey {
+    fn from(v: &i64) -> Self {
+        Self::Int(*v)
+    }
+}
+
+impl From<&i32> for IndexKey {
+    fn from(v: &i32) -> Self {
+        Self::Int(i64::from(*v))
+    }
+}
+
+impl From<&&str> for IndexKey {
+    fn from(s: &&str) -> Self {
+        Self::Str(SmolStr::new(*s))
+    }
+}
+
 impl<A, B> From<(A, B)> for IndexKey
 where
     A: Into<IndexKey>,

--- a/crates/oximo-core/src/set.rs
+++ b/crates/oximo-core/src/set.rs
@@ -37,6 +37,16 @@ impl SetRepr {
 
 // TODO: Simplify the following after removing the the builder API
 
+/// A single contiguous integer axis of a dense index grid.
+/// Carried by [`Set`] (see [`Set::axes`]) so an [`crate::IndexedVar`]
+/// built over a range can store its scalars densely and map
+/// a key to a flat offset without hashing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Axis {
+    pub start: i64,
+    pub len: usize,
+}
+
 /// A finite, ordered index set, parameterized by the type `K` its keys decode to.
 ///
 /// `K` is a phantom marker: the runtime representation is the same erased
@@ -46,15 +56,21 @@ impl SetRepr {
 ///
 /// Supports integer ranges (`K = usize`), string lists (`K = String`), and
 /// arbitrary tuple lists (built via [`Set::product`] / the `&a * &b` operator.
+///
+/// `axes` is `Some` exactly when the set is a dense integer grid
+/// and records the per-axis extents.
+/// It is `None` for string sets, sparse/`from_ints` sets, and any
+/// `filter`ed set.
 pub struct Set<K = IndexKey> {
     repr: SetRepr,
+    axes: Option<Box<[Axis]>>,
     _k: PhantomData<fn() -> K>,
 }
 
 // Manual `Clone`/`Debug` so they hold for every `K`
 impl<K> Clone for Set<K> {
     fn clone(&self) -> Self {
-        Self { repr: self.repr.clone(), _k: PhantomData }
+        Self { repr: self.repr.clone(), axes: self.axes.clone(), _k: PhantomData }
     }
 }
 
@@ -66,7 +82,18 @@ impl<K> std::fmt::Debug for Set<K> {
 
 impl<K> Set<K> {
     fn from_repr(repr: SetRepr) -> Self {
-        Self { repr, _k: PhantomData }
+        Self { repr, axes: None, _k: PhantomData }
+    }
+
+    fn from_repr_with_axes(repr: SetRepr, axes: Box<[Axis]>) -> Self {
+        Self { repr, axes: Some(axes), _k: PhantomData }
+    }
+
+    /// Per-axis extents when this set is a dense integer grid (a range or a
+    /// product of ranges), else `None`. Read by the `IndexedVar` builder to pick
+    /// dense vs sparse storage.
+    pub(crate) fn axes(&self) -> Option<&[Axis]> {
+        self.axes.as_deref()
     }
 
     /// Build a tuple set directly from an iterator of keys.
@@ -149,10 +176,20 @@ impl<K> Set<K> {
         let b_len = b.len();
         let total = a_len.checked_mul(b_len).expect("Set::product size overflow");
 
+        let axes = match (a.axes(), b.axes()) {
+            (Some(aa), Some(bb)) => {
+                let mut v = Vec::with_capacity(aa.len() + bb.len());
+                v.extend_from_slice(aa);
+                v.extend_from_slice(bb);
+                Some(v.into_boxed_slice())
+            }
+            _ => None,
+        };
+
         // Below this size, rayon dispatch overhead may dominate, so we stay serial.
         // TODO: benchmark and tune this threshold.
         const PAR_THRESHOLD: usize = 4096;
-        if total < PAR_THRESHOLD {
+        let out: Vec<IndexTuple> = if total < PAR_THRESHOLD {
             let mut out = Vec::with_capacity(total);
             for ka in a {
                 for kb in b {
@@ -162,21 +199,25 @@ impl<K> Set<K> {
                     out.push(parts.into_boxed_slice());
                 }
             }
-            return Set::from_repr(SetRepr::Tuples(out));
-        }
+            out
+        } else {
+            let a_keys: Vec<IndexKey> = a.iter().collect();
+            let b_keys: Vec<IndexKey> = b.iter().collect();
+            (0..total)
+                .into_par_iter()
+                .map(|i| {
+                    let mut parts: Vec<IndexKey> = Vec::new();
+                    push_flat(&mut parts, a_keys[i / b_len].clone());
+                    push_flat(&mut parts, b_keys[i % b_len].clone());
+                    parts.into_boxed_slice()
+                })
+                .collect()
+        };
 
-        let a_keys: Vec<IndexKey> = a.iter().collect();
-        let b_keys: Vec<IndexKey> = b.iter().collect();
-        let out: Vec<IndexTuple> = (0..total)
-            .into_par_iter()
-            .map(|i| {
-                let mut parts: Vec<IndexKey> = Vec::new();
-                push_flat(&mut parts, a_keys[i / b_len].clone());
-                push_flat(&mut parts, b_keys[i % b_len].clone());
-                parts.into_boxed_slice()
-            })
-            .collect();
-        Set::from_repr(SetRepr::Tuples(out))
+        match axes {
+            Some(axes) => Set::from_repr_with_axes(SetRepr::Tuples(out), axes),
+            None => Set::from_repr(SetRepr::Tuples(out)),
+        }
     }
 }
 
@@ -194,7 +235,16 @@ impl Set<usize> {
     pub fn range<T: PrimInt>(r: std::ops::Range<T>) -> Self {
         let start = r.start.to_i64().expect("range start out of i64 range");
         let end = r.end.to_i64().expect("range end out of i64 range");
-        Self::from_repr(SetRepr::Range((start..end).collect()))
+        Self::dense_i64(start, end)
+    }
+
+    /// Build a dense contiguous integer set from an `i64` half-open range,
+    /// recording the single axis so the resulting [`IndexedVar`] stores densely.
+    /// Shared by [`Self::range`] and the `RangeInclusive` `IntoSet` path.
+    pub(crate) fn dense_i64(start: i64, end: i64) -> Self {
+        let vals: Vec<i64> = (start..end).collect();
+        let len = vals.len();
+        Self::from_repr_with_axes(SetRepr::Range(vals), Box::from([Axis { start, len }]))
     }
 
     /// Build an integer index set from an iterator of any primitive integer

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -101,14 +101,14 @@ where
 /// Macro-facing entry point behind [`sum_over`]. Backs the `sum!` macro. Not
 /// part of the stable public API.
 #[doc(hidden)]
-pub fn __sum_over<'a, K, D, F>(domain: &D, mut f: F) -> Expr<'a>
+pub fn __sum_over<'a, K, D, F>(domain: &D, f: F) -> Expr<'a>
 where
     D: SumDomain<K> + ?Sized,
     F: FnMut(K) -> Expr<'a>,
 {
-    let mut iter = domain.keys();
-    let first = f(iter.next().expect("sum_over on empty domain"));
-    iter.fold(first, |acc, k| acc + f(k))
+    let terms: Vec<Expr<'a>> = domain.keys().map(f).collect();
+    assert!(!terms.is_empty(), "sum_over on empty domain");
+    terms.into_iter().sum()
 }
 
 #[cfg(test)]

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -37,6 +37,35 @@ impl<K: Copy, const N: usize> SumDomain<K> for [K; N] {
     }
 }
 
+// Forward through a reference, so a domain that is itself a reference (e.g. a
+// `&Set` function parameter passed to `sum!`/`constraint!`) is accepted.
+impl<K, D: SumDomain<K> + ?Sized> SumDomain<K> for &D {
+    fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        (**self).keys()
+    }
+}
+
+// Integer ranges as sum domains. Iteration is lazy, so `sum!(x[i] for i in 0..n)` 
+// allocates nothing. Provided for the common integer types the `sum!`/`constraint!` 
+// macros default to.
+impl SumDomain<usize> for std::ops::Range<usize> {
+    fn keys(&self) -> impl Iterator<Item = usize> + '_ {
+        self.clone()
+    }
+}
+
+impl SumDomain<i64> for std::ops::Range<i64> {
+    fn keys(&self) -> impl Iterator<Item = i64> + '_ {
+        self.clone()
+    }
+}
+
+impl SumDomain<i32> for std::ops::Range<i32> {
+    fn keys(&self) -> impl Iterator<Item = i32> + '_ {
+        self.clone()
+    }
+}
+
 /// Sum an expression over every element of a domain.
 ///
 /// Reads as the mathematical `sum_{k in domain} f(k)`. The closure parameter is
@@ -48,6 +77,10 @@ impl<K: Copy, const N: usize> SumDomain<K> for [K; N] {
 /// Panics if `domain` is empty, the resulting expression has no arena to
 /// attach to.
 pub fn sum_over<'a, K, D, F>(domain: &D, mut f: F) -> Expr<'a>
+/// Macro-facing entry point behind [`sum_over`]. Backs the `sum!` macro. Not
+/// part of the stable public API.
+#[doc(hidden)]
+pub fn __sum_over<'a, K, D, F>(domain: &D, mut f: F) -> Expr<'a>
 where
     D: SumDomain<K> + ?Sized,
     F: FnMut(K) -> Expr<'a>,

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -13,7 +13,11 @@ pub trait SumDomain<K> {
     fn keys(&self) -> impl Iterator<Item = K> + '_;
 }
 
-impl<K: FromIndexKey> SumDomain<K> for Set {
+// A typed set yields exactly its own key type.
+// The single `SumDomain` impl for `Set<K>`, so `sum!`/`constraint!`
+// can infer the closure parameter without an annotation
+// (the erased `Set` defaulted to `Set<IndexKey>`).
+impl<K: FromIndexKey> SumDomain<K> for Set<K> {
     fn keys(&self) -> impl Iterator<Item = K> + '_ {
         self.iter().map(|k| K::from_index_key(&k))
     }
@@ -109,7 +113,6 @@ mod tests {
 
     use super::*;
     use crate::model::Model;
-    use crate::set::IndexKey;
 
     #[test]
     fn sum_over_scalar_set() {
@@ -153,12 +156,12 @@ mod tests {
     }
 
     #[test]
-    fn sum_over_passes_raw_index_key() {
-        let m = Model::new("rawkey");
+    fn sum_over_passes_typed_usize_key() {
+        let m = Model::new("usizekey");
         let items = Set::range(0..3);
         let x = m.indexed_var("x", &items).lb(0.0).build();
 
-        let total = sum_over(&items, |k: IndexKey| x[k]);
+        let total = sum_over(&items, |i: usize| x[i]);
         let arena = m.arena();
         let terms = extract_linear(&arena, total.id).expect("linear");
         assert_eq!(terms.coeffs.len(), 3);

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -9,6 +9,12 @@ use crate::set::{FromIndexKey, Set};
 /// Returns an iterator (rather than taking a callback) so the trait method
 /// monomorphizes through to the loop body in [`sum_over`], allowing inlining
 /// in hot sums. Implementations are typically one line.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid index domain over key type `{K}`",
+    label = "the domain's keys are not `{K}`",
+    note = "the loop/closure binding type must match the domain's keys",
+    note = "for a `Set<T>` write `for x in set` (the key type is inferred) or annotate `for x: T in set`. Integer ranges yield `usize`/`i64`/`i32`. A slice/`Vec`/array yields its element type"
+)]
 pub trait SumDomain<K> {
     fn keys(&self) -> impl Iterator<Item = K> + '_;
 }

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -76,6 +76,10 @@ impl SumDomain<i32> for std::ops::Range<i32> {
 /// # Panics
 /// Panics if `domain` is empty, the resulting expression has no arena to
 /// attach to.
+#[deprecated(
+    since = "0.3.0",
+    note = "use the `sum!` macro, the builder API is scheduled for removal in 0.4.0"
+)]
 pub fn sum_over<'a, K, D, F>(domain: &D, f: F) -> Expr<'a>
 where
     D: SumDomain<K> + ?Sized,
@@ -98,6 +102,8 @@ where
 }
 
 #[cfg(test)]
+// exercises the builder API directly until its 0.4.0 removal
+#[allow(deprecated)] 
 mod tests {
     use oximo_expr::extract_linear;
 

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -76,7 +76,14 @@ impl SumDomain<i32> for std::ops::Range<i32> {
 /// # Panics
 /// Panics if `domain` is empty, the resulting expression has no arena to
 /// attach to.
-pub fn sum_over<'a, K, D, F>(domain: &D, mut f: F) -> Expr<'a>
+pub fn sum_over<'a, K, D, F>(domain: &D, f: F) -> Expr<'a>
+where
+    D: SumDomain<K> + ?Sized,
+    F: FnMut(K) -> Expr<'a>,
+{
+    __sum_over(domain, f)
+}
+
 /// Macro-facing entry point behind [`sum_over`]. Backs the `sum!` macro. Not
 /// part of the stable public API.
 #[doc(hidden)]

--- a/crates/oximo-core/src/sum.rs
+++ b/crates/oximo-core/src/sum.rs
@@ -45,8 +45,8 @@ impl<K, D: SumDomain<K> + ?Sized> SumDomain<K> for &D {
     }
 }
 
-// Integer ranges as sum domains. Iteration is lazy, so `sum!(x[i] for i in 0..n)` 
-// allocates nothing. Provided for the common integer types the `sum!`/`constraint!` 
+// Integer ranges as sum domains. Iteration is lazy, so `sum!(x[i] for i in 0..n)`
+// allocates nothing. Provided for the common integer types the `sum!`/`constraint!`
 // macros default to.
 impl SumDomain<usize> for std::ops::Range<usize> {
     fn keys(&self) -> impl Iterator<Item = usize> + '_ {
@@ -103,7 +103,7 @@ where
 
 #[cfg(test)]
 // exercises the builder API directly until its 0.4.0 removal
-#[allow(deprecated)] 
+#[allow(deprecated)]
 mod tests {
     use oximo_expr::extract_linear;
 

--- a/crates/oximo-core/tests/dense.rs
+++ b/crates/oximo-core/tests/dense.rs
@@ -1,0 +1,119 @@
+//! Dense-storage fast path for `IndexedVar` over integer-range grids.
+//!
+//! Range / product-of-range domains store densely; string, sparse `from_ints`,
+//! and `filter`ed families stay sparse.
+
+#![allow(clippy::float_cmp)]
+
+use oximo_core::prelude::*;
+
+#[test]
+fn range_family_is_dense_1d() {
+    let m = Model::new("d1");
+    variable!(m, x[i in 0..5] >= 0.0);
+    assert!(x.is_dense());
+    assert_eq!(x.shape().as_deref(), Some(&[5usize][..]));
+    assert_eq!(x.len(), 5);
+}
+
+#[test]
+fn product_family_is_dense_2d() {
+    let m = Model::new("d2");
+    variable!(m, b[i in 0..3, n in 0..4] >= 0.0);
+    assert!(b.is_dense());
+    assert_eq!(b.shape().as_deref(), Some(&[3usize, 4][..]));
+    assert_eq!(b.len(), 12);
+
+    // The universal key path, the `at` method, and the array `Index` all resolve
+    // to the same scalar.
+    for i in 0..3 {
+        for n in 0..4 {
+            let via_key = b[(i, n)];
+            let via_at = b.at([i, n]);
+            let via_arr = b[[i, n]];
+            assert_eq!(via_key.var_id(), via_at.var_id());
+            assert_eq!(via_key.var_id(), via_arr.var_id());
+        }
+    }
+    assert!(b.get_at([3, 0]).is_none());
+    assert!(b.get_at([0, 4]).is_none());
+}
+
+#[test]
+fn range_inclusive_is_dense() {
+    let m = Model::new("dinc");
+    variable!(m, st[s in 0..2, n in 0..=3] >= 0.0);
+    assert!(st.is_dense());
+    assert_eq!(st.shape().as_deref(), Some(&[2usize, 4][..]));
+    assert_eq!(st.len(), 8);
+    assert_eq!(st[(1, 3)].var_id(), st.at([1, 3]).var_id());
+    assert!(st.get_at([0, 4]).is_none());
+}
+
+#[test]
+fn nonzero_start_offsets_correctly() {
+    let m = Model::new("dstart");
+    variable!(m, x[i in 2..5] >= 0.0);
+    assert!(x.is_dense());
+    assert_eq!(x.shape().as_deref(), Some(&[3usize][..]));
+    // Coordinates are key values: `at([2])` and key `2` hit the same scalar.
+    assert_eq!(x[2].var_id(), x.at([2]).var_id());
+    assert_eq!(x[4].var_id(), x.get_at([4]).unwrap().var_id());
+    assert!(x.get(5).is_none());
+    assert!(x.get_at([5]).is_none());
+}
+
+#[test]
+fn iter_and_keys_preserve_order_when_dense() {
+    let m = Model::new("diter");
+    variable!(m, x[i in 0..3] >= 0.0);
+    // Dense iteration is deterministic and in key order.
+    let got: Vec<i64> = x.iter().map(|(k, _)| k.as_i64().unwrap()).collect();
+    assert_eq!(got, vec![0, 1, 2]);
+    let typed: Vec<usize> = x.keys().map(|(k, _)| k).collect();
+    assert_eq!(typed, vec![0, 1, 2]);
+}
+
+#[test]
+fn string_family_is_sparse() {
+    let m = Model::new("sstr");
+    let plants = Set::strings(["a", "b", "c"]);
+    variable!(m, x[p in plants] >= 0.0);
+    assert!(!x.is_dense());
+    assert_eq!(x.shape(), None);
+    assert_eq!(x.len(), 3);
+    assert!(x.get("a").is_some());
+    assert!(x.get("z").is_none());
+}
+
+#[test]
+fn sparse_from_ints_is_not_dense() {
+    let m = Model::new("ssparse");
+    let s = Set::from_ints(vec![0usize, 2, 4]);
+    variable!(m, x[i in s] >= 0.0);
+    assert!(!x.is_dense());
+    assert_eq!(x.len(), 3);
+    assert!(x.get(0).is_some());
+    assert!(x.get(2).is_some());
+    assert!(x.get(1).is_none());
+}
+
+#[test]
+fn filtered_family_is_not_dense() {
+    let m = Model::new("sfilter");
+    variable!(m, x[i in 0..5 if i % 2 == 0] >= 0.0);
+    // Filtering breaks contiguity, so the family falls back to sparse storage.
+    assert!(!x.is_dense());
+    assert_eq!(x.shape(), None);
+    assert_eq!(x.len(), 3);
+    assert_eq!(x[0].var_id(), x.get(0).unwrap().var_id());
+    assert!(x.get(1).is_none());
+}
+
+#[test]
+#[should_panic(expected = "key not present")]
+fn dense_index_out_of_range_panics() {
+    let m = Model::new("dpanic");
+    variable!(m, b[i in 0..2, n in 0..2] >= 0.0);
+    let _ = b[(2, 0)];
+}

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -203,6 +203,70 @@ fn computed_constraint_name_in_loop() {
     assert!(m.constraint_id("_c0").is_none());
 }
 
+// --- Filtered families
+
+#[test]
+fn filtered_constraint_family_keeps_matching_keys() {
+    let m = Model::new("ffam");
+    variable!(m, x[i in 0..5] >= 0.0);
+    constraint!(m, evens[i in 0..5 if i % 2 == 0], x[i] <= 1.0);
+    assert_eq!(m.num_constraints(), 3);
+    assert!(m.constraint_id("evens[0]").is_some());
+    assert!(m.constraint_id("evens[2]").is_some());
+    assert!(m.constraint_id("evens[4]").is_some());
+    assert!(m.constraint_id("evens[1]").is_none());
+    assert!(m.constraint_id("evens[3]").is_none());
+}
+
+#[test]
+fn filtered_variable_family_only_builds_matching_keys() {
+    let m = Model::new("fvar");
+    variable!(m, x[i in 0..5 if i % 2 == 0] >= 0.0);
+    assert_eq!(m.num_variables(), 3);
+    assert_eq!(x.len(), 3);
+    objective!(m, Min, x[0] + x[2] + x[4]);
+    assert_eq!(m.kind(), ModelKind::LP);
+}
+
+#[test]
+fn filtered_tuple_family_uses_cross_index_condition() {
+    let m = Model::new("ftuple");
+    let rows = Set::range(0..3);
+    let cols = Set::range(0..3);
+    let rc = &rows * &cols;
+    variable!(m, y[(i, j) in rc] >= 0.0);
+    constraint!(m, diag[(i, j) in rc if i == j], y[i, j] <= 1.0);
+    assert_eq!(m.num_constraints(), 3);
+    assert!(m.constraint_id("diag[0,0]").is_some());
+    assert!(m.constraint_id("diag[1,1]").is_some());
+    assert!(m.constraint_id("diag[2,2]").is_some());
+    assert!(m.constraint_id("diag[0,1]").is_none());
+}
+
+#[test]
+fn filtered_family_reads_external_data() {
+    let m = Model::new("fdata");
+    let unit_of = [0_usize, 0, 1, 1, 2];
+    variable!(m, w[i in 0..5] >= 0.0);
+    constraint!(m, only_unit1[i in 0..5 if unit_of[i] == 1], w[i] <= 1.0);
+    assert_eq!(m.num_constraints(), 2);
+    assert!(m.constraint_id("only_unit1[2]").is_some());
+    assert!(m.constraint_id("only_unit1[3]").is_some());
+    assert!(m.constraint_id("only_unit1[0]").is_none());
+}
+
+#[test]
+fn filtered_string_family_drops_keys() {
+    let m = Model::new("fstr");
+    let plants = Set::strings(["a", "skip", "c"]);
+    variable!(m, x[p in plants] >= 0.0);
+    constraint!(m, keep[p in plants if p != "skip"], x[p] <= 1.0);
+    assert_eq!(m.num_constraints(), 2);
+    assert!(m.constraint_id("keep[a]").is_some());
+    assert!(m.constraint_id("keep[c]").is_some());
+    assert!(m.constraint_id("keep[skip]").is_none());
+}
+
 #[test]
 fn index_sugar_leaves_arrays_untouched() {
     let m = Model::new("arrays");

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -148,3 +148,56 @@ fn index_dependent_bound_infers_key() {
     let vars = m.variables();
     assert!((vars[2].ub - 6.0).abs() < f64::EPSILON);
 }
+
+// --- Multi-index access sugar: `q[i, j, k]` == `q[(&i, &j, &k)]`.
+
+#[test]
+fn multi_index_sugar_builds_the_family() {
+    let m = Model::new("sugar");
+    let hp = Set::strings(["H1", "H2"]);
+    let cp = Set::strings(["C1", "C2"]);
+    let st = Set::range(0..2);
+    let hcs = &(&hp * &cp) * &st;
+    variable!(m, q[(i, j, k) in hcs] >= 0.0);
+    constraint!(m, lim[(i, j, k) in hcs], q[i, j, k] <= 10.0);
+    objective!(m, Max, sum!(q[i, j, k] for (i, j, k) in hcs));
+    assert_eq!(m.num_variables(), 8);
+    assert_eq!(m.num_constraints(), 8);
+    assert!(m.constraint_id("lim[H1,C2,1]").is_some());
+}
+
+#[test]
+fn multi_index_sugar_allows_key_reuse() {
+    let m = Model::new("reuse");
+    let p = Set::strings(["a", "b"]);
+    let n = Set::range(0..2);
+    let pn = &p * &n;
+    variable!(m, s[(pp, nn) in pn] >= 0.0);
+    constraint!(m, c[(pp, nn) in pn], s[pp, nn] + s[pp, nn] <= 5.0);
+    assert_eq!(m.num_constraints(), 4);
+}
+
+#[test]
+fn multi_bind_declaration_not_mangled() {
+    let m = Model::new("multibind");
+    variable!(m, b[i in 0..2, n in 0..3] >= 0.0);
+    constraint!(m, lim[i in 0..2, n in 0..3], b[i, n] <= 1.0);
+    assert_eq!(m.num_variables(), 6);
+    assert_eq!(m.num_constraints(), 6);
+}
+
+#[test]
+fn index_sugar_leaves_arrays_untouched() {
+    let m = Model::new("arrays");
+    let cost = [3.0, 5.0];
+    let mat = [[1.0, 0.0], [0.0, 1.0]];
+    variable!(m, x[i in 0..2] >= 0.0);
+    constraint!(m, c, sum!(cost[i] * x[i] for i in 0..2) <= 100.0);
+    objective!(
+        m,
+        Max,
+        sum!(mat[i][j] * x[i] for i in 0..2, j in 0..2) + sum!([3.0, 5.0][i] * x[i] for i in 0..2)
+    );
+    assert_eq!(m.num_variables(), 2);
+    assert_eq!(m.num_constraints(), 1);
+}

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -85,6 +85,36 @@ fn filtered_sum_skips_nonmatching_keys() {
 }
 
 #[test]
+fn large_sum_builds_correctly() {
+    const N: usize = 2000;
+    let m = Model::new("bigsum");
+    let c: Vec<f64> = (0..N).map(|i| [1.0, 2.0, 3.0, 4.0, 5.0][i % 5]).collect();
+    variable!(m, x[i in 0..N] >= 0.0);
+    objective!(m, Min, sum!(c[i] * x[i] for i in 0..N));
+
+    let arena = m.arena();
+    let obj = m.try_objective().unwrap();
+    let terms = oximo_expr::extract_linear(&arena, obj.expr).expect("linear");
+    assert_eq!(terms.coeffs.len(), N);
+    let total: f64 = terms.coeffs.iter().map(|(_, v)| v).sum();
+    let expected: f64 = c.iter().sum();
+    assert!((total - expected).abs() < 1e-6);
+}
+
+#[test]
+fn large_filtered_sum_builds_correctly() {
+    const N: usize = 1000;
+    let m = Model::new("bigfilter");
+    variable!(m, x[i in 0..N] >= 0.0);
+    objective!(m, Max, sum!(x[i] for i in 0..N if i % 2 == 0));
+
+    let arena = m.arena();
+    let obj = m.try_objective().unwrap();
+    let terms = oximo_expr::extract_linear(&arena, obj.expr).expect("linear");
+    assert_eq!(terms.coeffs.len(), N / 2);
+}
+
+#[test]
 fn param_handle_keeps_model_linear() {
     let m = Model::new("param");
     param!(m, rate = 0.05);

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -186,6 +186,26 @@ fn computed_name_range_suffixes_both_rows() {
 }
 
 #[test]
+fn semicontinuous_domain_sets_threshold() {
+    let m = Model::new("semi");
+    variable!(m, x <= 10.0, SemiCont(2.0));
+    objective!(m, Min, x);
+    let vars = m.variables();
+    assert_eq!(vars[0].domain, Domain::SemiContinuous { threshold: 2.0 });
+    assert!((vars[0].ub - 10.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn semi_integer_domain_sets_threshold() {
+    let m = Model::new("semii");
+    variable!(m, y <= 5.0, SemiInteger(1.0));
+    objective!(m, Min, y);
+    let vars = m.variables();
+    assert_eq!(vars[0].domain, Domain::SemiInteger { threshold: 1.0 });
+    assert!(vars[0].domain.is_integer());
+}
+
+#[test]
 fn param_handle_keeps_model_linear() {
     let m = Model::new("param");
     param!(m, rate = 0.05);

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -114,6 +114,77 @@ fn large_filtered_sum_builds_correctly() {
     assert_eq!(terms.coeffs.len(), N / 2);
 }
 
+// --- Two-sided range constraints: `lo <= e <= hi` lowers to `_lo` + `_hi` rows.
+
+#[test]
+fn range_constraint_lowers_to_two_rows() {
+    let m = Model::new("range");
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    constraint!(m, band, 1.0 <= x + y <= 3.0);
+
+    assert_eq!(m.num_constraints(), 2);
+    let cons = m.constraints();
+    let lo = &cons[m.constraint_id("band_lo").expect("lo row").index()];
+    let hi = &cons[m.constraint_id("band_hi").expect("hi row").index()];
+    assert_eq!(lo.sense, Sense::Ge);
+    assert!((lo.rhs - 1.0).abs() < f64::EPSILON);
+    assert_eq!(hi.sense, Sense::Le);
+    assert!((hi.rhs - 3.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn range_constraint_ge_form_is_equivalent() {
+    let m = Model::new("rangege");
+    variable!(m, x >= 0.0);
+    constraint!(m, b, 3.0 >= x >= 1.0);
+
+    let cons = m.constraints();
+    let lo = &cons[m.constraint_id("b_lo").unwrap().index()];
+    let hi = &cons[m.constraint_id("b_hi").unwrap().index()];
+    assert_eq!(lo.sense, Sense::Ge);
+    assert!((lo.rhs - 1.0).abs() < f64::EPSILON);
+    assert_eq!(hi.sense, Sense::Le);
+    assert!((hi.rhs - 3.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn anonymous_range_makes_two_auto_rows() {
+    let m = Model::new("anonr");
+    variable!(m, x >= 0.0);
+    constraint!(m, 0.0 <= x <= 5.0);
+    assert_eq!(m.num_constraints(), 2);
+    assert!(m.constraint_id("_c0").is_some());
+    assert!(m.constraint_id("_c1").is_some());
+}
+
+#[test]
+fn family_range_makes_two_rows_per_element() {
+    let m = Model::new("famr");
+    let lo = [1.0, 2.0, 3.0];
+    let hi = [4.0, 5.0, 6.0];
+    variable!(m, x[i in 0..3] >= 0.0);
+    constraint!(m, cap[i in 0..3], lo[i] <= x[i] <= hi[i]);
+
+    assert_eq!(m.num_constraints(), 6);
+    assert!(m.constraint_id("cap_lo[0]").is_some());
+    assert!(m.constraint_id("cap_hi[2]").is_some());
+    let cons = m.constraints();
+    let c = &cons[m.constraint_id("cap_lo[1]").unwrap().index()];
+    assert_eq!(c.sense, Sense::Ge);
+    assert!((c.rhs - 2.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn computed_name_range_suffixes_both_rows() {
+    let m = Model::new("crange");
+    variable!(m, x >= 0.0);
+    let tag = "band";
+    constraint!(m, name = format!("{tag}"), 1.0 <= x <= 2.0);
+    assert!(m.constraint_id("band_lo").is_some());
+    assert!(m.constraint_id("band_hi").is_some());
+}
+
 #[test]
 fn param_handle_keeps_model_linear() {
     let m = Model::new("param");

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -94,3 +94,57 @@ fn param_handle_keeps_model_linear() {
     assert_eq!(m.kind(), ModelKind::LP);
     assert!((m.param_value_of(rate).unwrap() - 0.05).abs() < f64::EPSILON);
 }
+
+#[test]
+fn infers_string_key_without_annotation() {
+    let m = Model::new("strkey");
+    let plants = Set::strings(["a", "b", "c"]);
+    variable!(m, x[p in plants] >= 0.0);
+    constraint!(m, total, sum!(x[p] for p in plants) <= 1.0);
+    objective!(m, Max, sum!(x[p] for p in plants));
+    assert_eq!(m.num_variables(), 3);
+    assert_eq!(m.kind(), ModelKind::LP);
+}
+
+#[test]
+fn infers_tuple_key_without_annotation() {
+    let m = Model::new("tuplekey");
+    let plants = Set::strings(["p1", "p2"]);
+    let times = Set::range(0..3); // Set<usize>
+    let pt = &plants * &times; // Set<(String, usize)>
+    variable!(m, b[(p, t) in pt] >= 0.0);
+    constraint!(m, lim[(p, t) in pt], b[(p, t)] <= 10.0);
+    assert_eq!(m.num_variables(), 6);
+    assert_eq!(m.num_constraints(), 6);
+}
+
+#[test]
+fn range_literal_defaults_usize_for_array_index() {
+    let m = Model::new("arr");
+    let cost = [1.0, 2.0, 3.0];
+    variable!(m, x[i in 0..3] >= 0.0);
+    // `i` defaults to usize, so it can index `cost` directly.
+    objective!(m, Min, sum!(cost[i] * x[i] for i in 0..3));
+    assert_eq!(m.num_variables(), 3);
+}
+
+#[test]
+fn named_integer_set_infers_usize() {
+    let m = Model::new("intset");
+    let days = Set::range(0..4); // Set<usize>
+    let demand = [5.0, 3.0, 8.0, 2.0];
+    variable!(m, y[d in days] >= 0.0);
+    constraint!(m, meet[d in days], y[d] >= demand[d]);
+    assert_eq!(m.num_constraints(), 4);
+}
+
+#[test]
+fn index_dependent_bound_infers_key() {
+    let m = Model::new("bound");
+    let items = Set::range(0..3);
+    let cap = [2.0, 4.0, 6.0];
+    variable!(m, 0.0 <= w[i in items] <= cap[i]);
+    assert_eq!(w.len(), 3);
+    let vars = m.variables();
+    assert!((vars[2].ub - 6.0).abs() < f64::EPSILON);
+}

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -187,6 +187,23 @@ fn multi_bind_declaration_not_mangled() {
 }
 
 #[test]
+fn computed_constraint_name_in_loop() {
+    let m = Model::new("named_loop");
+    let labels = ["a", "b", "c"];
+    variable!(m, x[i in 0..3] >= 0.0);
+    for (i, nm) in labels.iter().enumerate() {
+        constraint!(m, name = format!("cap_{nm}"), x[i] <= 1.0);
+    }
+    constraint!(m, name = "fixed", x[0] >= 0.0);
+
+    assert_eq!(m.num_constraints(), 4);
+    assert!(m.constraint_id("cap_a").is_some());
+    assert!(m.constraint_id("cap_c").is_some());
+    assert!(m.constraint_id("fixed").is_some());
+    assert!(m.constraint_id("_c0").is_none());
+}
+
+#[test]
 fn index_sugar_leaves_arrays_untouched() {
     let m = Model::new("arrays");
     let cost = [3.0, 5.0];

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -206,6 +206,53 @@ fn semi_integer_domain_sets_threshold() {
 }
 
 #[test]
+fn domain_aliases_map_correctly() {
+    let m = Model::new("aliases");
+    variable!(m, va, Bin);
+    variable!(m, vb, Binary);
+    variable!(m, vc, Int);
+    variable!(m, vd, Integer);
+    variable!(m, ve, Real);
+    variable!(m, vf, Cont);
+    variable!(m, vg, Continuous);
+    objective!(m, Min, va + vb + vc + vd + ve + vf + vg);
+
+    let v = m.variables();
+    assert_eq!(v[0].domain, Domain::Binary);
+    assert_eq!(v[1].domain, Domain::Binary);
+    assert_eq!(v[2].domain, Domain::Integer);
+    assert_eq!(v[3].domain, Domain::Integer);
+    assert_eq!(v[4].domain, Domain::Real);
+    assert_eq!(v[5].domain, Domain::Real);
+    assert_eq!(v[6].domain, Domain::Real);
+}
+
+#[test]
+fn objective_sense_aliases_map_correctly() {
+    use ObjectiveSense::{Maximize, Minimize};
+
+    let m = Model::new("o_min_long");
+    variable!(m, x >= 0.0);
+    objective!(m, Minimize, x);
+    assert_eq!(m.objective().as_ref().unwrap().sense, Minimize);
+
+    let m = Model::new("o_min_lower");
+    variable!(m, x >= 0.0);
+    objective!(m, min, x);
+    assert_eq!(m.objective().as_ref().unwrap().sense, Minimize);
+
+    let m = Model::new("o_max_long");
+    variable!(m, x >= 0.0);
+    objective!(m, Maximize, x);
+    assert_eq!(m.objective().as_ref().unwrap().sense, Maximize);
+
+    let m = Model::new("o_max_lower");
+    variable!(m, x >= 0.0);
+    objective!(m, max, x);
+    assert_eq!(m.objective().as_ref().unwrap().sense, Maximize);
+}
+
+#[test]
 fn param_handle_keeps_model_linear() {
     let m = Model::new("param");
     param!(m, rate = 0.05);

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -1,0 +1,96 @@
+//! End-to-end checks that the macros expand to the same model the
+//! builder API would produce.
+
+use oximo_core::prelude::*;
+
+#[test]
+fn scalar_variables_bounds_and_objective() {
+    let m = Model::new("scalar");
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 10.0);
+    variable!(m, z, Bin);
+
+    constraint!(m, cap, x + y + z <= 10.0);
+    objective!(m, Max, x + 2.0 * y);
+
+    assert_eq!(m.num_variables(), 3);
+    assert_eq!(m.num_constraints(), 1);
+    assert_eq!(m.kind(), ModelKind::MILP);
+}
+
+#[test]
+fn variable_bounds_apply() {
+    let m = Model::new("bounds");
+    variable!(m, 1.5 <= x <= 4.0);
+    objective!(m, Min, x);
+    let vars = m.variables();
+    let v = &vars[0];
+    assert!((v.lb - 1.5).abs() < f64::EPSILON);
+    assert!((v.ub - 4.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn indexed_variable_sum_and_family() {
+    let m = Model::new("indexed");
+    let assets = Set::range(0..3);
+    variable!(m, 0.0 <= w[i in assets] <= 1.0);
+
+    constraint!(m, budget, sum!(w[i] for i in assets) == 1);
+    constraint!(m, ub[i in 0..3], w[i] <= 1.0);
+    objective!(m, Min, sum!(w[i] for i in assets));
+
+    assert_eq!(m.num_variables(), 3);
+    assert_eq!(m.num_constraints(), 1 + 3);
+    assert_eq!(m.kind(), ModelKind::LP);
+    assert!(m.constraint_id("budget").is_some());
+    assert!(m.constraint_id("ub[0]").is_some());
+    assert!(m.constraint_id("ub[2]").is_some());
+}
+
+#[test]
+fn anonymous_constraints_are_auto_named() {
+    let m = Model::new("anon");
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    constraint!(m, x + y >= 1.0);
+    constraint!(m, x - y <= 2.0);
+    assert_eq!(m.num_constraints(), 2);
+    assert!(m.constraint_id("_c0").is_some());
+    assert!(m.constraint_id("_c1").is_some());
+}
+
+#[test]
+fn nested_sum_is_quadratic() {
+    let m = Model::new("qp");
+    let n = Set::range(0..2);
+    let sigma = [[1.0, 0.2], [0.2, 1.0]];
+    variable!(m, w[i in n] >= 0.0);
+    constraint!(m, budget, sum!(w[i] for i in n) == 1);
+    objective!(m, Min, sum!(sigma[i][j] * w[i] * w[j] for i in n, j in n));
+    assert_eq!(m.kind(), ModelKind::QP);
+}
+
+#[test]
+fn filtered_sum_skips_nonmatching_keys() {
+    let m = Model::new("filter");
+    let items = Set::range(0..5);
+    variable!(m, x[i in items] >= 0.0);
+    objective!(m, Max, sum!(x[i] for i in items if i % 2 == 0));
+    constraint!(m, evens, sum!(x[i] for i in items if i % 2 == 0) <= 3.0);
+
+    let arena = m.arena();
+    let obj = m.try_objective().unwrap();
+    let terms = oximo_expr::extract_linear(&arena, obj.expr).expect("linear");
+    assert_eq!(terms.coeffs.len(), 3);
+}
+
+#[test]
+fn param_handle_keeps_model_linear() {
+    let m = Model::new("param");
+    param!(m, rate = 0.05);
+    variable!(m, x >= 0.0);
+    constraint!(m, c, rate * x <= 1.0);
+    objective!(m, Max, rate * x);
+    assert_eq!(m.kind(), ModelKind::LP);
+    assert!((m.param_value_of(rate).unwrap() - 0.05).abs() < f64::EPSILON);
+}

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -5,74 +5,75 @@ use oximo_core::prelude::*;
 #[test]
 fn classifies_lp() {
     let m = Model::new("lp");
-    let x = m.var("x").lb(0.0).build();
-    m.constraint("c", x.le(10.0));
-    m.minimize(x);
+    variable!(m, x >= 0.0);
+    constraint!(m, c, x <= 10.0);
+    objective!(m, Min, x);
     assert_eq!(m.kind(), ModelKind::LP);
 }
 
 #[test]
 fn classifies_milp() {
     let m = Model::new("milp");
-    let x = m.var("x").lb(0.0).ub(1.0).integer().build();
-    m.constraint("c", x.le(1.0));
-    m.minimize(x);
+    variable!(m, 0.0 <= x <= 1.0, Int);
+    constraint!(m, c, x <= 1.0);
+    objective!(m, Min, x);
     assert_eq!(m.kind(), ModelKind::MILP);
 }
 
 #[test]
 fn classifies_qp() {
     let m = Model::new("qp");
-    let x = m.var("x").lb(0.0).build();
-    m.minimize(x.powi(2));
+    variable!(m, x >= 0.0);
+    objective!(m, Min, x.powi(2));
     assert_eq!(m.kind(), ModelKind::QP);
 }
 
 #[test]
 fn classifies_miqp() {
     let m = Model::new("miqp");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(1.0).integer().build();
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 1.0, Int);
     // Bilinear term keeps it quadratic, the integer var makes QP -> MIQP.
-    m.minimize(x * y);
+    objective!(m, Min, x * y);
     assert_eq!(m.kind(), ModelKind::MIQP);
 }
 
 #[test]
 fn quadratic_constraint_classifies_qp() {
     let m = Model::new("qp_con");
-    let x = m.var("x").lb(0.0).build();
+    variable!(m, x >= 0.0);
     // Linear objective but a quadratic constraint still makes the model a QP.
-    m.constraint("c", x.powi(2).le(4.0));
-    m.minimize(x);
+    constraint!(m, c, x.powi(2) <= 4.0);
+    objective!(m, Min, x);
     assert_eq!(m.kind(), ModelKind::QP);
 }
 
 #[test]
 fn classifies_nlp() {
     let m = Model::new("nlp");
-    let x = m.var("x").lb(0.0).build();
+    variable!(m, x >= 0.0);
     // Degree-3, so it falls through to the nonlinear path.
-    m.minimize(x.powi(3));
+    objective!(m, Min, x.powi(3));
     assert_eq!(m.kind(), ModelKind::NLP);
 }
 
 #[test]
 fn classifies_minlp_with_division() {
     let m = Model::new("minlp_div");
-    let x = m.var("x").lb(1.0).build();
-    let y = m.var("y").lb(0.0).ub(1.0).integer().build();
+    variable!(m, x >= 1.0);
+    variable!(m, 0.0 <= y <= 1.0, Int);
     // x / y is nonlinear (non-constant denominator)
-    m.minimize(x / y);
+    objective!(m, Min, x / y);
     assert_eq!(m.kind(), ModelKind::MINLP);
 }
 
 #[test]
 fn variable_count_matches_register() {
     let m = Model::new("vars");
-    let _ = m.var("x").build();
-    let _ = m.var("y").build();
-    let _ = m.var("z").build();
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, z);
+    let _ = (x, y, z);
     assert_eq!(m.num_variables(), 3);
 }
 
@@ -80,7 +81,7 @@ fn variable_count_matches_register() {
 fn indexed_var_creates_named_scalars() {
     let m = Model::new("net");
     let nodes = Set::range(0..3);
-    let flow = m.indexed_var("flow", &nodes).lb(0.0).build();
+    variable!(m, flow[i in nodes] >= 0.0);
     assert_eq!(flow.len(), 3);
     assert!(m.variable_id("flow[0]").is_some());
     assert!(m.variable_id("flow[2]").is_some());
@@ -89,23 +90,25 @@ fn indexed_var_creates_named_scalars() {
 #[test]
 fn kind_caches_and_invalidates() {
     let m = Model::new("cache");
-    let x = m.var("x").lb(0.0).build();
-    m.minimize(x);
+    variable!(m, x >= 0.0);
+    objective!(m, Min, x);
     // First call computes, second call must return same value without traversal
     assert_eq!(m.kind(), ModelKind::LP);
     assert_eq!(m.kind(), ModelKind::LP);
     // Adding an integer variable invalidates the cache
-    let _ = m.var("y").lb(0.0).integer().build();
+    variable!(m, y >= 0.0, Int);
+    let _ = y;
     assert_eq!(m.kind(), ModelKind::MILP);
     // Adding a constraint invalidates again
-    m.constraint("c", x.le(10.0));
+    constraint!(m, c, x <= 10.0);
     assert_eq!(m.kind(), ModelKind::MILP);
 }
 
 #[test]
-fn fix_builder_sets_equal_bounds() {
+fn fix_sets_equal_bounds() {
     let m = Model::new("fix_builder");
-    let _ = m.var("x").lb(0.0).ub(10.0).fix(3.5).build();
+    variable!(m, 0.0 <= x <= 10.0);
+    m.fix(x, 3.5);
     let vars = m.variables();
     assert_eq!(vars[0].lb, 3.5);
     assert_eq!(vars[0].ub, 3.5);
@@ -114,7 +117,8 @@ fn fix_builder_sets_equal_bounds() {
 #[test]
 fn fix_var_mutates_bounds_post_build() {
     let m = Model::new("fix_post");
-    let _ = m.var("x").lb(0.0).ub(10.0).build();
+    variable!(m, 0.0 <= x <= 10.0);
+    let _ = x;
     let id = m.variable_id("x").unwrap();
     m.fix_var(id, 7.0);
     let vars = m.variables();
@@ -125,7 +129,7 @@ fn fix_var_mutates_bounds_post_build() {
 #[test]
 fn fix_pins_var_expr_and_indexed_entry() {
     let m = Model::new("fix_expr");
-    let x = m.var("x").lb(0.0).ub(10.0).build();
+    variable!(m, 0.0 <= x <= 10.0);
     m.fix(x, 3.0);
     let xid = m.variable_id("x").unwrap();
     let vars = m.variables();
@@ -134,7 +138,7 @@ fn fix_pins_var_expr_and_indexed_entry() {
     drop(vars);
 
     let keys = Set::strings(["a", "b"]);
-    let w = m.indexed_var("w", &keys).binary().build();
+    variable!(m, w[k in keys], Bin);
     m.fix(w["a"], 1.0);
     let aid = m.variable_id("w[a]").unwrap();
     let vars = m.variables();
@@ -145,8 +149,8 @@ fn fix_pins_var_expr_and_indexed_entry() {
 #[test]
 fn var_id_is_none_for_compound_expr() {
     let m = Model::new("var_id");
-    let x = m.var("x").build();
-    let y = m.var("y").build();
+    variable!(m, x);
+    variable!(m, y);
     assert!(x.var_id().is_some());
     assert!((x + 1.0).var_id().is_none());
     assert!((x + y).var_id().is_none());
@@ -156,7 +160,8 @@ fn var_id_is_none_for_compound_expr() {
 #[test]
 fn unfix_var_restores_bounds() {
     let m = Model::new("unfix");
-    let _ = m.var("x").lb(0.0).ub(10.0).build();
+    variable!(m, 0.0 <= x <= 10.0);
+    let _ = x;
     let id = m.variable_id("x").unwrap();
     m.fix_var(id, 7.0);
     m.unfix_var(id, 0.0, 10.0);
@@ -168,8 +173,10 @@ fn unfix_var_restores_bounds() {
 #[test]
 fn initial_value_stored_on_variable() {
     let m = Model::new("init");
-    let _ = m.var("x").lb(0.0).initial(3.5).build();
-    let _ = m.var("y").lb(0.0).build();
+    variable!(m, x >= 0.0);
+    m.set_initial(x, 3.5);
+    variable!(m, y >= 0.0);
+    let _ = y;
     let vars = m.variables();
     assert_eq!(vars[0].initial, Some(3.5));
     assert_eq!(vars[1].initial, None);
@@ -179,10 +186,10 @@ fn initial_value_stored_on_variable() {
 fn rhs_expr_folded_into_lhs() {
     use oximo_expr::extract_linear;
     let m = Model::new("rhs");
-    let x = m.var("x").build();
-    let y = m.var("y").build();
+    variable!(m, x);
+    variable!(m, y);
     // x <= y + 3   ↦  canonical: (x - y - 3) <= 0
-    m.constraint("c", x.le(y + 3.0));
+    constraint!(m, c, x <= y + 3.0);
     let cs = m.constraints();
     assert_eq!(cs.len(), 1);
     assert_eq!(cs[0].rhs, 0.0);

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -121,6 +121,20 @@ fn tuple_key_from_pair_literal() {
 }
 
 #[test]
+fn ref_keys_convert_for_index_sugar() {
+    let p: String = "P1".into();
+    let s: &str = "C2";
+    let n: usize = 3;
+    let k: IndexKey = (&p, &s, &n).into();
+    let parts = k.as_tuple().unwrap();
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[0].as_str(), Some("P1"));
+    assert_eq!(parts[1].as_str(), Some("C2"));
+    assert_eq!(parts[2].as_i64(), Some(3));
+    assert_eq!(p, "P1");
+}
+
+#[test]
 fn indexed_var_over_product_creates_named_scalars() {
     let m = Model::new("net");
     let plants = Set::strings(["seattle", "san-diego"]);

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -132,6 +132,10 @@ fn ref_keys_convert_for_index_sugar() {
     assert_eq!(parts[1].as_str(), Some("C2"));
     assert_eq!(parts[2].as_i64(), Some(3));
     assert_eq!(p, "P1");
+
+    let pref: &String = &p;
+    let k2: IndexKey = (&pref, &n).into();
+    assert_eq!(k2.as_tuple().unwrap()[0].as_str(), Some("P1"));
 }
 
 #[test]

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::float_cmp)]
+// builder API exercised in tests until its 0.4.0 removal
+#![allow(deprecated)]
 
 use oximo_core::prelude::*;
 

--- a/crates/oximo-core/tests/set.rs
+++ b/crates/oximo-core/tests/set.rs
@@ -84,7 +84,7 @@ fn product_flattens_nested_tuples() {
 #[test]
 fn filter_keeps_variant_for_range() {
     let s = Set::range(0..10).filter(|k| k.as_i64().unwrap() % 2 == 0);
-    assert!(matches!(s, Set::Range(_)));
+    assert!(s.is_range());
     assert_eq!(s.len(), 5);
 }
 
@@ -96,7 +96,7 @@ fn filter_keeps_variant_for_tuples() {
         let p = k.as_tuple().unwrap();
         p[0].as_i64() != p[1].as_i64()
     });
-    assert!(matches!(filtered, Set::Tuples(_)));
+    assert!(filtered.is_tuples());
     assert_eq!(filtered.len(), 6);
 }
 
@@ -138,7 +138,7 @@ fn indexed_var_per_key_bounds() {
     let _x = m
         .indexed_var("x", &set)
         .lb(0.0)
-        .ub_by(|k: i64| {
+        .ub_by(|k: usize| {
             #[allow(clippy::cast_precision_loss)]
             {
                 k as f64
@@ -184,18 +184,18 @@ fn add_constraints_over_tuple_set_typed_closure() {
     let cols = Set::strings(["a", "b"]);
     let ij = &rows * &cols;
     let x = m.indexed_var("x", &ij).lb(0.0).build();
-    m.add_constraints_over("c", &ij, |(i, j): (i64, String)| x[(i, j)].le(5.0));
+    m.add_constraints_over("c", &ij, |(i, j): (usize, String)| x[(i, j)].le(5.0));
     assert_eq!(m.num_constraints(), 4);
     assert!(m.constraint_id("c[0,a]").is_some());
     assert!(m.constraint_id("c[1,b]").is_some());
 }
 
 #[test]
-fn add_constraints_over_raw_key_escape_hatch() {
-    let m = Model::new("rule_raw");
+fn add_constraints_over_indexes_by_value() {
+    let m = Model::new("rule_val");
     let set = Set::range(0..2);
     let x = m.indexed_var("x", &set).lb(0.0).build();
-    m.add_constraints_over("c", &set, |k: IndexKey| x[&k].le(1.0));
+    m.add_constraints_over("c", &set, |i: usize| x[i].le(1.0));
     assert_eq!(m.num_constraints(), 2);
 }
 
@@ -239,8 +239,8 @@ fn lb_by_ub_by_override_binary_defaults() {
     let _x = m
         .indexed_var("x", &set)
         .binary()
-        .lb_by(|k: i64| if k == 0 { 1.0 } else { 0.0 })
-        .ub_by(|k: i64| if k == 2 { 0.0 } else { 1.0 })
+        .lb_by(|k: usize| if k == 0 { 1.0 } else { 0.0 })
+        .ub_by(|k: usize| if k == 2 { 0.0 } else { 1.0 })
         .build();
     let vars = m.variables();
     assert_eq!(vars[0].lb, 1.0); // fixed to 1

--- a/crates/oximo-expr/README.md
+++ b/crates/oximo-expr/README.md
@@ -81,7 +81,8 @@ use oximo_expr::dot;
 let total = dot(&vars, &coeffs);
 ```
 
-For sums indexed by an `oximo-core` `Set`, prefer `oximo_core::sum_over`.
+For sums indexed by an `oximo-core` `Set`, prefer the `sum!` macro (re-exported by
+`oximo-core` / `oximo::prelude`).
 
 ### `extract_linear`
 

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -99,6 +99,20 @@ pub(crate) fn add_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
     arena.push(ExprNode::Add(smallvec![lhs, rhs]))
 }
 
+/// Build a flat n-ary sum of `ids` as a single `Add` node.
+/// `as_linear`/`split_linear` collapse the resulting `Add`
+/// in one pass at extraction, so the linear fast-path is preserved.
+///
+/// # Panics
+/// Panics if `ids` is empty (callers supply at least one term).
+pub(crate) fn add_n(arena: &mut ExprArena, ids: &[ExprId]) -> ExprId {
+    match ids {
+        [] => panic!("add_n on an empty term list"),
+        [one] => *one,
+        _ => arena.push(ExprNode::Add(ids.iter().copied().collect())),
+    }
+}
+
 /// Build `lhs - rhs`. Same linear fast-path as `add_into`.
 pub(crate) fn sub_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
     let neg = neg_into(arena, rhs);

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -1,7 +1,8 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
+use crate::arena::ExprId;
 use crate::handle::Expr;
-use crate::linear::{add_into, div_into, mul_into, neg_into, sub_into};
+use crate::linear::{add_into, add_n, div_into, mul_into, neg_into, sub_into};
 
 // -----------------------------------------------------------------------------
 // Expr <op> Expr
@@ -147,13 +148,16 @@ impl_scalar_ops!(i32, f64::from);
 
 // -----------------------------------------------------------------------------
 // std::iter::Sum: the first element of the iterator carries the arena handle,
-// so no external zero is required.
+// so no external zero is required. Collected into a single flat n-ary `Add`.
 // -----------------------------------------------------------------------------
 
 impl<'a> std::iter::Sum for Expr<'a> {
-    fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
-        let first = iter.next().expect("Expr::sum on empty iterator");
-        iter.fold(first, |acc, e| acc + e)
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        let items: Vec<Self> = iter.collect();
+        let first = *items.first().expect("Expr::sum on empty iterator");
+        let ids: Vec<ExprId> = items.iter().map(|e| e.id).collect();
+        let id = add_n(&mut first.arena.borrow_mut(), &ids);
+        Self::new(id, first.arena)
     }
 }
 

--- a/crates/oximo-gams/README.md
+++ b/crates/oximo-gams/README.md
@@ -46,13 +46,13 @@ use oximo::prelude::*;
 use oximo::solvers::Gams;
 
 let m = Model::new("transport");
-let x = m.var("x").lb(0.0).build();
-let y = m.var("y").lb(0.0).ub(4.0).build();
+variable!(m, x >= 0.0);
+variable!(m, 0.0 <= y <= 4.0);
 
-m.constraint("c1", (x + 2.0 * y).le(14.0));
-m.constraint("c2", (3.0 * x - y).ge(0.0));
-m.constraint("c3", (x - y).le(2.0));
-m.maximize(3.0 * x + 4.0 * y);
+constraint!(m, c1, x + 2.0 * y <= 14.0);
+constraint!(m, c2, 3.0 * x - y >= 0.0);
+constraint!(m, c3, x - y <= 2.0);
+objective!(m, Max, 3.0 * x + 4.0 * y);
 
 let result = Gams::new().solve(&m, &GamsOptions::default())?;
 println!("status = {:?}", result.status);

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -913,10 +913,10 @@ mod tests {
     #[test]
     fn linear_objective_uses_lp_solve_type() {
         let m = Model::new("lp");
-        let x = m.var("x").lb(0.0).ub(10.0).build();
-        let y = m.var("y").lb(0.0).ub(10.0).build();
-        m.constraint("c", (x + y).le(5.0));
-        m.minimize(x + 2.0 * y);
+        variable!(m, 0.0 <= x <= 10.0);
+        variable!(m, 0.0 <= y <= 10.0);
+        constraint!(m, c, x + y <= 5.0);
+        objective!(m, Min, x + 2.0 * y);
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using LP minimizing v_obj;"), "got:\n{gms}");
     }
@@ -924,8 +924,8 @@ mod tests {
     #[test]
     fn nlp_uses_transcendental_and_picks_nlp_solve_type() {
         let m = Model::new("nlp");
-        let x = m.var("x").lb(-std::f64::consts::PI).ub(std::f64::consts::PI).build();
-        m.minimize(x.sin() + x.exp());
+        variable!(m, -std::f64::consts::PI <= x <= std::f64::consts::PI);
+        objective!(m, Min, x.sin() + x.exp());
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using NLP minimizing v_obj;"), "got:\n{gms}");
         assert!(gms.contains("sin("), "expected sin(...) in objective:\n{gms}");
@@ -935,8 +935,8 @@ mod tests {
     #[test]
     fn abs_objective_emits_abs_func() {
         let m = Model::new("absnlp");
-        let x = m.var("x").lb(-5.0).ub(5.0).build();
-        m.minimize(x.abs());
+        variable!(m, -5.0 <= x <= 5.0);
+        objective!(m, Min, x.abs());
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using NLP minimizing v_obj;"), "got:\n{gms}");
         assert!(gms.contains("abs("), "expected abs(...) in objective:\n{gms}");
@@ -945,11 +945,10 @@ mod tests {
     #[test]
     fn minlp_nonlinear_knapsack_routes_to_minlp_solve_type() {
         let m = Model::new("minlp");
-        let x = m.var("x").binary().build();
-        let y = m.var("y").lb(0.0).ub(10.0).build();
-        m.constraint("budget", (x + y).le(8.0));
-        let one = Expr::constant(x.arena, 1.0);
-        m.maximize((one + y).log() + 2.0 * x);
+        variable!(m, x, Bin);
+        variable!(m, 0.0 <= y <= 10.0);
+        constraint!(m, budget, x + y <= 8.0);
+        objective!(m, Max, (1.0 + y).log() + 2.0 * x);
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using MINLP maximizing v_obj;"), "got:\n{gms}");
         assert!(gms.contains("log("), "expected log(...) in objective:\n{gms}");
@@ -958,10 +957,10 @@ mod tests {
     #[test]
     fn quadratic_constraint_emits_full_expression_against_rhs() {
         let m = Model::new("qcp");
-        let x = m.var("x").lb(0.0).ub(5.0).build();
-        let y = m.var("y").lb(0.0).ub(5.0).build();
-        m.constraint("xy", (x * y).le(4.0));
-        m.minimize(x + y);
+        variable!(m, 0.0 <= x <= 5.0);
+        variable!(m, 0.0 <= y <= 5.0);
+        constraint!(m, xy, x * y <= 4.0);
+        objective!(m, Min, x + y);
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using QCP minimizing v_obj;"), "got:\n{gms}");
         // The product term must appear on the LHS, the user RHS untouched.
@@ -972,8 +971,8 @@ mod tests {
     #[test]
     fn integer_power_uses_power_func() {
         let m = Model::new("pow");
-        let x = m.var("x").lb(-10.0).ub(10.0).build();
-        m.minimize(x.powi(3));
+        variable!(m, -10.0 <= x <= 10.0);
+        objective!(m, Min, x.powi(3));
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("power("), "expected power(...) for int Pow:\n{gms}");
         assert!(gms.contains(", 3)"), "expected exponent 3:\n{gms}");
@@ -983,8 +982,8 @@ mod tests {
     #[test]
     fn real_power_falls_back_to_double_star() {
         let m = Model::new("rpow");
-        let x = m.var("x").lb(0.1).ub(10.0).build();
-        m.minimize(x.powf(0.5));
+        variable!(m, 0.1 <= x <= 10.0);
+        objective!(m, Min, x.powf(0.5));
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains(" **"), "expected ** for real Pow:\n{gms}");
     }

--- a/crates/oximo-gurobi/README.md
+++ b/crates/oximo-gurobi/README.md
@@ -56,9 +56,9 @@ let m = Model::new("knapsack");
 let weights = [3.0, 4.0, 2.0, 5.0];
 let values  = [10.0, 12.0, 5.0, 14.0];
 
-let xs: Vec<_> = (0..4).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-m.constraint("cap", dot(&xs, &weights).le(7.0));
-m.maximize(dot(&xs, &values));
+variable!(m, x[i in 0..4], Bin);
+constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..4) <= 7.0);
+objective!(m, Max, sum!(values[i] * x[i] for i in 0..4));
 
 let result = Gurobi.solve(&m, &GurobiOptions::default())?;
 println!("status = {:?}", result.status);

--- a/crates/oximo-gurobi/tests/nonlinear.rs
+++ b/crates/oximo-gurobi/tests/nonlinear.rs
@@ -21,10 +21,10 @@ fn qp_min_sum_of_squares() {
     // min x^2 + y^2 s.t. x + y >= 1.
     // Optimum at x = y = 0.5, objective = 0.5.
     let m = Model::new("qp");
-    let x = m.var("x").lb(-10.0).ub(10.0).build();
-    let y = m.var("y").lb(-10.0).ub(10.0).build();
-    m.constraint("c", (x + y).ge(1.0));
-    m.minimize(x.powi(2) + y.powi(2));
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    constraint!(m, c, x + y >= 1.0);
+    objective!(m, Min, x.powi(2) + y.powi(2));
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
@@ -37,9 +37,9 @@ fn nlp_with_sin_objective() {
     // min (x - 1)^2 + 0.1 * sin(x)^2 over x in [-3, 3].
     // Local minimum near x = 1, objective near 0.
     let m = Model::new("nlp_sin");
-    let x = m.var("x").lb(-3.0).ub(3.0).initial(0.5).build();
-    let one = Expr::constant(x.arena, 1.0);
-    m.minimize((x - one).powi(2) + Expr::constant(x.arena, 0.1) * x.sin().powi(2));
+    variable!(m, -3.0 <= x <= 3.0);
+    m.set_initial(x, 0.5);
+    objective!(m, Min, (x - 1.0).powi(2) + 0.1 * x.sin().powi(2));
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
@@ -51,9 +51,9 @@ fn nlp_with_sin_objective() {
 fn nlp_with_abs_objective() {
     // min |x - 2| over x in [-10, 10]. Optimum at x = 2, objective = 0.
     let m = Model::new("nlp_abs");
-    let x = m.var("x").lb(-10.0).ub(10.0).initial(0.5).build();
-    let two = Expr::constant(x.arena, 2.0);
-    m.minimize((x - two).abs());
+    variable!(m, -10.0 <= x <= 10.0);
+    m.set_initial(x, 0.5);
+    objective!(m, Min, (x - 2.0).abs());
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
@@ -68,10 +68,10 @@ fn minlp_binary_with_log() {
     // Binary b, continuous x in [0.1, 10]. Min (x - 1)^2 + b * log(1 + x).
     // Optimal: b = 0, x = 1, objective = 0.
     let m = Model::new("minlp_log");
-    let b = m.var("b").binary().build();
-    let x = m.var("x").lb(0.1).ub(10.0).initial(0.5).build();
-    let one = Expr::constant(x.arena, 1.0);
-    m.minimize((x - one).powi(2) + b * (one + x).log());
+    variable!(m, b, Bin);
+    variable!(m, 0.1 <= x <= 10.0);
+    m.set_initial(x, 0.5);
+    objective!(m, Min, (x - 1.0).powi(2) + b * (1.0 + x).log());
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
@@ -85,11 +85,13 @@ fn minlp_binary_with_log() {
 fn div_by_linear_denominator() {
     // x / (y + z) == 3, with x = 12 and z = 1 fixed -> y + 1 = 4 -> y = 3.
     let m = Model::new("div_linear");
-    let x = m.var("x").fix(12.0).build();
-    let y = m.var("y").lb(0.1).ub(100.0).build();
-    let z = m.var("z").fix(1.0).build();
-    m.constraint("c", (x / (y + z)).eq(3.0));
-    m.minimize(y);
+    variable!(m, x);
+    m.fix(x, 12.0);
+    variable!(m, 0.1 <= y <= 100.0);
+    variable!(m, z);
+    m.fix(z, 1.0);
+    constraint!(m, c, x / (y + z) == 3.0);
+    objective!(m, Min, y);
 
     let sol = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&sol);
@@ -103,10 +105,11 @@ fn div_by_negative_denominator() {
     // A `pow(den, -1)` lowering could not represent a negative denominator,
     // the bilinear `d * recip == 1` pin can.
     let m = Model::new("div_negative");
-    let x = m.var("x").fix(12.0).build();
-    let d = m.var("d").lb(-100.0).ub(-0.1).build();
-    m.constraint("c", (x / d).eq(-3.0));
-    m.minimize(d);
+    variable!(m, x);
+    m.fix(x, 12.0);
+    variable!(m, -100.0 <= d <= -0.1);
+    constraint!(m, c, x / d == -3.0);
+    objective!(m, Min, d);
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
@@ -119,9 +122,9 @@ fn div_constant_numerator() {
     // 6 / d == 2 -> d = 3. Exercises the constant-numerator fold (`6 * recip`,
     // which stays linear in `recip` rather than materializing a product).
     let m = Model::new("div_const_num");
-    let d = m.var("d").lb(0.1).ub(100.0).build();
-    m.constraint("c", (6.0 / d).eq(2.0));
-    m.minimize(d);
+    variable!(m, 0.1 <= d <= 100.0);
+    constraint!(m, c, 6.0 / d == 2.0);
+    objective!(m, Min, d);
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
@@ -135,10 +138,10 @@ fn div_by_quadratic_denominator() {
     // The quadratic denominator is first materialized into an aux variable so
     // the reciprocal pin stays bilinear rather than cubic.
     let m = Model::new("div_quadratic");
-    let x = m.var("x").lb(1.0).ub(10.0).build();
-    let y = m.var("y").lb(0.1).ub(10.0).build();
-    m.constraint("c", (x / (x * y)).eq(0.5));
-    m.minimize(x);
+    variable!(m, 1.0 <= x <= 10.0);
+    variable!(m, 0.1 <= y <= 10.0);
+    constraint!(m, c, x / (x * y) == 0.5);
+    objective!(m, Min, x);
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
     assert_solved(&r);
@@ -152,8 +155,8 @@ fn div_by_zero_constant_errors() {
     // nonzero constants are folded into the linear path), so lowering must
     // reject it rather than emit an infeasible `0 * recip == 1`.
     let m = Model::new("div_zero");
-    let x = m.var("x").lb(0.0).ub(10.0).build();
-    m.minimize(x / 0.0);
+    variable!(m, 0.0 <= x <= 10.0);
+    objective!(m, Min, x / 0.0);
 
     let err = Gurobi.solve(&m, &GurobiOptions::default()).expect_err("expected error");
     assert!(err.to_string().contains("division by zero"), "err = {err}");

--- a/crates/oximo-highs/README.md
+++ b/crates/oximo-highs/README.md
@@ -30,11 +30,11 @@ use oximo_highs::{Highs, HighsOptions};
 use oximo_solver::{Solver, SolverStatus};
 
 let m = Model::new("toy");
-let x = m.var("x").lb(0.0).build();
-let y = m.var("y").lb(0.0).ub(4.0).build();
-m.constraint("c1", (x + 2.0 * y).le(14.0));
-m.constraint("c2", (3.0 * x - y).ge(0.0));
-m.maximize(3.0 * x + 4.0 * y);
+variable!(m, x >= 0.0);
+variable!(m, 0.0 <= y <= 4.0);
+constraint!(m, c1, x + 2.0 * y <= 14.0);
+constraint!(m, c2, 3.0 * x - y >= 0.0);
+objective!(m, Max, 3.0 * x + 4.0 * y);
 
 let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
 assert_eq!(result.status, SolverStatus::Optimal);
@@ -56,10 +56,10 @@ use oximo_highs::{Highs, HighsOptions};
 use oximo_solver::{Solver, SolverStatus};
 
 let m = Model::new("qp");
-let x = m.var("x").lb(-10.0).ub(10.0).build();
-let y = m.var("y").lb(-10.0).ub(10.0).build();
-m.constraint("c", (x + y).eq(1.0));
-m.minimize(x.powi(2) + y.powi(2)); // min x^2 + y^2
+variable!(m, -10.0 <= x <= 10.0);
+variable!(m, -10.0 <= y <= 10.0);
+constraint!(m, c, x + y == 1.0);
+objective!(m, Min, x.powi(2) + y.powi(2)); // min x^2 + y^2
 
 let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
 assert_eq!(result.status, SolverStatus::Optimal); // x = y = 0.5, obj = 0.5

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -284,10 +284,10 @@ mod tests {
     fn qp_min_sum_of_squares() {
         // min x^2 + y^2  s.t.  x + y = 1  ->  (0.5, 0.5), objective 0.5.
         let m = Model::new("sq");
-        let x = m.var("x").lb(-10.0).ub(10.0).build();
-        let y = m.var("y").lb(-10.0).ub(10.0).build();
-        m.constraint("c", (x + y).eq(1.0));
-        m.minimize(x.powi(2) + y.powi(2));
+        variable!(m, -10.0 <= x <= 10.0);
+        variable!(m, -10.0 <= y <= 10.0);
+        constraint!(m, c, x + y == 1.0);
+        objective!(m, Min, x.powi(2) + y.powi(2));
         assert_eq!(m.kind(), ModelKind::QP);
 
         let res = solve(&m, &HighsOptions::default()).unwrap();
@@ -302,10 +302,10 @@ mod tests {
         // min 2 x0^2 + x0 x1 + x1^2 + x0 + x1  s.t.  x0 + x1 = 1,  x >= 0.
         // cvxopt reference solution: x = [0.25, 0.75], objective = 1.875.
         let m = Model::new("cvxopt");
-        let x0 = m.var("x0").lb(0.0).build();
-        let x1 = m.var("x1").lb(0.0).build();
-        m.constraint("eq", (x0 + x1).eq(1.0));
-        m.minimize(2.0 * x0.powi(2) + x0 * x1 + x1.powi(2) + x0 + x1);
+        variable!(m, x0 >= 0.0);
+        variable!(m, x1 >= 0.0);
+        constraint!(m, eq, x0 + x1 == 1.0);
+        objective!(m, Min, 2.0 * x0.powi(2) + x0 * x1 + x1.powi(2) + x0 + x1);
 
         let res = solve(&m, &HighsOptions::default()).unwrap();
         assert_eq!(res.status, SolverStatus::Optimal);
@@ -318,8 +318,8 @@ mod tests {
     fn qp_objective_constant_is_added_back() {
         // min (x - 1)^2 = x^2 - 2x + 1  ->  x = 1, objective 0 (constant 1).
         let m = Model::new("shift");
-        let x = m.var("x").lb(-5.0).ub(5.0).build();
-        m.minimize((x - 1.0).powi(2));
+        variable!(m, -5.0 <= x <= 5.0);
+        objective!(m, Min, (x - 1.0).powi(2));
         assert_eq!(m.kind(), ModelKind::QP);
 
         let res = solve(&m, &HighsOptions::default()).unwrap();
@@ -332,8 +332,8 @@ mod tests {
     fn miqp_is_unsupported() {
         // Integer variable + quadratic objective = MIQP, which HiGHS cannot solve.
         let m = Model::new("miqp");
-        let x = m.var("x").lb(0.0).ub(5.0).integer().build();
-        m.minimize(x.powi(2));
+        variable!(m, 0.0 <= x <= 5.0, Int);
+        objective!(m, Min, x.powi(2));
         assert_eq!(m.kind(), ModelKind::MIQP);
 
         let err = solve(&m, &HighsOptions::default()).unwrap_err();

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -35,12 +35,12 @@ use oximo::prelude::*;
 use oximo::io::{to_mps_string, to_lp_string};
 
 let m = Model::new("knapsack");
-let x = m.var("x").lb(0.0).build();
-let y = m.var("y").lb(0.0).ub(4.0).build();
+variable!(m, x >= 0.0);
+variable!(m, 0.0 <= y <= 4.0);
 
-m.constraint("c1", (x + 2.0 * y).le(14.0));
-m.constraint("c2", (3.0 * x - y).ge(0.0));
-m.maximize(3.0 * x + 4.0 * y);
+constraint!(m, c1, x + 2.0 * y <= 14.0);
+constraint!(m, c2, 3.0 * x - y >= 0.0);
+objective!(m, Max, 3.0 * x + 4.0 * y);
 
 let mps = to_mps_string(&m)?;
 let lp  = to_lp_string(&m)?;
@@ -120,9 +120,9 @@ use std::path::Path;
 
 // Rosenbrock: min (1 - x)^2 + 100 (y - x^2)^2
 let m = Model::new("rosen");
-let x = m.var("x").bounds(-5.0, 5.0).build();
-let y = m.var("y").bounds(-5.0, 5.0).build();
-m.minimize((1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
+variable!(m, -5.0 <= x <= 5.0);
+variable!(m, -5.0 <= y <= 5.0);
+objective!(m, Min, (1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
 
 // To string (ASCII only)
 let nl = to_nl_string(&m)?;

--- a/crates/oximo-io/tests/nl_options.rs
+++ b/crates/oximo-io/tests/nl_options.rs
@@ -10,10 +10,10 @@ use tempfile::TempDir;
 
 fn simple_lp() -> Model {
     let m = Model::new("opt");
-    let x = m.var("x").build();
-    let y = m.var("y").build();
-    m.minimize(x + 2.0 * y);
-    m.constraint("c0", (x + y).ge(3.0));
+    variable!(m, x);
+    variable!(m, y);
+    objective!(m, Min, x + 2.0 * y);
+    constraint!(m, c0, x + y >= 3.0);
     m
 }
 
@@ -30,9 +30,9 @@ fn no_comments() {
 fn precision_knob() {
     let m = {
         let m = Model::new("p");
-        let x = m.var("x").build();
-        m.minimize(x * std::f64::consts::PI);
-        m.constraint("c0", x.ge(0.0));
+        variable!(m, x);
+        objective!(m, Min, x * std::f64::consts::PI);
+        constraint!(m, c0, x >= 0.0);
         m
     };
     let mut opts = WriteOptions::ascii_lean();
@@ -47,9 +47,9 @@ fn precision_knob() {
 fn nonfinite_strings() {
     let m = {
         let m = Model::new("nf");
-        let x = m.var("x").lb(f64::NEG_INFINITY).ub(f64::INFINITY).build();
-        m.minimize(x);
-        m.constraint("c0", x.ge(0.0));
+        variable!(m, f64::NEG_INFINITY <= x <= f64::INFINITY);
+        objective!(m, Min, x);
+        constraint!(m, c0, x >= 0.0);
         m
     };
     // Default strict mode passes because bounds use the `b 3` (free) line
@@ -67,9 +67,9 @@ fn nonfinite_strings() {
 #[test]
 fn nonfinite_constant_in_residual() {
     let m = Model::new("nf_res");
-    let x = m.var("x").build();
-    m.minimize(f64::INFINITY * x.sin());
-    m.constraint("c0", x.ge(0.0));
+    variable!(m, x);
+    objective!(m, Min, f64::INFINITY * x.sin());
+    constraint!(m, c0, x >= 0.0);
 
     assert!(
         matches!(to_nl_string_with(&m, &WriteOptions::default()), Err(IoError::InvalidNumber)),
@@ -82,6 +82,7 @@ fn nonfinite_constant_in_residual() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn rejects_semi_domains() {
     for (dom, name) in [
         (Domain::SemiContinuous { threshold: 2.0 }, "SemiContinuous"),
@@ -213,9 +214,9 @@ fn d_segment_hook() {
 fn complementarity_in_r() {
     let m = {
         let m = Model::new("comp");
-        let x = m.var("x").lb(0.0).build();
-        m.minimize(x);
-        m.constraint("c0", x.ge(0.0));
+        variable!(m, x >= 0.0);
+        objective!(m, Min, x);
+        constraint!(m, c0, x >= 0.0);
         m
     };
     let mut opts = WriteOptions::ascii_lean();

--- a/crates/oximo-io/tests/nl_options.rs
+++ b/crates/oximo-io/tests/nl_options.rs
@@ -82,21 +82,24 @@ fn nonfinite_constant_in_residual() {
 }
 
 #[test]
-#[allow(deprecated)]
 fn rejects_semi_domains() {
-    for (dom, name) in [
-        (Domain::SemiContinuous { threshold: 2.0 }, "SemiContinuous"),
-        (Domain::SemiInteger { threshold: 2.0 }, "SemiInteger"),
-    ] {
-        let m = Model::new("semi");
-        let x = m.var("x").lb(0.0).ub(10.0).domain(dom).build();
-        m.minimize(x);
-        let err = to_nl_string_with(&m, &WriteOptions::default()).unwrap_err();
-        assert!(
-            matches!(err, IoError::UnsupportedDomain(d) if d == name),
-            "expected UnsupportedDomain({name}), got {err:?}"
-        );
-    }
+    let m = Model::new("semic");
+    variable!(m, 0.0 <= x <= 10.0, SemiCont(2.0));
+    objective!(m, Min, x);
+    let err = to_nl_string_with(&m, &WriteOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, IoError::UnsupportedDomain(d) if d == "SemiContinuous"),
+        "expected UnsupportedDomain(SemiContinuous), got {err:?}"
+    );
+
+    let m = Model::new("semii");
+    variable!(m, 0.0 <= x <= 10.0, SemiInt(2.0));
+    objective!(m, Min, x);
+    let err = to_nl_string_with(&m, &WriteOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, IoError::UnsupportedDomain(d) if d == "SemiInteger"),
+        "expected UnsupportedDomain(SemiInteger), got {err:?}"
+    );
 }
 
 #[test]

--- a/crates/oximo-io/tests/nl_snapshots.rs
+++ b/crates/oximo-io/tests/nl_snapshots.rs
@@ -12,10 +12,10 @@ fn nl_pure_lp() {
     // s.t. x + y >= 3
     // x, y free
     let m = Model::new("tinylp");
-    let x = m.var("x").build();
-    let y = m.var("y").build();
-    m.minimize(x + 2.0 * y);
-    m.constraint("c0", (x + y).ge(3.0));
+    variable!(m, x);
+    variable!(m, y);
+    objective!(m, Min, x + 2.0 * y);
+    constraint!(m, c0, x + y >= 3.0);
 
     let s = to_nl_string(&m).expect("nl writer");
     let expected = "\
@@ -56,10 +56,10 @@ fn nl_milp() {
     // s.t. z + y <= 4
     // z continuous, y binary
     let m = Model::new("milp");
-    let z = m.var("z").lb(0.0).ub(10.0).build();
-    let y = m.var("y").binary().build();
-    m.minimize(z + y);
-    m.constraint("c0", (z + y).le(4.0));
+    variable!(m, 0.0 <= z <= 10.0);
+    variable!(m, y, Bin);
+    objective!(m, Min, z + y);
+    constraint!(m, c0, z + y <= 4.0);
 
     let s = to_nl_string(&m).expect("nl writer");
     // Variables: z (id 0, linear continuous, bucket LinC), y (id 1, linear binary, bucket LinB).
@@ -101,9 +101,9 @@ fn nl_nlp_rosenbrock() {
     // min (1 - x)^2 + 100 (y - x^2)^2
     // x, y free
     let m = Model::new("rosen");
-    let x = m.var("x").build();
-    let y = m.var("y").build();
-    m.minimize((1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
+    variable!(m, x);
+    variable!(m, y);
+    objective!(m, Min, (1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
 
     let s = to_nl_string(&m).expect("nl writer");
     // Both vars are nonlinear in obj only -> bucket NlOnlyO, var_order = [x, y].
@@ -124,8 +124,8 @@ fn nl_nlp_rosenbrock() {
 fn nl_abs_objective() {
     // min |x|, x free
     let m = Model::new("absobj");
-    let x = m.var("x").build();
-    m.minimize(x.abs());
+    variable!(m, x);
+    objective!(m, Min, x.abs());
 
     let s = to_nl_string(&m).expect("nl writer");
     // abs is nonlinear in the objective and lowers to the OPABS opcode o15.
@@ -139,10 +139,10 @@ fn nl_minlp() {
     // s.t. x + y >= 1
     // x continuous free, y integer in [0, 5]
     let m = Model::new("mi");
-    let x = m.var("x").build();
-    let y = m.var("y").integer().lb(0.0).ub(5.0).build();
-    m.minimize(x * x + 3.0 * y);
-    m.constraint("c0", (x + y).ge(1.0));
+    variable!(m, x);
+    variable!(m, 0.0 <= y <= 5.0, Int);
+    objective!(m, Min, x * x + 3.0 * y);
+    constraint!(m, c0, x + y >= 1.0);
 
     let s = to_nl_string(&m).expect("nl writer");
     // split_linear separates `3*y` (linear) from `x*x` (residual). Only x
@@ -170,10 +170,10 @@ fn nl_nonlinear_integer_order() {
     // obj-only), continuous before integer within each group. So NlBothI (y)
     // precedes NlOnlyC (x): var_order = [y, x], i.e. y -> v0, x -> v1.
     let m = Model::new("minlp_nl_int");
-    let x = m.var("x").build();
-    let y = m.var("y").integer().lb(0.0).ub(5.0).build();
-    m.minimize(y * y);
-    m.constraint("c0", (x * x + y * y).le(10.0));
+    variable!(m, x);
+    variable!(m, 0.0 <= y <= 5.0, Int);
+    objective!(m, Min, y * y);
+    constraint!(m, c0, x * x + y * y <= 10.0);
 
     let s = to_nl_string(&m).expect("nl writer");
     // Nonlinear vars: in constraints = 2 (x, y), in objective = 1 (y), both = 1 (y).

--- a/crates/oximo-io/tests/nl_solver.rs
+++ b/crates/oximo-io/tests/nl_solver.rs
@@ -70,9 +70,11 @@ fn write_and_solve(m: &Model, expected_obj: f64, tol: f64) {
 fn rosenbrock_via_solver() {
     // min (1-x0)^2 + 100 (x1 - x0^2)^2, minimum 0 at (1, 1).
     let m = Model::new("rosenbrock");
-    let x0 = m.var("x0").lb(-5.0).ub(5.0).initial(-1.2).build();
-    let x1 = m.var("x1").lb(-5.0).ub(5.0).initial(1.0).build();
-    m.minimize((1.0 - x0).powi(2) + 100.0 * (x1 - x0.powi(2)).powi(2));
+    variable!(m, -5.0 <= x0 <= 5.0);
+    variable!(m, -5.0 <= x1 <= 5.0);
+    m.set_initial(x0, -1.2);
+    m.set_initial(x1, 1.0);
+    objective!(m, Min, (1.0 - x0).powi(2) + 100.0 * (x1 - x0.powi(2)).powi(2));
     write_and_solve(&m, 0.0, 1e-4);
 }
 
@@ -83,10 +85,10 @@ fn small_lp_via_solver() {
     //      0 <= x0, x1 <= 10
     // Optimal: x0=3, x1=0, obj=3.
     let m = Model::new("smalllp");
-    let x0 = m.var("x0").lb(0.0).ub(10.0).build();
-    let x1 = m.var("x1").lb(0.0).ub(10.0).build();
-    m.minimize(x0 + 2.0 * x1);
-    m.constraint("c0", (x0 + x1).ge(3.0));
+    variable!(m, 0.0 <= x0 <= 10.0);
+    variable!(m, 0.0 <= x1 <= 10.0);
+    objective!(m, Min, x0 + 2.0 * x1);
+    constraint!(m, c0, x0 + x1 >= 3.0);
     write_and_solve(&m, 3.0, 1e-4);
 }
 

--- a/crates/oximo-macros/Cargo.toml
+++ b/crates/oximo-macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oximo-macros"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Internal procedural macros for oximo, re-exported through oximo-core"
+readme = "README.md"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true, features = ["full"] }
+quote.workspace = true
+proc-macro2.workspace = true
+proc-macro-crate.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oximo-macros/README.md
+++ b/crates/oximo-macros/README.md
@@ -1,0 +1,15 @@
+# oximo-macros
+
+Internal procedural macros backing oximo's modeling surface:
+`variable!`, `constraint!`, `objective!`, `sum!`, and `param!`.
+
+This crate is an implementation detail, do not depend on it directly.
+The macros are re-exported through `oximo-core` and `oximo::prelude`, which is the
+supported entry point:
+
+```rust,ignore
+use oximo::prelude::*;
+```
+
+The macros expand to the typed builder API in `oximo-core` (`Model`, `Set`,
+`Expr`, `sum_over`, ...). See the `oximo` crate docs for the macro grammar and examples.

--- a/crates/oximo-macros/src/bind.rs
+++ b/crates/oximo-macros/src/bind.rs
@@ -1,0 +1,70 @@
+//! Parsing for index bindings (`pat in domain`, optionally `pat: ty in domain`)
+//! shared by `variable!`, `constraint!`, and `sum!`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Expr, Pat, Token, Type};
+
+/// One `pat in domain` clause, with an optional explicit key type.
+///
+/// The type annotation is only needed when the domain is a `Set` whose keys are
+/// not plain integers (strings, tuples).
+/// The macros decode keys through `FromIndexKey`,
+/// and a bare identifier defaults to `usize`.
+pub(crate) struct IndexBind {
+    pub(crate) pat: Pat,
+    pub(crate) ty: Option<Type>,
+    pub(crate) domain: Expr,
+}
+
+impl Parse for IndexBind {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let pat = Pat::parse_single(input)?;
+        let ty = if input.peek(Token![:]) {
+            input.parse::<Token![:]>()?;
+            Some(input.parse::<Type>()?)
+        } else {
+            None
+        };
+        input.parse::<Token![in]>()?;
+        let domain = input.parse::<Expr>()?;
+        Ok(Self { pat, ty, domain })
+    }
+}
+
+/// A comma-separated, optionally trailing list of [`IndexBind`]s
+pub(crate) struct Binds(pub(crate) Vec<IndexBind>);
+
+impl Parse for Binds {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let parsed = Punctuated::<IndexBind, Token![,]>::parse_terminated(input)?;
+        Ok(Self(parsed.into_iter().collect()))
+    }
+}
+
+impl IndexBind {
+    /// The key type for this binding: the explicit annotation, else `usize`.
+    pub(crate) fn key_type(&self) -> TokenStream2 {
+        if let Some(ty) = &self.ty { quote!(#ty) } else { quote!(usize) }
+    }
+
+    /// A typed closure parameter for a single-index closure (`|pat: ty|`).
+    pub(crate) fn closure_param(&self) -> TokenStream2 {
+        let pat = &self.pat;
+        let ty = self.key_type();
+        quote!(#pat: #ty)
+    }
+}
+
+/// Build the closure parameter for an index family decoded as a whole key:
+/// single binding -> `pat: ty`; multiple -> `(p0, p1, ...): (t0, t1, ...)`.
+pub(crate) fn family_closure_param(binds: &[IndexBind]) -> TokenStream2 {
+    if let [single] = binds {
+        return single.closure_param();
+    }
+    let pats = binds.iter().map(|b| &b.pat);
+    let tys = binds.iter().map(IndexBind::key_type);
+    quote!( (#(#pats),*): (#(#tys),*) )
+}

--- a/crates/oximo-macros/src/bind.rs
+++ b/crates/oximo-macros/src/bind.rs
@@ -45,26 +45,55 @@ impl Parse for Binds {
 }
 
 impl IndexBind {
-    /// The key type for this binding: the explicit annotation, else `usize`.
-    pub(crate) fn key_type(&self) -> TokenStream2 {
-        if let Some(ty) = &self.ty { quote!(#ty) } else { quote!(usize) }
+    /// Whether the domain is written as a range expression.
+    pub(crate) fn is_range_literal(&self) -> bool {
+        matches!(self.domain, Expr::Range(_))
     }
 
-    /// A typed closure parameter for a single-index closure (`|pat: ty|`).
+    /// Closure parameter for a single-index `sum!` term. The domain is consumed
+    /// directly via `SumDomain`.
     pub(crate) fn closure_param(&self) -> TokenStream2 {
         let pat = &self.pat;
-        let ty = self.key_type();
-        quote!(#pat: #ty)
+        if let Some(ty) = &self.ty {
+            quote!(#pat: #ty)
+        } else if self.is_range_literal() {
+            quote!(#pat: usize)
+        } else {
+            quote!(#pat)
+        }
+    }
+
+    /// Key type to pin when iterating this binding via `keys_of::<K, _>`.
+    pub(crate) fn keys_of_type(&self) -> Option<TokenStream2> {
+        if let Some(ty) = &self.ty {
+            Some(quote!(#ty))
+        } else if self.is_range_literal() {
+            Some(quote!(usize))
+        } else {
+            None
+        }
     }
 }
 
-/// Build the closure parameter for an index family decoded as a whole key:
-/// single binding -> `pat: ty`; multiple -> `(p0, p1, ...): (t0, t1, ...)`.
+/// Build the closure parameter for an index family decoded as a whole key.
+/// The `Set<K>` passed to `__add_constraints_over` pins `K`, so the
+/// pattern is left bare unless the user annotated every binding.
 pub(crate) fn family_closure_param(binds: &[IndexBind]) -> TokenStream2 {
-    if let [single] = binds {
-        return single.closure_param();
-    }
     let pats = binds.iter().map(|b| &b.pat);
-    let tys = binds.iter().map(IndexBind::key_type);
-    quote!( (#(#pats),*): (#(#tys),*) )
+    let pattern = if let [single] = binds {
+        let pat = &single.pat;
+        quote!(#pat)
+    } else {
+        quote!( (#(#pats),*) )
+    };
+
+    let tys: Option<Vec<&Type>> = binds.iter().map(|b| b.ty.as_ref()).collect();
+    match tys {
+        Some(tys) if binds.len() == 1 => {
+            let ty = tys[0];
+            quote!(#pattern: #ty)
+        }
+        Some(tys) => quote!( #pattern: (#(#tys),*) ),
+        None => pattern,
+    }
 }

--- a/crates/oximo-macros/src/bind.rs
+++ b/crates/oximo-macros/src/bind.rs
@@ -4,7 +4,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::punctuated::Punctuated;
 use syn::{Expr, Pat, Token, Type};
 
 /// One `pat in domain` clause, with an optional explicit key type.
@@ -34,13 +33,34 @@ impl Parse for IndexBind {
     }
 }
 
-/// A comma-separated, optionally trailing list of [`IndexBind`]s
-pub(crate) struct Binds(pub(crate) Vec<IndexBind>);
+/// A comma-separated, optionally trailing list of [`IndexBind`]s, with an
+/// optional trailing `if cond` filter (`name[i in S if cond]`).
+pub(crate) struct Binds {
+    pub(crate) binds: Vec<IndexBind>,
+    pub(crate) cond: Option<Expr>,
+}
 
 impl Parse for Binds {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let parsed = Punctuated::<IndexBind, Token![,]>::parse_terminated(input)?;
-        Ok(Self(parsed.into_iter().collect()))
+        let mut binds = Vec::new();
+        while !input.is_empty() && !input.peek(Token![if]) {
+            binds.push(input.parse::<IndexBind>()?);
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            } else {
+                break;
+            }
+        }
+        let cond = if input.peek(Token![if]) {
+            input.parse::<Token![if]>()?;
+            Some(input.parse::<Expr>()?)
+        } else {
+            None
+        };
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after index bindings"));
+        }
+        Ok(Self { binds, cond })
     }
 }
 
@@ -71,6 +91,24 @@ impl IndexBind {
             Some(quote!(usize))
         } else {
             None
+        }
+    }
+}
+
+/// Wrap a built `Set` token expression in `filter_keys(.., |pat| cond)` when the
+/// family carries an `if` filter (`name[i in dom if cond]`), otherwise return the
+/// set unchanged.
+pub(crate) fn filtered_set(
+    set: TokenStream2,
+    binds: &[IndexBind],
+    cond: Option<&Expr>,
+    root: &TokenStream2,
+) -> TokenStream2 {
+    match cond {
+        None => set,
+        Some(cond) => {
+            let param = family_closure_param(binds);
+            quote!( #root::__macro_support::filter_keys(&(#set), |#param| #cond) )
         }
     }
 }

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Spacing, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::Expr;
 
-use crate::bind::family_closure_param;
+use crate::bind::{family_closure_param, filtered_set};
 use crate::{Named, build_set, oximo_root, parse_named, split_relops, split_top_commas};
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
@@ -37,7 +37,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
                 return Ok(quote!( (#model).__add_constraint(#name_expr, #rel) ));
             }
 
-            let Named { name, binds } = parse_named(first)?;
+            let Named { name, binds, cond } = parse_named(first)?;
             let name_str = name.to_string();
             match binds {
                 None => {
@@ -47,6 +47,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
                 Some(binds) => {
                     let param = family_closure_param(&binds);
                     let set = build_set(&binds, &root);
+                    let set = filtered_set(set, &binds, cond.as_ref(), &root);
                     let rel = build_relation(rel_tokens, &root)?;
                     Ok(quote! {
                         (#model).__add_constraints_over(#name_str, &(#set), |#param| #rel);

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -1,6 +1,6 @@
-//! `constraint!(model, [name | name[i in dom, ...]], lhs <op> rhs)`.
+//! `constraint!(model, [name | name = expr | name[i in dom, ...]], lhs <op> rhs)`.
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Spacing, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::Expr;
 
@@ -29,6 +29,14 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
             Ok(quote!( (#model).__add_constraint_auto(#rel) ))
         }
         Some(rel_tokens) => {
+            // Computed name at run-time: `constraint!(m, name = expr, lhs OP rhs)`.
+            // Lets per-element constraints built in a `for` loop stay named
+            // (`format!("mb_{s}_{n}")`).
+            if let Some(name_expr) = computed_name(&first) {
+                let rel = build_relation(rel_tokens, &root)?;
+                return Ok(quote!( (#model).__add_constraint(#name_expr, #rel) ));
+            }
+
             let Named { name, binds } = parse_named(first)?;
             let name_str = name.to_string();
             match binds {
@@ -47,6 +55,22 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
             }
         }
     }
+}
+
+/// Detect the computed-name form `name = EXPR` in the name slot, returning the
+/// `EXPR` tokens. The literal marker `name` keeps a bare ident a literal name.
+fn computed_name(first: &TokenStream2) -> Option<TokenStream2> {
+    let mut it = first.clone().into_iter();
+    match it.next()? {
+        TokenTree::Ident(id) if id == "name" => {}
+        _ => return None,
+    }
+    match it.next()? {
+        TokenTree::Punct(p) if p.as_char() == '=' && p.spacing() == Spacing::Alone => {}
+        _ => return None,
+    }
+    let expr: TokenStream2 = it.collect();
+    (!expr.is_empty()).then_some(expr)
 }
 
 /// Split `lhs <op> rhs` on its single relational operator and build the

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -1,0 +1,72 @@
+//! `constraint!(model, [name | name[i in dom, ...]], lhs <op> rhs)`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::Expr;
+
+use crate::bind::family_closure_param;
+use crate::{Named, build_set, oximo_root, parse_named, split_relops, split_top_commas};
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let parts = split_top_commas(input);
+    let mut parts = parts.into_iter();
+    let model = parts.next().expect("split always yields at least one segment");
+    let model: Expr = syn::parse2(model)?;
+
+    let first = parts.next().ok_or_else(|| {
+        syn::Error::new(proc_macro2::Span::call_site(), "constraint! needs a relational expression")
+    })?;
+    let second = parts.next();
+    if let Some(extra) = parts.next() {
+        return Err(syn::Error::new_spanned(extra, "unexpected trailing tokens in constraint!"));
+    }
+
+    let root = oximo_root();
+
+    match second {
+        None => {
+            let rel = build_relation(first, &root)?;
+            Ok(quote!( (#model).__add_constraint_auto(#rel) ))
+        }
+        Some(rel_tokens) => {
+            let Named { name, binds } = parse_named(first)?;
+            let name_str = name.to_string();
+            match binds {
+                None => {
+                    let rel = build_relation(rel_tokens, &root)?;
+                    Ok(quote!( (#model).__add_constraint(#name_str, #rel) ))
+                }
+                Some(binds) => {
+                    let param = family_closure_param(&binds);
+                    let set = build_set(&binds, &root);
+                    let rel = build_relation(rel_tokens, &root)?;
+                    Ok(quote! {
+                        (#model).__add_constraints_over(#name_str, &(#set), |#param| #rel);
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Split `lhs <op> rhs` on its single relational operator and build the
+/// `Relate::{le,ge,eq}(lhs, rhs)` call that yields a `ConstraintExpr`.
+fn build_relation(tokens: TokenStream2, root: &TokenStream2) -> syn::Result<TokenStream2> {
+    let (segs, ops) = split_relops(tokens);
+    let [lhs, rhs] = <[TokenStream2; 2]>::try_from(segs).map_err(|_| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "constraint must contain exactly one of `==`, `<=`, or `>=`",
+        )
+    })?;
+    let [op] = ops.as_slice() else {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "constraint must contain exactly one of `==`, `<=`, or `>=`",
+        ));
+    };
+    let method = op.method();
+    let lhs: Expr = syn::parse2(lhs)?;
+    let rhs: Expr = syn::parse2(rhs)?;
+    Ok(quote!( #root::__macro_support::Relate::#method(#lhs, #rhs) ))
+}

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -192,17 +192,12 @@ fn register_family(
         },
         Relations::Range { mid, lo, hi } => {
             let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
-            quote! {{
-                let __set = #set;
-                (#model).__add_constraints_over(::core::concat!(#name_str, "_lo"), &__set, |#param| {
+            quote! {
+                (#model).__add_range_constraints_over(#name_str, &(#set), |#param| {
                     let __mid = #mid;
-                    #lo_rel
+                    (#lo_rel, #hi_rel)
                 });
-                (#model).__add_constraints_over(::core::concat!(#name_str, "_hi"), &__set, |#param| {
-                    let __mid = #mid;
-                    #hi_rel
-                });
-            }}
+            }
         }
     }
 }

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -1,11 +1,15 @@
-//! `constraint!(model, [name | name = expr | name[i in dom, ...]], lhs <op> rhs)`.
+//! `constraint!(model, [name | name = expr | name[i in dom, ...]], <relation>)`,
+//! where `<relation>` is `lhs <op> rhs` or a two-sided range `lo <= e <= hi`
+//! (`hi >= e >= lo`). A range lowers to two rows, `{name}_lo` and `{name}_hi`.
 
-use proc_macro2::{Spacing, TokenStream as TokenStream2, TokenTree};
+// TODO: Improve so that ranges don't lower to two rows.
+
+use proc_macro2::{Spacing, Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::Expr;
 
 use crate::bind::{family_closure_param, filtered_set};
-use crate::{Named, build_set, oximo_root, parse_named, split_relops, split_top_commas};
+use crate::{Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas};
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let parts = split_top_commas(input);
@@ -14,7 +18,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let model: Expr = syn::parse2(model)?;
 
     let first = parts.next().ok_or_else(|| {
-        syn::Error::new(proc_macro2::Span::call_site(), "constraint! needs a relational expression")
+        syn::Error::new(Span::call_site(), "constraint! needs a relational expression")
     })?;
     let second = parts.next();
     if let Some(extra) = parts.next() {
@@ -24,34 +28,24 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let root = oximo_root();
 
     match second {
-        None => {
-            let rel = build_relation(first, &root)?;
-            Ok(quote!( (#model).__add_constraint_auto(#rel) ))
-        }
+        None => Ok(register_anonymous(&model, build_relations(first, &root)?, &root)),
         Some(rel_tokens) => {
-            // Computed name at run-time: `constraint!(m, name = expr, lhs OP rhs)`.
-            // Lets per-element constraints built in a `for` loop stay named
-            // (`format!("mb_{s}_{n}")`).
+            // Computed name at run-time: `constraint!(m, name = expr, <relation>)`.
             if let Some(name_expr) = computed_name(&first) {
-                let rel = build_relation(rel_tokens, &root)?;
-                return Ok(quote!( (#model).__add_constraint(#name_expr, #rel) ));
+                let rel = build_relations(rel_tokens, &root)?;
+                return Ok(register_computed(&model, &name_expr, rel, &root));
             }
 
             let Named { name, binds, cond } = parse_named(first)?;
             let name_str = name.to_string();
+            let rel = build_relations(rel_tokens, &root)?;
             match binds {
-                None => {
-                    let rel = build_relation(rel_tokens, &root)?;
-                    Ok(quote!( (#model).__add_constraint(#name_str, #rel) ))
-                }
+                None => Ok(register_named(&model, &name_str, rel, &root)),
                 Some(binds) => {
                     let param = family_closure_param(&binds);
                     let set = build_set(&binds, &root);
                     let set = filtered_set(set, &binds, cond.as_ref(), &root);
-                    let rel = build_relation(rel_tokens, &root)?;
-                    Ok(quote! {
-                        (#model).__add_constraints_over(#name_str, &(#set), |#param| #rel);
-                    })
+                    Ok(register_family(&model, &name_str, &set, &param, rel, &root))
                 }
             }
         }
@@ -74,24 +68,141 @@ fn computed_name(first: &TokenStream2) -> Option<TokenStream2> {
     (!expr.is_empty()).then_some(expr)
 }
 
-/// Split `lhs <op> rhs` on its single relational operator and build the
-/// `Relate::{le,ge,eq}(lhs, rhs)` call that yields a `ConstraintExpr`.
-fn build_relation(tokens: TokenStream2, root: &TokenStream2) -> syn::Result<TokenStream2> {
+/// A constraint relation: a single `lhs <op> rhs`, or a two-sided range that
+/// lowers to two rows.
+#[allow(clippy::large_enum_variant)]
+enum Relations {
+    Single(TokenStream2),
+    Range { mid: Expr, lo: Expr, hi: Expr },
+}
+
+fn parse_seg(ts: TokenStream2) -> syn::Result<Expr> {
+    syn::parse2(crate::index::rewrite_index_subscripts(ts))
+}
+
+/// Split the relation on its relational operators. One operator yields a
+/// [`Relations::Single`]. Two like operators (`<= <=` or `>= >=`) a
+/// [`Relations::Range`].
+fn build_relations(tokens: TokenStream2, root: &TokenStream2) -> syn::Result<Relations> {
     let (segs, ops) = split_relops(tokens);
-    let [lhs, rhs] = <[TokenStream2; 2]>::try_from(segs).map_err(|_| {
-        syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "constraint must contain exactly one of `==`, `<=`, or `>=`",
-        )
-    })?;
-    let [op] = ops.as_slice() else {
-        return Err(syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "constraint must contain exactly one of `==`, `<=`, or `>=`",
-        ));
-    };
-    let method = op.method();
-    let lhs: Expr = syn::parse2(crate::index::rewrite_index_subscripts(lhs))?;
-    let rhs: Expr = syn::parse2(crate::index::rewrite_index_subscripts(rhs))?;
-    Ok(quote!( #root::__macro_support::Relate::#method(#lhs, #rhs) ))
+    match (segs.len(), ops.as_slice()) {
+        (2, [op]) => {
+            let method = op.method();
+            let mut segs = segs.into_iter();
+            let lhs = parse_seg(segs.next().unwrap())?;
+            let rhs = parse_seg(segs.next().unwrap())?;
+            Ok(Relations::Single(quote!( #root::__macro_support::Relate::#method(#lhs, #rhs) )))
+        }
+        (3, [a, b]) => {
+            let mut segs = segs.into_iter();
+            let s0 = parse_seg(segs.next().unwrap())?;
+            let mid = parse_seg(segs.next().unwrap())?;
+            let s2 = parse_seg(segs.next().unwrap())?;
+            match (a, b) {
+                // lo <= mid <= hi
+                (RelOp::Le, RelOp::Le) => Ok(Relations::Range { mid, lo: s0, hi: s2 }),
+                // hi >= mid >= lo
+                (RelOp::Ge, RelOp::Ge) => Ok(Relations::Range { mid, lo: s2, hi: s0 }),
+                _ => Err(syn::Error::new(
+                    Span::call_site(),
+                    "a two-sided range must use `<=` twice (`lo <= e <= hi`) or `>=` twice (`hi >= e >= lo`)",
+                )),
+            }
+        }
+        _ => Err(syn::Error::new(
+            Span::call_site(),
+            "constraint must contain exactly one `==`/`<=`/`>=`, or be a two-sided range `lo <= e <= hi`",
+        )),
+    }
+}
+
+/// The two relation tokens for a range: `mid >= lo` (the `_lo` row) and
+/// `mid <= hi` (the `_hi` row).
+fn range_rows(lo: &Expr, hi: &Expr, root: &TokenStream2) -> (TokenStream2, TokenStream2) {
+    (
+        quote!( #root::__macro_support::Relate::ge(__mid, #lo) ),
+        quote!( #root::__macro_support::Relate::le(__mid, #hi) ),
+    )
+}
+
+fn register_anonymous(model: &Expr, rel: Relations, root: &TokenStream2) -> TokenStream2 {
+    match rel {
+        Relations::Single(r) => quote!( (#model).__add_constraint_auto(#r) ),
+        Relations::Range { mid, lo, hi } => {
+            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
+            quote! {{
+                let __mid = #mid;
+                (#model).__add_constraint_auto(#lo_rel);
+                (#model).__add_constraint_auto(#hi_rel);
+            }}
+        }
+    }
+}
+
+fn register_named(
+    model: &Expr,
+    name_str: &str,
+    rel: Relations,
+    root: &TokenStream2,
+) -> TokenStream2 {
+    match rel {
+        Relations::Single(r) => quote!( (#model).__add_constraint(#name_str, #r) ),
+        Relations::Range { mid, lo, hi } => {
+            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
+            quote! {{
+                let __mid = #mid;
+                (#model).__add_constraint(::core::concat!(#name_str, "_lo"), #lo_rel);
+                (#model).__add_constraint(::core::concat!(#name_str, "_hi"), #hi_rel);
+            }}
+        }
+    }
+}
+
+fn register_computed(
+    model: &Expr,
+    name_expr: &TokenStream2,
+    rel: Relations,
+    root: &TokenStream2,
+) -> TokenStream2 {
+    match rel {
+        Relations::Single(r) => quote!( (#model).__add_constraint(#name_expr, #r) ),
+        Relations::Range { mid, lo, hi } => {
+            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
+            quote! {{
+                let __mid = #mid;
+                let __name = #name_expr;
+                (#model).__add_constraint(::std::format!("{__name}_lo"), #lo_rel);
+                (#model).__add_constraint(::std::format!("{__name}_hi"), #hi_rel);
+            }}
+        }
+    }
+}
+
+fn register_family(
+    model: &Expr,
+    name_str: &str,
+    set: &TokenStream2,
+    param: &TokenStream2,
+    rel: Relations,
+    root: &TokenStream2,
+) -> TokenStream2 {
+    match rel {
+        Relations::Single(r) => quote! {
+            (#model).__add_constraints_over(#name_str, &(#set), |#param| #r);
+        },
+        Relations::Range { mid, lo, hi } => {
+            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
+            quote! {{
+                let __set = #set;
+                (#model).__add_constraints_over(::core::concat!(#name_str, "_lo"), &__set, |#param| {
+                    let __mid = #mid;
+                    #lo_rel
+                });
+                (#model).__add_constraints_over(::core::concat!(#name_str, "_hi"), &__set, |#param| {
+                    let __mid = #mid;
+                    #hi_rel
+                });
+            }}
+        }
+    }
 }

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -66,7 +66,7 @@ fn build_relation(tokens: TokenStream2, root: &TokenStream2) -> syn::Result<Toke
         ));
     };
     let method = op.method();
-    let lhs: Expr = syn::parse2(lhs)?;
-    let rhs: Expr = syn::parse2(rhs)?;
+    let lhs: Expr = syn::parse2(crate::index::rewrite_index_subscripts(lhs))?;
+    let rhs: Expr = syn::parse2(crate::index::rewrite_index_subscripts(rhs))?;
     Ok(quote!( #root::__macro_support::Relate::#method(#lhs, #rhs) ))
 }

--- a/crates/oximo-macros/src/index.rs
+++ b/crates/oximo-macros/src/index.rs
@@ -1,0 +1,169 @@
+//! Token rewriter for multi-index access `q[i, j, k]`.
+//!
+//! Inside the modeling macros' value expressions, an index-position bracket with
+//! top-level commas (`q[i, j, k]`) is rewritten to a parenthesized, auto-ref'd
+//! tuple (`q[(&(i), &(j), &(k))]`). A comma subscript is a syntax error for every
+//! std type (`Vec`/array/slice/`HashMap` all use single-arg or chained `x[i][j]`
+//! indexing), so a multi-arg bracket in index position is an
+//! [`IndexedVar`](../../oximo_core/struct.IndexedVar.html) access.
+
+use proc_macro2::{Delimiter, Group, TokenStream as TokenStream2, TokenTree};
+use quote::quote;
+
+use crate::split_top_commas;
+
+/// Rust keywords that may precede a `[` without it being a subscript.
+/// After these, a bracket starts a pattern or expression, not an index.
+fn is_keyword(id: &str) -> bool {
+    matches!(
+        id,
+        "for"
+            | "in"
+            | "if"
+            | "else"
+            | "while"
+            | "loop"
+            | "match"
+            | "let"
+            | "return"
+            | "move"
+            | "as"
+            | "where"
+            | "mut"
+            | "ref"
+            | "yield"
+            | "await"
+            | "break"
+            | "continue"
+            | "const"
+    )
+}
+
+/// Whether a freshly emitted token leaves us in "index position".
+fn subscriptable(tt: &TokenTree) -> bool {
+    match tt {
+        TokenTree::Ident(id) => !is_keyword(&id.to_string()),
+        TokenTree::Group(g) => {
+            matches!(g.delimiter(), Delimiter::Parenthesis | Delimiter::Bracket)
+        }
+        TokenTree::Literal(_) => true,
+        TokenTree::Punct(_) => false,
+    }
+}
+
+/// Rewrite every multi-arg index subscript in a value-expression token stream.
+pub(crate) fn rewrite_index_subscripts(ts: TokenStream2) -> TokenStream2 {
+    let mut out: Vec<TokenTree> = Vec::new();
+    let mut index_pos = false;
+
+    for tt in ts {
+        if let TokenTree::Group(g) = &tt {
+            let delim = g.delimiter();
+            let inner = rewrite_index_subscripts(g.stream());
+
+            if delim == Delimiter::Bracket && index_pos {
+                let mut elems = split_top_commas(inner.clone());
+                // trailing comma
+                elems.retain(|e| !e.is_empty());
+                if elems.len() >= 2 {
+                    let tuple = build_ref_tuple(&elems);
+                    let mut newg = Group::new(Delimiter::Bracket, tuple);
+                    newg.set_span(g.span());
+                    out.push(TokenTree::Group(newg));
+                    // the resulting `]` can be subscripted again
+                    index_pos = true;
+                    continue;
+                }
+            }
+
+            let mut newg = Group::new(delim, inner);
+            newg.set_span(g.span());
+            let g_tt = TokenTree::Group(newg);
+            index_pos = subscriptable(&g_tt);
+            out.push(g_tt);
+        } else {
+            index_pos = subscriptable(&tt);
+            out.push(tt);
+        }
+    }
+
+    out.into_iter().collect()
+}
+
+/// `[e0, e1, ..]` -> `(&(e0), &(e1), ..)`, leaving an element that already begins
+/// with `&` as-is.
+fn build_ref_tuple(elems: &[TokenStream2]) -> TokenStream2 {
+    let refd = elems.iter().map(ref_elem);
+    quote!( ( #(#refd),* ) )
+}
+
+fn ref_elem(e: &TokenStream2) -> TokenStream2 {
+    if let Some(TokenTree::Punct(p)) = e.clone().into_iter().next() {
+        if p.as_char() == '&' {
+            return e.clone();
+        }
+    }
+    quote!( &(#e) )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn norm(ts: TokenStream2) -> String {
+        ts.to_string().chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    fn rewrite(src: &str) -> String {
+        norm(rewrite_index_subscripts(src.parse().unwrap()))
+    }
+
+    fn unchanged(src: &str) {
+        let parsed: TokenStream2 = src.parse().unwrap();
+        assert_eq!(norm(rewrite_index_subscripts(parsed.clone())), norm(parsed), "{src}");
+    }
+
+    #[test]
+    fn rewrites_multi_index() {
+        assert_eq!(rewrite("q[i, j, k]"), "q[(&(i),&(j),&(k))]");
+        assert_eq!(rewrite("s[p, n]"), "s[(&(p),&(n))]");
+        assert_eq!(rewrite("s[p, n + 1]"), "s[(&(p),&(n+1))]");
+    }
+
+    #[test]
+    fn keeps_explicit_ref_components() {
+        assert_eq!(rewrite("q[&i, j, k]"), "q[(&i,&(j),&(k))]");
+    }
+
+    #[test]
+    fn leaves_single_index_and_chains() {
+        unchanged("cost[i]");
+        unchanged("sigma[i][j]");
+        unchanged("a[i + 1]");
+    }
+
+    #[test]
+    fn leaves_already_tupled() {
+        unchanged("q[(i, j, k)]");
+        unchanged("q[(&i, &j, k)]");
+    }
+
+    #[test]
+    fn leaves_array_and_macro_literals() {
+        unchanged("[1, 2, 3]");
+        unchanged("vec![1, 2, 3]");
+        unchanged("let a = [1, 2, 3];");
+        unchanged("foo([1, 2, 3])");
+    }
+
+    #[test]
+    fn leaves_slice_patterns_after_keyword() {
+        unchanged("for [a, b] in pairs {}");
+    }
+
+    #[test]
+    fn rewrites_inside_nested_groups() {
+        assert_eq!(rewrite("(q[i, j] + r[a, b])"), "(q[(&(i),&(j))]+r[(&(a),&(b))])");
+        assert_eq!(rewrite("foo(q[i, j])"), "foo(q[(&(i),&(j))])");
+    }
+}

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -9,6 +9,7 @@ use syn::Ident;
 
 mod bind;
 mod constraint;
+mod index;
 mod objective;
 mod param;
 mod sum;

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -175,6 +175,12 @@ fn parse_named(seg: TokenStream2) -> syn::Result<Named> {
         None => (None, None),
         Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => {
             let parsed: Binds = syn::parse2(g.stream())?;
+            if parsed.binds.is_empty() {
+                return Err(syn::Error::new(
+                    g.span(),
+                    "index family needs at least one binding, e.g. `name[i in domain]`",
+                ));
+            }
             (Some(parsed.binds), parsed.cond)
         }
         Some(other) => {

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -152,10 +152,11 @@ fn split_relops(ts: TokenStream2) -> (Vec<TokenStream2>, Vec<RelOp>) {
 }
 
 /// A parsed `name` or `name[binds]` "core" of a `variable!`/`constraint!`
-/// declaration.
+/// declaration. `cond` holds an optional `if` filter on the index family.
 struct Named {
     name: Ident,
     binds: Option<Vec<IndexBind>>,
+    cond: Option<syn::Expr>,
 }
 
 /// Parse a `name`/`name[i in dom, ...]` core out of a token segment.
@@ -170,17 +171,17 @@ fn parse_named(seg: TokenStream2) -> syn::Result<Named> {
         return Err(syn::Error::new(span, "expected a name identifier"));
     };
 
-    let binds = match tts.get(1) {
-        None => None,
+    let (binds, cond) = match tts.get(1) {
+        None => (None, None),
         Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => {
             let parsed: Binds = syn::parse2(g.stream())?;
-            Some(parsed.0)
+            (Some(parsed.binds), parsed.cond)
         }
         Some(other) => {
             return Err(syn::Error::new(other.span(), "expected `[index in domain, ...]`"));
         }
     };
-    Ok(Named { name, binds })
+    Ok(Named { name, binds, cond })
 }
 
 /// Build an owned `Set` token expression from one or more index bindings.

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -1,0 +1,193 @@
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+
+use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Delimiter, Spacing, TokenStream as TokenStream2, TokenTree};
+use quote::quote;
+use syn::Ident;
+
+mod bind;
+mod constraint;
+mod objective;
+mod param;
+mod sum;
+mod variable;
+
+use bind::{Binds, IndexBind};
+
+/// Resolve the path prefix used to reach `__macro_support`. Prefers the umbrella
+/// `oximo` crate (which re-exports the support module) and falls back to
+/// `oximo-core`.
+fn oximo_root() -> TokenStream2 {
+    fn to_path(found: &FoundCrate, fallback: &str) -> TokenStream2 {
+        let name = match found {
+            FoundCrate::Itself => fallback,
+            FoundCrate::Name(n) => n.as_str(),
+        };
+        let id = Ident::new(name, proc_macro2::Span::call_site());
+        quote!(::#id)
+    }
+
+    if let Ok(found) = crate_name("oximo") {
+        return to_path(&found, "oximo");
+    }
+    if let Ok(found) = crate_name("oximo-core") {
+        return to_path(&found, "oximo_core");
+    }
+    quote!(::oximo_core)
+}
+
+/// `variable!(model, spec)`, declare a decision variable (or an indexed family)
+/// and bind it to a local of the same name. See the crate docs for the grammar.
+#[proc_macro]
+pub fn variable(input: TokenStream) -> TokenStream {
+    variable::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `constraint!(model, [name|name[idx]], lhs <op> rhs)`, register a constraint,
+/// an auto-named anonymous constraint, or an indexed family of constraints.
+#[proc_macro]
+pub fn constraint(input: TokenStream) -> TokenStream {
+    constraint::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `objective!(model, Min|Max, expr)`, set the model objective and sense.
+#[proc_macro]
+pub fn objective(input: TokenStream) -> TokenStream {
+    objective::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `sum!(body for pat in domain[, pat in domain ...])`, algebraic summation,
+/// lowered to nested `sum_over` folds.
+#[proc_macro]
+pub fn sum(input: TokenStream) -> TokenStream {
+    sum::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `param!(model, name = value)`, declare a re-bindable scalar parameter and
+/// bind it to a local of the same name.
+#[proc_macro]
+pub fn param(input: TokenStream) -> TokenStream {
+    param::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+// ---------------------------------------------------------------------------
+// Shared token-walking helpers. The macros must accept forms that are not valid
+// `syn::Expr` (indexed `name[i in set]`, chained `lb <= x <= ub`), so a few
+// splits are done at the raw token-tree level.
+// ---------------------------------------------------------------------------
+
+/// Relational operator recognized inside `constraint!`/`variable!`.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum RelOp {
+    Le,
+    Ge,
+    Eq,
+}
+
+impl RelOp {
+    /// The `Relate` method this operator maps to.
+    fn method(self) -> Ident {
+        let name = match self {
+            RelOp::Le => "le",
+            RelOp::Ge => "ge",
+            RelOp::Eq => "eq",
+        };
+        Ident::new(name, proc_macro2::Span::call_site())
+    }
+}
+
+/// Split a token stream on top-level commas.
+fn split_top_commas(ts: TokenStream2) -> Vec<TokenStream2> {
+    let mut out = Vec::new();
+    let mut cur = Vec::new();
+    for tt in ts {
+        if let TokenTree::Punct(p) = &tt {
+            if p.as_char() == ',' {
+                out.push(cur.drain(..).collect());
+                continue;
+            }
+        }
+        cur.push(tt);
+    }
+    out.push(cur.into_iter().collect());
+    out
+}
+
+/// Split a token stream on top-level relational operators (`==`, `<=`, `>=`),
+/// returning the intervening segments and the operators between them.
+fn split_relops(ts: TokenStream2) -> (Vec<TokenStream2>, Vec<RelOp>) {
+    let tts: Vec<TokenTree> = ts.into_iter().collect();
+    let mut segs: Vec<TokenStream2> = Vec::new();
+    let mut ops: Vec<RelOp> = Vec::new();
+    let mut cur: Vec<TokenTree> = Vec::new();
+
+    let mut i = 0;
+    while i < tts.len() {
+        if let TokenTree::Punct(p1) = &tts[i] {
+            if p1.spacing() == Spacing::Joint && i + 1 < tts.len() {
+                if let TokenTree::Punct(p2) = &tts[i + 1] {
+                    let op = match (p1.as_char(), p2.as_char()) {
+                        ('<', '=') => Some(RelOp::Le),
+                        ('>', '=') => Some(RelOp::Ge),
+                        ('=', '=') => Some(RelOp::Eq),
+                        _ => None,
+                    };
+                    if let Some(op) = op {
+                        segs.push(cur.drain(..).collect());
+                        ops.push(op);
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+        }
+        cur.push(tts[i].clone());
+        i += 1;
+    }
+    segs.push(cur.into_iter().collect());
+    (segs, ops)
+}
+
+/// A parsed `name` or `name[binds]` "core" of a `variable!`/`constraint!`
+/// declaration.
+struct Named {
+    name: Ident,
+    binds: Option<Vec<IndexBind>>,
+}
+
+/// Parse a `name`/`name[i in dom, ...]` core out of a token segment.
+fn parse_named(seg: TokenStream2) -> syn::Result<Named> {
+    let tts: Vec<TokenTree> = seg.into_iter().collect();
+    let span = tts.first().map_or_else(proc_macro2::Span::call_site, TokenTree::span);
+    let TokenTree::Ident(name) = tts
+        .first()
+        .cloned()
+        .ok_or_else(|| syn::Error::new(span, "expected a variable/constraint name identifier"))?
+    else {
+        return Err(syn::Error::new(span, "expected a name identifier"));
+    };
+
+    let binds = match tts.get(1) {
+        None => None,
+        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => {
+            let parsed: Binds = syn::parse2(g.stream())?;
+            Some(parsed.0)
+        }
+        Some(other) => {
+            return Err(syn::Error::new(other.span(), "expected `[index in domain, ...]`"));
+        }
+    };
+    Ok(Named { name, binds })
+}
+
+/// Build an owned `Set` token expression from one or more index bindings.
+fn build_set(binds: &[IndexBind], root: &TokenStream2) -> TokenStream2 {
+    let mut iter = binds.iter().map(|b| {
+        let dom = &b.domain;
+        quote!(#root::__macro_support::as_set(&(#dom)))
+    });
+    let first = iter.next().expect("at least one index binding");
+    iter.fold(first, |acc, s| quote!(#root::__macro_support::product(&(#acc), &(#s))))
+}

--- a/crates/oximo-macros/src/objective.rs
+++ b/crates/oximo-macros/src/objective.rs
@@ -1,0 +1,37 @@
+//! `objective!(model, Min|Max, expr)`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Expr, Ident, Token};
+
+struct ObjectiveInput {
+    model: Expr,
+    sense: Ident,
+    expr: Expr,
+}
+
+impl Parse for ObjectiveInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let model = input.parse::<Expr>()?;
+        input.parse::<Token![,]>()?;
+        let sense = input.parse::<Ident>()?;
+        input.parse::<Token![,]>()?;
+        let expr = input.parse::<Expr>()?;
+        Ok(Self { model, sense, expr })
+    }
+}
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let ObjectiveInput { model, sense, expr } = syn::parse2(input)?;
+
+    let method = match sense.to_string().as_str() {
+        "Min" | "Minimize" | "min" => quote!(__minimize),
+        "Max" | "Maximize" | "max" => quote!(__maximize),
+        _ => {
+            return Err(syn::Error::new(sense.span(), "objective sense must be `Min` or `Max`"));
+        }
+    };
+
+    Ok(quote!( (#model).#method(#expr) ))
+}

--- a/crates/oximo-macros/src/objective.rs
+++ b/crates/oximo-macros/src/objective.rs
@@ -23,6 +23,8 @@ impl Parse for ObjectiveInput {
 }
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    // Rewrite `q[i, j, k]` index sugar in the objective expression.
+    let input = crate::index::rewrite_index_subscripts(input);
     let ObjectiveInput { model, sense, expr } = syn::parse2(input)?;
 
     let method = match sense.to_string().as_str() {

--- a/crates/oximo-macros/src/objective.rs
+++ b/crates/oximo-macros/src/objective.rs
@@ -1,4 +1,5 @@
-//! `objective!(model, Min|Max, expr)`.
+//! `objective!(model, Min|Max, expr)`. The sense also accepts the long forms
+//! `Minimize`/`Maximize` and lowercase `min`/`max`.
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
@@ -31,7 +32,10 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         "Min" | "Minimize" | "min" => quote!(__minimize),
         "Max" | "Maximize" | "max" => quote!(__maximize),
         _ => {
-            return Err(syn::Error::new(sense.span(), "objective sense must be `Min` or `Max`"));
+            return Err(syn::Error::new(
+                sense.span(),
+                "objective sense must be `Min`/`Minimize` or `Max`/`Maximize`",
+            ));
         }
     };
 

--- a/crates/oximo-macros/src/objective.rs
+++ b/crates/oximo-macros/src/objective.rs
@@ -34,7 +34,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         _ => {
             return Err(syn::Error::new(
                 sense.span(),
-                "objective sense must be `Min`/`Minimize` or `Max`/`Maximize`",
+                "objective sense must be `Min`/`min`/`Minimize` or `Max`/`max`/`Maximize`",
             ));
         }
     };

--- a/crates/oximo-macros/src/param.rs
+++ b/crates/oximo-macros/src/param.rs
@@ -1,0 +1,29 @@
+//! `param!(model, name = value)`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Expr, Ident, Token};
+
+struct ParamInput {
+    model: Expr,
+    name: Ident,
+    value: Expr,
+}
+
+impl Parse for ParamInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let model = input.parse::<Expr>()?;
+        input.parse::<Token![,]>()?;
+        let name = input.parse::<Ident>()?;
+        input.parse::<Token![=]>()?;
+        let value = input.parse::<Expr>()?;
+        Ok(Self { model, name, value })
+    }
+}
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let ParamInput { model, name, value } = syn::parse2(input)?;
+    let name_str = name.to_string();
+    Ok(quote!( let #name = (#model).__param(#name_str, f64::from(#value)); ))
+}

--- a/crates/oximo-macros/src/sum.rs
+++ b/crates/oximo-macros/src/sum.rs
@@ -49,15 +49,11 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         return Ok(expr);
     };
 
-    // Filtered: iterate the (decoded) keys with nested `for` loops, skipping
-    // keys that fail `cond`, and accumulate only the matching terms.
+    // Filtered: iterate the (decoded) keys with nested `for` loops, pushing only
+    // the matching terms, then flatten them in one pass (`sum_terms`).
     let mut inner = quote! {
         if #cond {
-            let __term = #body;
-            __acc = ::core::option::Option::Some(match __acc {
-                ::core::option::Option::Some(__a) => __a + __term,
-                ::core::option::Option::None => __term,
-            });
+            __terms.push(#body);
         }
     };
     for b in binds.iter().rev() {
@@ -75,8 +71,12 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         };
     }
     Ok(quote! {{
-        let mut __acc = ::core::option::Option::None;
+        let mut __terms = ::std::vec::Vec::new();
         #inner
-        __acc.expect("sum! with an `if` filter produced no terms")
+        ::core::assert!(
+            !__terms.is_empty(),
+            "sum! with an `if` filter produced no terms"
+        );
+        #root::__macro_support::sum_terms(__terms)
     }})
 }

--- a/crates/oximo-macros/src/sum.rs
+++ b/crates/oximo-macros/src/sum.rs
@@ -34,6 +34,8 @@ impl Parse for SumInput {
 }
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    // Rewrite `q[i, j, k]` index sugar in the body / filter.
+    let input = crate::index::rewrite_index_subscripts(input);
     let SumInput { body, binds, cond } = syn::parse2(input)?;
     let root = oximo_root();
 

--- a/crates/oximo-macros/src/sum.rs
+++ b/crates/oximo-macros/src/sum.rs
@@ -1,0 +1,76 @@
+//! `sum!(body for pat in domain[, pat in domain ...][ if cond])`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Expr, Token};
+
+use crate::IndexBind;
+use crate::oximo_root;
+
+struct SumInput {
+    body: Expr,
+    binds: Vec<IndexBind>,
+    cond: Option<Expr>,
+}
+
+impl Parse for SumInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let body = input.parse::<Expr>()?;
+        input.parse::<Token![for]>()?;
+        let binds = Punctuated::<IndexBind, Token![,]>::parse_separated_nonempty(input)?;
+        let cond = if input.peek(Token![if]) {
+            input.parse::<Token![if]>()?;
+            Some(input.parse::<Expr>()?)
+        } else {
+            None
+        };
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after `sum!` clauses"));
+        }
+        Ok(Self { body, binds: binds.into_iter().collect(), cond })
+    }
+}
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let SumInput { body, binds, cond } = syn::parse2(input)?;
+    let root = oximo_root();
+
+    let Some(cond) = cond else {
+        let mut expr = quote!(#body);
+        for b in binds.iter().rev() {
+            let param = b.closure_param();
+            let domain = &b.domain;
+            expr = quote!( #root::__macro_support::sum_over(&(#domain), |#param| #expr) );
+        }
+        return Ok(expr);
+    };
+
+    // Filtered: iterate the (decoded) keys with nested `for` loops, skipping
+    // keys that fail `cond`, and accumulate only the matching terms.
+    let mut inner = quote! {
+        if #cond {
+            let __term = #body;
+            __acc = ::core::option::Option::Some(match __acc {
+                ::core::option::Option::Some(__a) => __a + __term,
+                ::core::option::Option::None => __term,
+            });
+        }
+    };
+    for b in binds.iter().rev() {
+        let pat = &b.pat;
+        let ty = b.key_type();
+        let domain = &b.domain;
+        inner = quote! {
+            for #pat in #root::__macro_support::keys_of::<#ty, _>(&(#domain)) {
+                #inner
+            }
+        };
+    }
+    Ok(quote! {{
+        let mut __acc = ::core::option::Option::None;
+        #inner
+        __acc.expect("sum! with an `if` filter produced no terms")
+    }})
+}

--- a/crates/oximo-macros/src/sum.rs
+++ b/crates/oximo-macros/src/sum.rs
@@ -60,10 +60,14 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     };
     for b in binds.iter().rev() {
         let pat = &b.pat;
-        let ty = b.key_type();
         let domain = &b.domain;
+        let keys = if let Some(ty) = b.keys_of_type() {
+            quote!( #root::__macro_support::keys_of::<#ty, _>(&(#domain)) )
+        } else {
+            quote!( #root::__macro_support::keys_of(&(#domain)) )
+        };
         inner = quote! {
-            for #pat in #root::__macro_support::keys_of::<#ty, _>(&(#domain)) {
+            for #pat in #keys {
                 #inner
             }
         };

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -9,6 +9,7 @@ use proc_macro2::{TokenStream as TokenStream2, TokenTree};
 use quote::{ToTokens, quote};
 use syn::{Ident, Pat};
 
+use crate::bind::filtered_set;
 use crate::{
     IndexBind, Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas,
 };
@@ -65,7 +66,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let lb = lb.map(crate::index::rewrite_index_subscripts);
     let ub = ub.map(crate::index::rewrite_index_subscripts);
 
-    let Named { name, binds } = parse_named(core)?;
+    let Named { name, binds, cond } = parse_named(core)?;
     let name_str = name.to_string();
     let root = oximo_root();
 
@@ -107,6 +108,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         },
         Some(binds) => {
             let set = build_set(&binds, &root);
+            let set = filtered_set(set, &binds, cond.as_ref(), &root);
             quote! {
                 let #name = {
                     let __set = #set;

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -61,6 +61,10 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         }
     };
 
+    // Bound expressions are value expressions, so `q[i, j]` index sugar applies.
+    let lb = lb.map(crate::index::rewrite_index_subscripts);
+    let ub = ub.map(crate::index::rewrite_index_subscripts);
+
     let Named { name, binds } = parse_named(core)?;
     let name_str = name.to_string();
     let root = oximo_root();

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -122,16 +122,26 @@ enum BoundKind {
 
 /// Closure parameter for a per-key (`.lb_by`/`.ub_by`) bound: each index the
 /// bound does not reference is replaced with `_`, so the generated closure never
-/// has an unused parameter.
+/// has an unused parameter. The builder's key type pins the parameter, so it is
+/// left bare for inference unless the user annotated every binding.
 fn bound_closure_param(binds: &[IndexBind], bound: &TokenStream2) -> TokenStream2 {
-    if let [single] = binds {
-        let p = mask_pat(&single.pat, bound);
-        let ty = single.key_type();
-        return quote!(#p: #ty);
+    let masked = binds.iter().map(|b| mask_pat(&b.pat, bound));
+    let pattern = if binds.len() == 1 {
+        let p = mask_pat(&binds[0].pat, bound);
+        quote!(#p)
+    } else {
+        quote!( (#(#masked),*) )
+    };
+
+    let tys: Option<Vec<&syn::Type>> = binds.iter().map(|b| b.ty.as_ref()).collect();
+    match tys {
+        Some(tys) if binds.len() == 1 => {
+            let ty = tys[0];
+            quote!(#pattern: #ty)
+        }
+        Some(tys) => quote!( #pattern: (#(#tys),*) ),
+        None => pattern,
     }
-    let pats = binds.iter().map(|b| mask_pat(&b.pat, bound));
-    let tys = binds.iter().map(IndexBind::key_type);
-    quote!( (#(#pats),*): (#(#tys),*) )
 }
 
 /// Replace each bare-ident sub-pattern the bound does not reference with `_`,

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -121,7 +121,7 @@ enum BoundKind {
 }
 
 /// Closure parameter for a per-key (`.lb_by`/`.ub_by`) bound: each index the
-/// bound does not reference is replaced with `_`, so the generated closure never 
+/// bound does not reference is replaced with `_`, so the generated closure never
 /// has an unused parameter.
 fn bound_closure_param(binds: &[IndexBind], bound: &TokenStream2) -> TokenStream2 {
     if let [single] = binds {

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -1,0 +1,170 @@
+//! `variable!(model, spec[, Bin|Int])`.
+//!
+//! Accepted `spec` shapes (where `name` may be `name` or `name[i in dom, ...]`):
+//! `name`, `name >= lb`, `name <= ub`, `lb <= name <= ub`. Bounds may reference
+//! the index variables (e.g. `b[i in I] <= b_max[i]`), in which case they are
+//! lowered to the builder's per-key `.lb_by` / `.ub_by`.
+
+use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+use quote::{ToTokens, quote};
+use syn::{Ident, Pat};
+
+use crate::{
+    IndexBind, Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas,
+};
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let mut parts = split_top_commas(input).into_iter();
+    let model = parts.next().expect("split always yields at least one segment");
+    let model: syn::Expr = syn::parse2(model)?;
+
+    let spec = parts.next().ok_or_else(|| {
+        syn::Error::new(proc_macro2::Span::call_site(), "variable! needs a `name`/bounds spec")
+    })?;
+    let domain = parts.next();
+    if let Some(extra) = parts.next() {
+        return Err(syn::Error::new_spanned(extra, "unexpected trailing tokens in variable!"));
+    }
+
+    let domain_method = match domain {
+        None => quote!(),
+        Some(ts) => {
+            let id: Ident = syn::parse2(ts)?;
+            match id.to_string().as_str() {
+                "Bin" | "Binary" => quote!(.binary()),
+                "Int" | "Integer" => quote!(.integer()),
+                "Real" | "Cont" | "Continuous" => quote!(),
+                _ => {
+                    return Err(syn::Error::new(
+                        id.span(),
+                        "domain must be `Bin`, `Int`, or `Real`",
+                    ));
+                }
+            }
+        }
+    };
+
+    // Split the bound spec on relational operators and identify the core name.
+    let (segs, ops) = split_relops(spec);
+    let (core, lb, ub) = match (segs.len(), ops.as_slice()) {
+        (1, []) => (segs[0].clone(), None, None),
+        (2, [RelOp::Le]) => (segs[0].clone(), None, Some(segs[1].clone())),
+        (2, [RelOp::Ge]) => (segs[0].clone(), Some(segs[1].clone()), None),
+        (3, [RelOp::Le, RelOp::Le]) => {
+            (segs[1].clone(), Some(segs[0].clone()), Some(segs[2].clone()))
+        }
+        _ => {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "variable! bounds must be `name`, `name >= lb`, `name <= ub`, or `lb <= name <= ub`",
+            ));
+        }
+    };
+
+    let Named { name, binds } = parse_named(core)?;
+    let name_str = name.to_string();
+    let root = oximo_root();
+
+    let mut idents = Vec::new();
+    if let Some(binds) = &binds {
+        for b in binds {
+            collect_idents(&b.pat.to_token_stream(), &mut idents);
+        }
+    }
+    let binds_slice = binds.as_deref();
+
+    let bound_method = |val: &TokenStream2, kind: BoundKind| -> TokenStream2 {
+        match binds_slice {
+            Some(bs) if references_any(val, &idents) => {
+                let param = bound_closure_param(bs, val);
+                match kind {
+                    BoundKind::Lb => quote!(.lb_by(move |#param| f64::from(#val))),
+                    BoundKind::Ub => quote!(.ub_by(move |#param| f64::from(#val))),
+                }
+            }
+            _ => match kind {
+                BoundKind::Lb => quote!(.lb(f64::from(#val))),
+                BoundKind::Ub => quote!(.ub(f64::from(#val))),
+            },
+        }
+    };
+
+    let mut bounds = TokenStream2::new();
+    if let Some(lb) = &lb {
+        bounds.extend(bound_method(lb, BoundKind::Lb));
+    }
+    if let Some(ub) = &ub {
+        bounds.extend(bound_method(ub, BoundKind::Ub));
+    }
+
+    let expanded = match binds {
+        None => quote! {
+            let #name = (#model).__var(#name_str) #domain_method #bounds .build();
+        },
+        Some(binds) => {
+            let set = build_set(&binds, &root);
+            quote! {
+                let #name = {
+                    let __set = #set;
+                    (#model).__indexed_var(#name_str, &__set) #domain_method #bounds .build()
+                };
+            }
+        }
+    };
+    Ok(expanded)
+}
+
+#[derive(Copy, Clone)]
+enum BoundKind {
+    Lb,
+    Ub,
+}
+
+/// Closure parameter for a per-key (`.lb_by`/`.ub_by`) bound: each index the
+/// bound does not reference is replaced with `_`, so the generated closure never 
+/// has an unused parameter.
+fn bound_closure_param(binds: &[IndexBind], bound: &TokenStream2) -> TokenStream2 {
+    if let [single] = binds {
+        let p = mask_pat(&single.pat, bound);
+        let ty = single.key_type();
+        return quote!(#p: #ty);
+    }
+    let pats = binds.iter().map(|b| mask_pat(&b.pat, bound));
+    let tys = binds.iter().map(IndexBind::key_type);
+    quote!( (#(#pats),*): (#(#tys),*) )
+}
+
+/// Replace each bare-ident sub-pattern the bound does not reference with `_`,
+/// recursing into tuple patterns.
+fn mask_pat(pat: &Pat, bound: &TokenStream2) -> TokenStream2 {
+    match pat {
+        Pat::Tuple(t) => {
+            let elems = t.elems.iter().map(|e| mask_pat(e, bound));
+            quote!( (#(#elems),*) )
+        }
+        Pat::Ident(pi) if pi.subpat.is_none() && pi.by_ref.is_none() => {
+            if references_any(bound, &[pi.ident.to_string()]) { quote!(#pat) } else { quote!(_) }
+        }
+        _ => quote!(#pat),
+    }
+}
+
+/// Collect every identifier appearing in a token stream (recursing into groups).
+fn collect_idents(ts: &TokenStream2, out: &mut Vec<String>) {
+    for tt in ts.clone() {
+        match tt {
+            TokenTree::Ident(id) => out.push(id.to_string()),
+            TokenTree::Group(g) => collect_idents(&g.stream(), out),
+            _ => {}
+        }
+    }
+}
+
+/// Whether a token stream references any of the given identifiers.
+fn references_any(ts: &TokenStream2, idents: &[String]) -> bool {
+    ts.clone().into_iter().any(|tt| match tt {
+        TokenTree::Ident(id) => idents.contains(&id.to_string()),
+        TokenTree::Group(g) => references_any(&g.stream(), idents),
+        _ => false,
+    })
+}

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -1,13 +1,16 @@
-//! `variable!(model, spec[, Bin|Int])`.
+//! `variable!(model, spec[, domain])`.
 //!
 //! Accepted `spec` shapes (where `name` may be `name` or `name[i in dom, ...]`):
 //! `name`, `name >= lb`, `name <= ub`, `lb <= name <= ub`. Bounds may reference
 //! the index variables (e.g. `b[i in I] <= b_max[i]`), in which case they are
 //! lowered to the builder's per-key `.lb_by` / `.ub_by`.
+//!
+//! The optional trailing `domain` is `Bin`/`Int`/`Real` (and aliases) or a call
+//! `SemiCont(thr)` / `SemiContinuous(thr)` / `SemiInt(thr)` / `SemiInteger(thr)`.
 
 use proc_macro2::{TokenStream as TokenStream2, TokenTree};
 use quote::{ToTokens, quote};
-use syn::{Ident, Pat};
+use syn::Pat;
 
 use crate::bind::filtered_set;
 use crate::{
@@ -27,22 +30,10 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         return Err(syn::Error::new_spanned(extra, "unexpected trailing tokens in variable!"));
     }
 
+    let root = oximo_root();
     let domain_method = match domain {
         None => quote!(),
-        Some(ts) => {
-            let id: Ident = syn::parse2(ts)?;
-            match id.to_string().as_str() {
-                "Bin" | "Binary" => quote!(.binary()),
-                "Int" | "Integer" => quote!(.integer()),
-                "Real" | "Cont" | "Continuous" => quote!(),
-                _ => {
-                    return Err(syn::Error::new(
-                        id.span(),
-                        "domain must be `Bin`, `Int`, or `Real`",
-                    ));
-                }
-            }
-        }
+        Some(ts) => domain_method(ts, &root)?,
     };
 
     // Split the bound spec on relational operators and identify the core name.
@@ -68,7 +59,6 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
 
     let Named { name, binds, cond } = parse_named(core)?;
     let name_str = name.to_string();
-    let root = oximo_root();
 
     let mut idents = Vec::new();
     if let Some(binds) = &binds {
@@ -118,6 +108,52 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         }
     };
     Ok(expanded)
+}
+
+/// Map the trailing domain token to the builder method. Accepts the bare-ident
+/// forms (`Bin`/`Int`/`Real` and aliases) and the call forms `SemiCont(thr)`/
+/// `SemiContinuous(thr)`/`SemiInt(thr)`/`SemiInteger(thr)`, where `thr` is the
+/// semicontinuous threshold (`f64`).
+fn domain_method(ts: TokenStream2, root: &TokenStream2) -> syn::Result<TokenStream2> {
+    const HELP: &str = "domain must be `Bin`, `Int`, `Real`, `SemiCont(thr)`, or `SemiInt(thr)`";
+    match syn::parse2::<syn::Expr>(ts)? {
+        syn::Expr::Path(p) => {
+            let id = p.path.get_ident().ok_or_else(|| syn::Error::new_spanned(&p, HELP))?;
+            match id.to_string().as_str() {
+                "Bin" | "Binary" => Ok(quote!(.binary())),
+                "Int" | "Integer" => Ok(quote!(.integer())),
+                "Real" | "Cont" | "Continuous" => Ok(quote!()),
+                "SemiCont" | "SemiContinuous" | "SemiInt" | "SemiInteger" => {
+                    Err(syn::Error::new_spanned(
+                        id,
+                        format!("`{id}` needs a threshold, e.g. `{id}(1.0)`"),
+                    ))
+                }
+                _ => Err(syn::Error::new_spanned(id, HELP)),
+            }
+        }
+        syn::Expr::Call(call) => {
+            let syn::Expr::Path(fp) = &*call.func else {
+                return Err(syn::Error::new_spanned(&call.func, HELP));
+            };
+            let func = fp.path.get_ident().ok_or_else(|| syn::Error::new_spanned(fp, HELP))?;
+            let variant = match func.to_string().as_str() {
+                "SemiCont" | "SemiContinuous" => quote!(SemiContinuous),
+                "SemiInt" | "SemiInteger" => quote!(SemiInteger),
+                _ => return Err(syn::Error::new_spanned(func, HELP)),
+            };
+            let [thr] = call.args.iter().collect::<Vec<_>>()[..] else {
+                return Err(syn::Error::new_spanned(
+                    &call,
+                    format!("`{func}` takes exactly one threshold argument, e.g. `{func}(1.0)`"),
+                ));
+            };
+            Ok(quote! {
+                .domain(#root::__macro_support::Domain::#variant { threshold: f64::from(#thr) })
+            })
+        }
+        other => Err(syn::Error::new_spanned(other, HELP)),
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -273,12 +273,12 @@ mod tests {
 
     #[test]
     fn report_renders_sections() {
-        use oximo_core::Relate;
+        use oximo_core::{constraint, objective, variable};
 
         let m = Model::new("toy");
-        let x = m.var("x").lb(0.0).build();
-        let c = m.constraint("c", x.le(5.0));
-        m.maximize(x);
+        variable!(m, x >= 0.0);
+        let c = constraint!(m, c, x <= 5.0);
+        objective!(m, Max, x);
 
         let mut primal = FxHashMap::default();
         primal.insert(x.var_id().unwrap(), 5.0);

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -41,7 +41,11 @@ impl SolutionPoint {
     ///
     /// Returns `None` if `key` is not in the variable's set or the solver did
     /// not return a primal value for that scalar.
-    pub fn value_of_idx<K: Into<IndexKey>>(&self, var: &IndexedVar<'_>, key: K) -> Option<f64> {
+    pub fn value_of_idx<V, K: Into<IndexKey>>(
+        &self,
+        var: &IndexedVar<'_, V>,
+        key: K,
+    ) -> Option<f64> {
         var.get(key).and_then(|e| self.value_of(e))
     }
 
@@ -49,9 +53,9 @@ impl SolutionPoint {
     ///
     /// Yields `(&IndexKey, f64)` for every index whose primal value is present
     /// in the solution.
-    pub fn values_of<'iv, 'a>(
+    pub fn values_of<'iv, 'a, V>(
         &'iv self,
-        var: &'iv IndexedVar<'a>,
+        var: &'iv IndexedVar<'a, V>,
     ) -> impl Iterator<Item = (&'iv IndexKey, f64)> + 'iv {
         var.iter().filter_map(|(k, e)| self.value_of(*e).map(|v| (k, v)))
     }
@@ -135,15 +139,19 @@ impl SolverResult {
 
     /// Look up the best solution's primal value for a specific index of an
     /// [`IndexedVar`].
-    pub fn value_of_idx<K: Into<IndexKey>>(&self, var: &IndexedVar<'_>, key: K) -> Option<f64> {
+    pub fn value_of_idx<V, K: Into<IndexKey>>(
+        &self,
+        var: &IndexedVar<'_, V>,
+        key: K,
+    ) -> Option<f64> {
         var.get(key).and_then(|e| self.value_of(e))
     }
 
     /// Iterate over the best solution's primal values for all entries of an
     /// [`IndexedVar`]. Yields nothing when no solution was found.
-    pub fn values_of<'iv, 'a>(
+    pub fn values_of<'iv, 'a, V>(
         &'iv self,
-        var: &'iv IndexedVar<'a>,
+        var: &'iv IndexedVar<'a, V>,
     ) -> impl Iterator<Item = (&'iv IndexKey, f64)> + 'iv {
         var.iter().filter_map(|(k, e)| self.value_of(*e).map(|v| (k, v)))
     }

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -14,20 +14,20 @@
     <img src="https://img.shields.io/github/actions/workflow/status/oximo-rs/oximo/ci.yml?branch=main&label=oximo%20CI&logo=github" alt="CI" />
 </a>
 
-oximo is a Rust algebraic modeling library for mathematical optimization. Build LP, MILP, QP/MIQP, NLP, and MINLP models with a clean builder API, then solve them with bundled or commercial solvers.
+oximo is a Rust algebraic modeling library for mathematical optimization. Build LP, MILP, QP/MIQP, NLP, and MINLP models with a concise macro API, then solve them with bundled or commercial solvers.
 
 ```rust,no_run
 use oximo::prelude::*;
 use oximo::solvers::Highs;
 
 let m = Model::new("transport");
-let x = m.var("x").lb(0.0).build();
-let y = m.var("y").lb(0.0).ub(4.0).build();
+variable!(m, x >= 0.0);
+variable!(m, 0.0 <= y <= 4.0);
 
-m.constraint("c1", (x + 2.0 * y).le(14.0));
-m.constraint("c2", (3.0 * x).ge(y));
-m.constraint("c3", x.le(y + 2.0));
-m.maximize(3.0 * x + 4.0 * y);
+constraint!(m, c1, x + 2.0 * y <= 14.0);
+constraint!(m, c2, 3.0 * x >= y);
+constraint!(m, c3, x <= y + 2.0);
+objective!(m, Max, 3.0 * x + 4.0 * y);
 
 let result = Highs.solve(&m, &HighsOptions::default())?;
 println!("obj = {:?}", result.objective()); // 34.0
@@ -43,25 +43,29 @@ println!("y   = {:?}", result.value_of(y)); // 4.0
 ```rust,ignore
 let m = Model::new("my_model");
 
-let x = m.var("x").lb(0.0).build();           // continuous, x >= 0
-let y = m.var("y").lb(0.0).ub(10.0).build();  // continuous, 0 <= y <= 10
-let z = m.var("z").build();                   // free (unbounded by default)
-let b = m.var("b").binary().build();          // binary {0, 1}
-let n = m.var("n").lb(0.0).integer().build(); // general integer
+variable!(m, x >= 0.0);                 // continuous, x >= 0
+variable!(m, 0.0 <= y <= 10.0);         // continuous, 0 <= y <= 10
+variable!(m, z);                        // free (unbounded by default)
+variable!(m, b, Bin);                   // binary {0, 1}   (also Binary)
+variable!(m, n >= 0.0, Int);            // general integer (also Integer)
+variable!(m, s <= 10.0, SemiCont(2.0)); // semicontinuous: 0 or in [2, 10] (SemiInt too)
 ```
 
 ### Constraints and objectives
 
-Expressions are built with standard Rust operators. Scalar multiplication, addition, subtraction, and nonlinear operations (see [Nonlinear Expressions](#nonlinear-expressions)) all work out of the box:
+Expressions are built with standard Rust operators. The macros let you write the
+relational operators `==`, `<=`, `>=` directly. Scalar multiplication, addition,
+subtraction, and nonlinear operations (see [Nonlinear Expressions](#nonlinear-expressions)) all work out of the box:
 
 ```rust,ignore
-m.constraint("cap", (2.0 * x + 3.0 * y).le(100.0));
-m.constraint("demand", x.ge(5.0));
-m.constraint("balance", (x - y).eq(0.0));
+constraint!(m, cap, 2.0 * x + 3.0 * y <= 100.0);
+constraint!(m, demand, x >= 5.0);
+constraint!(m, balance, x - y == 0.0);
+constraint!(m, band, 1.0 <= x + y <= 10.0); // two-sided range -> band_lo + band_hi
 
-m.minimize(3.0 * x + 5.0 * y);
+objective!(m, Min, 3.0 * x + 5.0 * y);
 // or
-m.maximize(x + 2.0 * y);
+objective!(m, Max, x + 2.0 * y);            // also Minimize/min, Maximize/max
 ```
 
 ### Index sets
@@ -90,69 +94,55 @@ let arcs = (&plants * &plants).filter(|k| {
 
 ### Indexed variables
 
-`Model::indexed_var(name, &set)` registers one scalar per key with auto-named
-entries like `x[seattle,nyc]`. Bounds apply uniformly by default, you can use
-`lb_by` / `ub_by` for per-key bounds.
+`variable!(m, x[k in set])` registers one scalar per key with auto-named entries
+like `x[seattle,nyc]`. Bounds apply uniformly by default.
 
 ```rust,ignore
 let m = Model::new("transport");
-let x = m.indexed_var("x", &routes).lb(0.0).build();
+variable!(m, x[r in routes] >= 0.0);
 
 // Scalar lookup: any type that converts to IndexKey works.
 let e1 = x[("seattle", "nyc")];
 let e2 = x[("san-diego", "chi")];
 
-// Per-key upper bound (e.g. capacity per arc).
-let _y = m.indexed_var("y", &routes)
-    .lb(0.0)
-    .ub_by(|(p, q): (String, String)| capacity_for(&p, &q))
-    .build();
+// Per-key upper bound (capacity per arc) -> index-dependent bound.
+variable!(m, 0.0 <= y[(p, q) in routes] <= capacity_for(&p, &q));
 ```
 
 ### Summing over sets
 
-`sum_over(&set, |k| expr)` reads as `sum_{k in set} expr(k)`. The closure
-receives the index as a typed value via `FromIndexKey`. Built-in impls cover
-`i64`, `i32`, `usize`, `String`, raw `IndexKey`, and tuples up to arity 4.
-State the shape in the closure-arg annotation.
+`sum!(body for k in set)` reads as `sum_{k in set} body`.
 
 ```rust,ignore
 // Single sum: sum_{i in items} weights[i] * x[i]
-let total_weight = sum_over(&items, |i: usize| weights[i] * x[i]);
-m.constraint("cap", total_weight.le(capacity));
+constraint!(m, cap, sum!(weights[i] * x[i] for i in items) <= capacity);
 
 // Double sum, flat: sum_{(p,q) in P*M} c[p,q] * x[p,q]
-let total_cost = sum_over(&(&plants * &markets), |(p, q): (String, String)| {
-    c[(&p, &q)] * x[(p, q)]
-});
+let total_cost = sum!(c[p, q] * x[p, q] for p in plants, q in markets);
 
-// Coefficient-weighted sum on paired Vecs: sum_{i} w_i * x_i
-let weight_sum = dot(&xs, &weights);
-
-// Freeform iterator -> use Iterator::sum.
-let active = (0..n).filter(|&i| online[i]).map(|i| x[i]).sum::<Expr>();
+// Filtered sum.
+let active = sum!(x[i] for i in 0..n if online[i]);
 ```
 
 ### Rule-style constraints
 
-`Model::add_constraints_over` is the constraint equivalent of `sum_over`, a
-closure receives the index as a typed value and returns one constraint per
-set element.
+The indexed form of `constraint!` emits one constraint per key, auto-named like
+`supply[seattle]`. A trailing `if` filters the keys, and `name = expr` gives a
+computed run-time name.
 
 ```rust,ignore
 // Scalar set: one constraint per period.
 let periods = Set::range(0..T);
-m.add_constraints_over("setup", &periods, |t: usize| {
-    (x[t] - capacity * s[t]).le(0.0)
-});
+constraint!(m, setup[t in periods], x[t] <= capacity * s[t]);
 
-// Tuple set: destructure inline. Inner `sum_over` builds the LHS expression.
-m.add_constraints_over("supply", &plants, |p: String| {
-    sum_over(&markets, |q: String| x[(&p, q)]).le(supply_of(&p))
-});
+// Tuple set + inner sum builds the LHS expression (key types inferred).
+constraint!(m, supply[p in plants], sum!(x[p, q] for q in markets) <= supply_of(&p));
 
-// Want the raw key? Annotate as IndexKey (clones once per iteration).
-m.add_constraints_over("c", &set, |k: IndexKey| x[&k].le(1.0));
+// Filtered family: only the keys passing the guard are built.
+constraint!(m, diag[(i, j) in arcs if i == j], x[i, j] <= 1.0);
+
+// Computed run-time name.
+constraint!(m, name = format!("bal_{p}"), inflow[p] - outflow[p] == 0.0);
 ```
 
 ### Nonlinear expressions
@@ -163,13 +153,13 @@ expressions.
 
 ```rust,ignore
 // Rosenbrock NLP
-m.minimize((1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
+objective!(m, Min, (1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
 
 // Quadratic constraint
-m.constraint("disk", (x.powi(2) + y.powi(2)).le(1.0));
+constraint!(m, disk, x.powi(2) + y.powi(2) <= 1.0);
 
 // Transcendental utility (MINLP when any variable is integer/binary)
-m.maximize(sum_over(&items, |i: usize| u[i] * (1.0 + w[i] * x[i]).log()));
+objective!(m, Max, sum!(u[i] * (1.0 + w[i] * x[i]).log() for i in items));
 ```
 
 ## Solving

--- a/crates/oximo/examples/baron_robot.rs
+++ b/crates/oximo/examples/baron_robot.rs
@@ -36,34 +36,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let m = Model::new("robot");
 
     // Eight unknowns, each in [-1, 1].
-    let x1 = m.var("x1").lb(-1.0).ub(1.0).build();
-    let x2 = m.var("x2").lb(-1.0).ub(1.0).build();
-    let x3 = m.var("x3").lb(-1.0).ub(1.0).build();
-    let x4 = m.var("x4").lb(-1.0).ub(1.0).build();
-    let x5 = m.var("x5").lb(-1.0).ub(1.0).build();
-    let x6 = m.var("x6").lb(-1.0).ub(1.0).build();
-    let x7 = m.var("x7").lb(-1.0).ub(1.0).build();
-    let x8 = m.var("x8").lb(-1.0).ub(1.0).build();
+    variable!(m, -1.0 <= x1 <= 1.0);
+    variable!(m, -1.0 <= x2 <= 1.0);
+    variable!(m, -1.0 <= x3 <= 1.0);
+    variable!(m, -1.0 <= x4 <= 1.0);
+    variable!(m, -1.0 <= x5 <= 1.0);
+    variable!(m, -1.0 <= x6 <= 1.0);
+    variable!(m, -1.0 <= x7 <= 1.0);
+    variable!(m, -1.0 <= x8 <= 1.0);
 
     // Kinematic loop equations (linear + bilinear).
-    m.constraint(
-        "e1",
-        (0.004731 * x1 * x3 - 0.1238 * x1 - 0.3578 * x2 * x3 - 0.001637 * x2 - 0.9338 * x4 + x7)
-            .eq(0.3571),
+    constraint!(
+        m,
+        e1,
+        0.004731 * x1 * x3 - 0.1238 * x1 - 0.3578 * x2 * x3 - 0.001637 * x2 - 0.9338 * x4 + x7
+            == 0.3571
     );
-    m.constraint(
-        "e2",
-        (0.2238 * x1 * x3 + 0.2638 * x1 + 0.7623 * x2 * x3 - 0.07745 * x2 - 0.6734 * x4 - x7)
-            .eq(0.6022),
+    constraint!(
+        m,
+        e2,
+        0.2238 * x1 * x3 + 0.2638 * x1 + 0.7623 * x2 * x3 - 0.07745 * x2 - 0.6734 * x4 - x7
+            == 0.6022
     );
-    m.constraint("e3", (x6 * x8 + 0.3578 * x1 + 0.004731 * x2).eq(0.0));
-    m.constraint("e4", (-0.7623 * x1 + 0.2238 * x2).eq(-0.3461));
+    constraint!(m, e3, x6 * x8 + 0.3578 * x1 + 0.004731 * x2 == 0.0);
+    constraint!(m, e4, -0.7623 * x1 + 0.2238 * x2 == -0.3461);
 
     // Trigonometric identities: each (sin, cos) pair lies on the unit circle.
-    m.constraint("e5", (x1.powi(2) + x2.powi(2)).eq(1.0));
-    m.constraint("e6", (x3.powi(2) + x4.powi(2)).eq(1.0));
-    m.constraint("e7", (x5.powi(2) + x6.powi(2)).eq(1.0));
-    m.constraint("e8", (x7.powi(2) + x8.powi(2)).eq(1.0));
+    constraint!(m, e5, x1.powi(2) + x2.powi(2) == 1.0);
+    constraint!(m, e6, x3.powi(2) + x4.powi(2) == 1.0);
+    constraint!(m, e7, x5.powi(2) + x6.powi(2) == 1.0);
+    constraint!(m, e8, x7.powi(2) + x8.powi(2) == 1.0);
 
     // Pure feasibility problem: no objective set => `minimize 0`.
 

--- a/crates/oximo/examples/lot_sizing.rs
+++ b/crates/oximo/examples/lot_sizing.rs
@@ -69,20 +69,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let m = Model::new("lot_sizing");
     let periods = Set::range(0..T);
 
-    let x = m.indexed_var("x", &periods).lb(0.0).ub(capacity).build();
-    let h = m.indexed_var("h", &periods).lb(0.0).build();
-    let s = m.indexed_var("s", &periods).binary().build();
+    variable!(m, 0.0 <= x[t in periods] <= capacity);
+    variable!(m, h[t in periods] >= 0.0);
+    variable!(m, s[t in periods], Bin);
 
-    m.constraint("inv_bal[0]", (h[0] - x[0]).eq(initial_inventory - demand[0]));
-    m.add_constraints_over("inv_bal", &periods.filter(|k| k.as_i64().unwrap() > 0), |t: usize| {
-        (h[t] - h[t - 1] - x[t]).eq(-demand[t])
-    });
-    m.add_constraints_over("setup", &periods, |t: usize| (x[t] - capacity * s[t]).le(0.0));
-    m.constraint("safety_stock", h[T - 1].ge(safety_stock));
+    constraint!(m, inv_bal0, h[0] - x[0] == initial_inventory - demand[0]);
+    constraint!(m, inv_bal[t in 1..T], h[t] - h[t - 1] - x[t] == -demand[t]);
+    constraint!(m, setup[t in periods], x[t] <= capacity * s[t]);
+    constraint!(m, safety_stock, h[T - 1] >= safety_stock);
 
-    let cost =
-        sum_over(&periods, |t: usize| prod_cost[t] * x[t] + setup_cost * s[t] + hold_cost * h[t]);
-    m.minimize(cost);
+    objective!(
+        m,
+        Min,
+        sum!(prod_cost[t] * x[t] + setup_cost * s[t] + hold_cost * h[t] for t in periods)
+    );
 
     #[cfg(feature = "gurobi")]
     let result = {

--- a/crates/oximo/examples/parametric_pricing.rs
+++ b/crates/oximo/examples/parametric_pricing.rs
@@ -24,18 +24,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let m = Model::new("parametric_pricing");
 
     // Per-unit margin of product 1: a market price we re-bind per scenario.
-    let p1 = m.param("p1", 0.0);
+    param!(m, p1 = 0.0);
 
     // Production quantities (units)
-    let x1 = m.var("x1").lb(0.0).build();
-    let x2 = m.var("x2").lb(0.0).build();
+    variable!(m, x1 >= 0.0);
+    variable!(m, x2 >= 0.0);
 
     // Shared resources
-    m.constraint("labor", (2.0 * x1 + x2).le(100.0));
-    m.constraint("material", (x1 + 3.0 * x2).le(90.0));
+    constraint!(m, labor, 2.0 * x1 + x2 <= 100.0);
+    constraint!(m, material, x1 + 3.0 * x2 <= 90.0);
 
     // profit = p1 * x1 + 5 * x2  (product 2's margin is fixed at 5)
-    m.maximize(p1 * x1 + 5.0 * x2);
+    objective!(m, Max, p1 * x1 + 5.0 * x2);
 
     // The model kind is inferred and does not change as we re-bind `p1`.
     assert_eq!(m.kind(), ModelKind::LP);

--- a/crates/oximo/examples/process_selection.rs
+++ b/crates/oximo/examples/process_selection.rs
@@ -39,30 +39,32 @@ mod model {
         let m = Model::new("procsel");
 
         // Positive variables (consumptions, capacities, purchases).
-        let a2 = m.var("a2").lb(0.0).build();
-        let a3 = m.var("a3").lb(0.0).build();
-        let b2 = m.var("b2").lb(0.0).build();
-        let b3 = m.var("b3").lb(0.0).build();
-        let bp = m.var("bp").lb(0.0).build();
-        let b1 = m.var("b1").lb(0.0).build();
-        let c1 = m.var("c1").lb(0.0).ub(1.0).build();
+        variable!(m, a2 >= 0.0);
+        variable!(m, a3 >= 0.0);
+        variable!(m, b2 >= 0.0);
+        variable!(m, b3 >= 0.0);
+        variable!(m, bp >= 0.0);
+        variable!(m, b1 >= 0.0);
+        variable!(m, 0.0 <= c1 <= 1.0);
 
         // Binaries: existence of each process unit.
-        let y1 = m.var("y1").binary().build();
-        let y2 = m.var("y2").binary().build();
-        let y3 = m.var("y3").binary().build();
+        variable!(m, y1, Bin);
+        variable!(m, y2, Bin);
+        variable!(m, y3, Bin);
 
-        m.constraint("inout1", c1.eq(0.9 * b1));
-        m.constraint("inout2", (b2.exp() - 1.0).eq(a2));
-        m.constraint("inout3", ((b3 / 1.2).exp() - 1.0).eq(a3));
-        m.constraint("mbalb", b1.eq(b2 + b3 + bp));
-        m.constraint("log1", c1.le(2.0 * y1));
-        m.constraint("log2", b2.le(4.0 * y2));
-        m.constraint("log3", b3.le(5.0 * y3));
+        constraint!(m, inout1, c1 == 0.9 * b1);
+        constraint!(m, inout2, b2.exp() - 1.0 == a2);
+        constraint!(m, inout3, (b3 / 1.2).exp() - 1.0 == a3);
+        constraint!(m, mbalb, b1 == b2 + b3 + bp);
+        constraint!(m, log1, c1 <= 2.0 * y1);
+        constraint!(m, log2, b2 <= 4.0 * y2);
+        constraint!(m, log3, b3 <= 5.0 * y3);
 
         // profit = sales - fixed investment - operating cost - purchases
-        m.maximize(
-            11.0 * c1 - 3.5 * y1 - y2 - 1.5 * y3 - b2 - 1.2 * b3 - 1.8 * (a2 + a3) - 7.0 * bp,
+        objective!(
+            m,
+            Max,
+            11.0 * c1 - 3.5 * y1 - y2 - 1.5 * y3 - b2 - 1.2 * b3 - 1.8 * (a2 + a3) - 7.0 * bp
         );
 
         let result = solver.solve(&m, opts)?;

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -90,30 +90,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let m = Model::new("reaction_path");
     let chemicals = Set::strings(CHEMICALS);
 
-    let y = m
-        .indexed_var("y", &chemicals)
-        .binary()
-        .lb_by(
-            |name: String| {
-                if available.iter().any(|&i| CHEMICALS[i] == name) { 1.0 } else { 0.0 }
-            },
-        )
-        .ub_by(
-            |name: String| {
-                if unavailable.iter().any(|&i| CHEMICALS[i] == name) { 0.0 } else { 1.0 }
-            },
-        )
-        .build();
+    variable!(m, y[v in chemicals], Bin);
+    // Fix availability: raw materials/catalysts to 1, unavailable chemicals to 0.
+    for &i in available {
+        m.fix(y[CHEMICALS[i]], 1.0);
+    }
+    for &i in unavailable {
+        m.fix(y[CHEMICALS[i]], 0.0);
+    }
 
     // sum_vv (1 - y[vv]) >= 1 - y[v]
     //    <=>  y[v] - sum_vv y[vv] >= 1 - |reactants|
-    for &(rx, prod, reactants) in logicc {
+    for &(_rx, prod, reactants) in logicc {
         let n = reactants.len() as f64;
-        let reactant_sum = sum_over(reactants, |vv: usize| y[CHEMICALS[vv]]);
-        m.constraint(format!("leq_{rx}"), (y[CHEMICALS[prod]] - reactant_sum).ge(1.0 - n));
+        constraint!(m, y[CHEMICALS[prod]] - sum!(y[CHEMICALS[vv]] for vv in reactants) >= 1.0 - n);
     }
 
-    m.minimize(y["y06"]); // acetone
+    objective!(m, Min, y["y06"]); // acetone
 
     #[cfg(feature = "gams")]
     let result = {

--- a/crates/oximo/examples/transport.rs
+++ b/crates/oximo/examples/transport.rs
@@ -16,13 +16,13 @@ use oximo::solvers::Highs;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let m = Model::new("transport");
 
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
 
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x).ge(y));
-    m.constraint("c3", x.le(y + 2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x >= y);
+    constraint!(m, c3, x <= y + 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let mut solver = Highs;
     let result = solver.solve(&m, &HighsOptions::default().verbose(true))?;

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -1,7 +1,15 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
+// Lets the `::oximo::...` paths emitted by `oximo-macros` resolve inside this
+// crate's own examples, tests, and doctests.
+extern crate self as oximo;
+
 pub use oximo_core as core;
+
+// Runtime glue the modeling macros expand into.
+#[doc(hidden)]
+pub use oximo_core::__macro_support;
 pub use oximo_expr as expr;
 pub use oximo_solver as solver;
 

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -4,12 +4,12 @@ use oximo::solvers::Highs;
 #[test]
 fn lp_canonical() {
     let m = Model::new("transport");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -24,9 +24,9 @@ fn highs_multi_optima_returns_single_best() {
     // HiGHS has no solution pool, so the multi-solution API surfaces exactly one optimum.
     let m = Model::new("multi");
     let items = Set::range(0..4usize);
-    let x = m.indexed_var("x", &items).binary().build();
-    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
-    m.maximize(sum_over(&items, |i: usize| x[i]));
+    variable!(m, x[i in items], Bin);
+    constraint!(m, cap, sum!(x[i] for i in items) <= 2.0);
+    objective!(m, Max, sum!(x[i] for i in items));
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(r.status, SolverStatus::Optimal);
@@ -39,9 +39,9 @@ fn highs_multi_optima_returns_single_best() {
 #[test]
 fn param_coefficient_lp_rebinds_without_rebuild() {
     let m = Model::new("param_lp");
-    let price = m.param("price", 3.0);
-    let x = m.var("x").bounds(0.0, 10.0).build();
-    m.maximize(price * x);
+    param!(m, price = 3.0);
+    variable!(m, 0.0 <= x <= 10.0);
+    objective!(m, Max, price * x);
     assert_eq!(m.kind(), ModelKind::LP);
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
@@ -56,9 +56,9 @@ fn param_coefficient_lp_rebinds_without_rebuild() {
 #[test]
 fn param_coefficient_qp_rebinds() {
     let m = Model::new("param_qp");
-    let t = m.param("t", 2.0);
-    let x = m.var("x").bounds(-10.0, 10.0).build();
-    m.minimize((x - t).powi(2));
+    param!(m, t = 2.0);
+    variable!(m, -10.0 <= x <= 10.0);
+    objective!(m, Min, (x - t).powi(2));
     assert_eq!(m.kind(), ModelKind::QP);
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
@@ -76,10 +76,10 @@ fn io_linear_writers_fold_param_coefficient() {
     use oximo::io::{to_lp_string, to_mps_string};
 
     let m = Model::new("io_param");
-    let cost = m.param("cost", 3.0);
-    let x = m.var("x").lb(0.0).build();
-    m.constraint("c", x.ge(2.0));
-    m.minimize(cost * x);
+    param!(m, cost = 3.0);
+    variable!(m, x >= 0.0);
+    constraint!(m, c, x >= 2.0);
+    objective!(m, Min, cost * x);
 
     let mps = to_mps_string(&m).unwrap();
     assert!(mps.contains("x         OBJ       3"), "got:\n{mps}");
@@ -96,10 +96,10 @@ fn nl_writer_emits_param_in_nonlinear_term() {
     use oximo::io::to_nl_string;
 
     let m = Model::new("nl_param");
-    let k = m.param("k", 2.0);
-    let x = m.var("x").lb(0.0).build();
-    m.constraint("c", (k * x.powi(2)).le(10.0));
-    m.minimize(x);
+    param!(m, k = 2.0);
+    variable!(m, x >= 0.0);
+    constraint!(m, c, k * x.powi(2) <= 10.0);
+    objective!(m, Min, x);
     let nl = to_nl_string(&m).unwrap();
     assert!(!nl.is_empty());
 }
@@ -108,11 +108,12 @@ fn nl_writer_emits_param_in_nonlinear_term() {
 fn knapsack_milp() {
     let weights = [3.0, 4.0, 2.0, 5.0, 1.0, 6.0, 7.0, 2.0];
     let values = [10.0, 12.0, 5.0, 14.0, 3.0, 18.0, 22.0, 6.0];
+    let n = weights.len();
 
     let m = Model::new("knapsack");
-    let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(&xs, &weights).le(15.0));
-    m.maximize(dot(&xs, &values));
+    variable!(m, x[i in 0..n], Bin);
+    constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..n) <= 15.0);
+    objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -122,12 +123,14 @@ fn knapsack_milp() {
 #[test]
 fn lp_initial_values_do_not_affect_optimum() {
     let m = Model::new("lp_warm");
-    let x = m.var("x").lb(0.0).initial(6.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).initial(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    m.set_initial(x, 6.0);
+    m.set_initial(y, 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -143,13 +146,15 @@ fn milp_warm_start_finds_optimum() {
     let weights = [3.0, 4.0, 2.0, 5.0, 1.0, 6.0, 7.0, 2.0];
     let values = [10.0, 12.0, 5.0, 14.0, 3.0, 18.0, 22.0, 6.0];
     let warm_start = [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0];
+    let n = weights.len();
 
     let m = Model::new("knapsack_warm");
-    let xs: Vec<_> = (0..weights.len())
-        .map(|i| m.var(format!("x{i}")).binary().initial(warm_start[i]).build())
-        .collect();
-    m.constraint("cap", dot(&xs, &weights).le(15.0));
-    m.maximize(dot(&xs, &values));
+    variable!(m, x[i in 0..n], Bin);
+    for i in 0..n {
+        m.set_initial(x[i], warm_start[i]);
+    }
+    constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..n) <= 15.0);
+    objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -159,9 +164,9 @@ fn milp_warm_start_finds_optimum() {
 #[test]
 fn infeasible_returns_status() {
     let m = Model::new("infeas");
-    let x = m.var("x").lb(0.0).ub(1.0).build();
-    m.constraint("c1", x.ge(5.0));
-    m.minimize(x);
+    variable!(m, 0.0 <= x <= 1.0);
+    constraint!(m, c1, x >= 5.0);
+    objective!(m, Min, x);
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Infeasible);
 }
@@ -169,12 +174,12 @@ fn infeasible_returns_status() {
 #[test]
 fn presolve_off_gives_correct_result() {
     let m = Model::new("canon");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().presolve(HighsPresolve::Off)).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
@@ -185,12 +190,12 @@ fn presolve_off_gives_correct_result() {
 #[test]
 fn ipm_method_gives_correct_result() {
     let m = Model::new("canon");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().method(HighsMethod::Ipm)).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
@@ -201,12 +206,12 @@ fn ipm_method_gives_correct_result() {
 #[test]
 fn threads_one_gives_correct_result() {
     let m = Model::new("canon");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().threads(1)).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
@@ -219,10 +224,11 @@ fn mip_gap_accepted_and_solves() {
     // Loose gap on a tiny knapsack, still gets optimal on small instances.
     let weights = [3.0, 4.0, 2.0, 5.0, 1.0];
     let values = [10.0, 12.0, 5.0, 14.0, 3.0];
-    let m = oximo_core::Model::new("ks");
-    let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(&xs, &weights).le(8.0));
-    m.maximize(dot(&xs, &values));
+    let n = weights.len();
+    let m = Model::new("ks");
+    variable!(m, x[i in 0..n], Bin);
+    constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..n) <= 8.0);
+    objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
     let opts = HighsOptions::default().mip_gap(0.5).verbose(false);
     let result = Highs.solve(&m, &opts).unwrap();
     assert!(
@@ -237,11 +243,11 @@ fn mip_gap_accepted_and_solves() {
 fn indexed_var_retrieval() {
     let m = Model::new("indexed");
     let routes = Set::strings(["a", "b"]);
-    let flow = m.indexed_var("flow", &routes).lb(0.0).build();
+    variable!(m, flow[r in routes] >= 0.0);
 
-    m.constraint("ca", flow["a"].ge(3.0));
-    m.constraint("cb", flow["b"].ge(7.0));
-    m.minimize(flow["a"] + flow["b"]);
+    constraint!(m, ca, flow["a"] >= 3.0);
+    constraint!(m, cb, flow["b"] >= 7.0);
+    objective!(m, Min, flow["a"] + flow["b"]);
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -263,10 +269,10 @@ fn mps_coefficients_and_rhs() {
     // Verify that COLUMNS carries the right coefficients and RHS is correct.
     // Model: min 3x + 4y, s.t. x + 2y <= 14 (y bounded 0..4)
     let m = Model::new("transport");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.minimize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    objective!(m, Min, 3.0 * x + 4.0 * y);
 
     let s = oximo::io::to_mps_string(&m).unwrap();
 
@@ -302,10 +308,11 @@ fn mps_coefficients_and_rhs() {
 #[test]
 fn mps_fixed_variable_emits_fx_bound() {
     let m = Model::new("fixed");
-    let x = m.var("x").lb(0.0).ub(10.0).build();
-    let y = m.var("y").lb(0.0).ub(10.0).fix(3.5).build();
-    m.constraint("c", (x + y).le(20.0));
-    m.minimize(x + y);
+    variable!(m, 0.0 <= x <= 10.0);
+    variable!(m, y);
+    m.fix(y, 3.5);
+    constraint!(m, c, x + y <= 20.0);
+    objective!(m, Min, x + y);
 
     let s = oximo::io::to_mps_string(&m).unwrap();
 
@@ -321,22 +328,23 @@ fn mps_fixed_variable_emits_fx_bound() {
 #[test]
 fn mps_free_and_integer_bounds() {
     let m = Model::new("mixed");
-    let _x = m.var("x").binary().build();
-    let _y = m.var("y").lb(0.0).ub(10.0).integer().build();
-    let z = m.var("z").lb(f64::NEG_INFINITY).build();
-    m.minimize(z);
+    variable!(m, x, Bin);
+    variable!(m, 0.0 <= y <= 10.0, Int);
+    variable!(m, z >= f64::NEG_INFINITY);
+    objective!(m, Min, z);
+    let _ = (x, y);
 
-    let s = oximo::io::to_mps_string(&m).unwrap();
+    let mps = oximo::io::to_mps_string(&m).unwrap();
 
     // Integer markers present
-    assert!(s.contains("'INTORG'"));
-    assert!(s.contains("'INTEND'"));
+    assert!(mps.contains("'INTORG'"));
+    assert!(mps.contains("'INTEND'"));
 
     // z is free
-    assert!(s.contains("FR BND       z"));
+    assert!(mps.contains("FR BND       z"));
 
     // y upper bound
-    assert!(s.contains("UP BND       y         10"));
+    assert!(mps.contains("UP BND       y         10"));
 }
 
 #[cfg(feature = "io")]
@@ -344,11 +352,11 @@ fn mps_free_and_integer_bounds() {
 fn lp_coefficients_and_bounds() {
     // Verify coefficients, sense, constraint operators, and bound declarations.
     let m = Model::new("transport");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let s = oximo::io::to_lp_string(&m).unwrap();
 
@@ -384,8 +392,8 @@ fn lp_coefficients_and_bounds() {
 #[test]
 fn lp_free_variable_emits_free_keyword() {
     let m = Model::new("free_test");
-    let x = m.var("x").lb(f64::NEG_INFINITY).build();
-    m.minimize(x);
+    variable!(m, x >= f64::NEG_INFINITY);
+    objective!(m, Min, x);
 
     let s = oximo::io::to_lp_string(&m).unwrap();
     assert!(s.contains("x free"), "free variable must use 'x free' syntax");
@@ -395,23 +403,24 @@ fn lp_free_variable_emits_free_keyword() {
 #[test]
 fn lp_export_lists_binaries_and_integers() {
     let m = Model::new("mixed");
-    let _x = m.var("x").binary().build();
-    let _y = m.var("y").lb(0.0).ub(10.0).integer().build();
-    let z = m.var("z").lb(0.0).build();
-    m.minimize(z);
+    variable!(m, x, Bin);
+    variable!(m, 0.0 <= y <= 10.0, Int);
+    variable!(m, z >= 0.0);
+    objective!(m, Min, z);
+    let _ = (x, y);
 
-    let s = oximo::io::to_lp_string(&m).unwrap();
-    assert!(s.contains("General"));
-    assert!(s.contains("Binaries"));
+    let lp = oximo::io::to_lp_string(&m).unwrap();
+    assert!(lp.contains("General"));
+    assert!(lp.contains("Binaries"));
 
-    let gen_start = s.find("General").unwrap();
-    let bin_start = s.find("Binaries").unwrap();
+    let gen_start = lp.find("General").unwrap();
+    let bin_start = lp.find("Binaries").unwrap();
     // y in General section, not Binaries
-    assert!(s[gen_start..bin_start].contains(" y"));
-    assert!(!s[gen_start..bin_start].contains(" x"));
+    assert!(lp[gen_start..bin_start].contains(" y"));
+    assert!(!lp[gen_start..bin_start].contains(" x"));
     // x in Binaries section
-    assert!(s[bin_start..].contains(" x"));
-    assert!(!s[bin_start..].contains(" y"));
+    assert!(lp[bin_start..].contains(" x"));
+    assert!(!lp[bin_start..].contains(" y"));
 }
 
 #[cfg(feature = "io")]
@@ -420,12 +429,11 @@ fn mps_columns_nonzero_count() {
     // 5 variables, 5 constraints, each constraint involves all 5 variables.
     // COLUMNS section must have exactly 5*5 + 5 = 30 data lines
     let m = Model::new("dense");
-    let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).lb(0.0).build()).collect();
-    for i in 0..5usize {
-        let row = xs.iter().copied().sum::<Expr>();
-        m.constraint(format!("c{i}"), row.le(10.0));
+    variable!(m, x[i in 0..5] >= 0.0);
+    for _ in 0..5usize {
+        constraint!(m, sum!(x[j] for j in 0..5) <= 10.0);
     }
-    m.minimize(xs.iter().copied().sum::<Expr>());
+    objective!(m, Min, sum!(x[j] for j in 0..5));
 
     let s = oximo::io::to_mps_string(&m).unwrap();
 

--- a/crates/oximo/tests/solve_baron.rs
+++ b/crates/oximo/tests/solve_baron.rs
@@ -21,9 +21,9 @@ fn baron_enumerates_multiple_solutions() {
     // result's solution pool (best first).
     let m = Model::new("multi");
     let items = Set::range(0..4usize);
-    let x = m.indexed_var("x", &items).binary().build();
-    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
-    m.maximize(sum_over(&items, |i: usize| x[i]));
+    variable!(m, x[i in items], Bin);
+    constraint!(m, cap, sum!(x[i] for i in items) <= 2.0);
+    objective!(m, Max, sum!(x[i] for i in items));
 
     let opts = BaronOptions::default().num_sol(10).time_limit(Duration::from_secs(60));
     let r = Baron::new().solve(&m, &opts).unwrap();
@@ -42,10 +42,10 @@ fn baron_lp_duals_and_reduced_costs() {
     // min x + 2y  s.t.  x + y >= 5,  x, y >= 0
     // Optimal: (x, y) = (5, 0), obj 5, dual of c = 1, rc(x) = 0, rc(y) = 1.
     let m = Model::new("lp_dual");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).build();
-    let cap = m.constraint("cap", (x + y).ge(5.0));
-    m.minimize(x + 2.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    let cap = constraint!(m, cap, x + y >= 5.0);
+    objective!(m, Min, x + 2.0 * y);
 
     let opts = BaronOptions::default().want_dual(true).time_limit(Duration::from_secs(30));
     let result = Baron::new().solve(&m, &opts).unwrap();
@@ -68,10 +68,10 @@ fn baron_milp_duals_at_best_point() {
     // max 2a + 3b  s.t.  a + b <= 1,  a, b binary.
     // Optimal: (0, 1), obj 3.
     let m = Model::new("milp_dual");
-    let a = m.var("a").binary().build();
-    let b = m.var("b").binary().build();
-    let cap = m.constraint("cap", (a + b).le(1.0));
-    m.maximize(2.0 * a + 3.0 * b);
+    variable!(m, a, Bin);
+    variable!(m, b, Bin);
+    let cap = constraint!(m, cap, a + b <= 1.0);
+    objective!(m, Max, 2.0 * a + 3.0 * b);
 
     let opts = BaronOptions::default().want_dual(true).time_limit(Duration::from_secs(30));
     let result = Baron::new().solve(&m, &opts).unwrap();

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -21,12 +21,12 @@ use oximo::solvers::Gams;
 #[test]
 fn gams_lp_canonical() {
     let m = Model::new("lp");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -41,9 +41,9 @@ fn gams_lp_duals_and_reduced_costs() {
     // max x  s.t.  x <= 5,  x >= 0
     // Optimal: x = 5, dual of (x <= 5) = +/-1.0, reduced cost of x = 0.
     let m = Model::new("lp_dual");
-    let x = m.var("x").lb(0.0).build();
-    let c = m.constraint("cap", x.le(5.0));
-    m.maximize(x);
+    variable!(m, x >= 0.0);
+    let c = constraint!(m, cap, x <= 5.0);
+    objective!(m, Max, x);
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -56,7 +56,6 @@ fn gams_lp_duals_and_reduced_costs() {
     // Only one variable in the model -> VarId(0).
     let rc = result.reduced_costs.get(&VarId(0)).copied().expect("reduced cost missing for x");
     assert!(rc.abs() < 1e-6, "reduced_cost(x)={rc}");
-    let _ = x;
 }
 
 #[test]
@@ -65,9 +64,9 @@ fn gams_nlp_duals_at_local_point() {
     // Optimum: x = 1, obj e. KKT: exp(x) = lambda => dual of (x >= 1) = +/-e,
     // reduced cost of x = 0.
     let m = Model::new("nlp_dual");
-    let x = m.var("x").lb(-10.0).ub(10.0).build();
-    let cap = m.constraint("cap", x.ge(1.0));
-    m.minimize(x.exp());
+    variable!(m, -10.0 <= x <= 10.0);
+    let cap = constraint!(m, cap, x >= 1.0);
+    objective!(m, Min, x.exp());
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -93,10 +92,10 @@ fn gams_mip_duals_at_fixed_point() {
     // The exact split between constraint duals and reduced costs is
     // solver-dependent. We assert presence, not values.
     let m = Model::new("mip_dual");
-    let a = m.var("a").binary().build();
-    let b = m.var("b").binary().build();
-    let cap = m.constraint("cap", (a + b).le(1.0));
-    m.maximize(2.0 * a + 3.0 * b);
+    variable!(m, a, Bin);
+    variable!(m, b, Bin);
+    let cap = constraint!(m, cap, a + b <= 1.0);
+    objective!(m, Max, 2.0 * a + 3.0 * b);
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -110,11 +109,12 @@ fn gams_mip_duals_at_fixed_point() {
 fn gams_knapsack_milp() {
     let weights = [3.0, 4.0, 2.0, 5.0, 1.0, 6.0, 7.0, 2.0];
     let values = [10.0, 12.0, 5.0, 14.0, 3.0, 18.0, 22.0, 6.0];
+    let n = weights.len();
 
     let m = Model::new("knapsack");
-    let xs: Vec<_> = (0..weights.len()).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(&xs, &weights).le(15.0));
-    m.maximize(dot(&xs, &values));
+    variable!(m, x[i in 0..n], Bin);
+    constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..n) <= 15.0);
+    objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -125,9 +125,9 @@ fn gams_knapsack_milp() {
 #[test]
 fn gams_infeasible_returns_status() {
     let m = Model::new("infeas");
-    let x = m.var("x").lb(0.0).ub(1.0).build();
-    m.constraint("c1", x.ge(5.0));
-    m.minimize(x);
+    variable!(m, 0.0 <= x <= 1.0);
+    constraint!(m, c1, x >= 5.0);
+    objective!(m, Min, x);
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
@@ -138,10 +138,11 @@ fn gams_infeasible_returns_status() {
 fn gams_mip_gap_option() {
     let weights = [3.0, 4.0, 2.0, 5.0, 1.0];
     let values = [10.0, 12.0, 5.0, 14.0, 3.0];
+    let n = weights.len();
     let m = Model::new("ks");
-    let xs: Vec<_> = (0..5).map(|i| m.var(format!("x{i}")).binary().build()).collect();
-    m.constraint("cap", dot(&xs, &weights).le(8.0));
-    m.maximize(dot(&xs, &values));
+    variable!(m, x[i in 0..n], Bin);
+    constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..n) <= 8.0);
+    objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
 
     let result = Gams::new().solve(&m, &GamsOptions::default().mip_gap(0.5)).unwrap();
     assert!(
@@ -159,12 +160,12 @@ fn gams_mip_gap_option() {
 #[test]
 fn gams_highs_opt_file_simplex() {
     let m = Model::new("lp");
-    let x = m.var("x").lb(0.0).build();
-    let y = m.var("y").lb(0.0).ub(4.0).build();
-    m.constraint("c1", (x + 2.0 * y).le(14.0));
-    m.constraint("c2", (3.0 * x - y).ge(0.0));
-    m.constraint("c3", (x - y).le(2.0));
-    m.maximize(3.0 * x + 4.0 * y);
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 4.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    constraint!(m, c3, x - y <= 2.0);
+    objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let opts = GamsOptions::default().solver(GamsSolverConfig::Highs(GamsHighsOptions {
         solver: Some(GamsHighsSolver::Simplex),
@@ -181,9 +182,9 @@ fn gams_multi_optima_returns_single_best() {
     // GAMS bridge returns one optimum: exactly one valid point.
     let m = Model::new("multi");
     let items = Set::range(0..4usize);
-    let x = m.indexed_var("x", &items).binary().build();
-    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
-    m.maximize(sum_over(&items, |i: usize| x[i]));
+    variable!(m, x[i in items], Bin);
+    constraint!(m, cap, sum!(x[i] for i in items) <= 2.0);
+    objective!(m, Max, sum!(x[i] for i in items));
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let r = Gams::new().solve(&m, &opts).unwrap();
@@ -202,9 +203,9 @@ fn gams_reads_cplex_solution_pool() {
     // Requires a GAMS install with a licensed CPLEX.
     let m = Model::new("multi");
     let items = Set::range(0..4usize);
-    let x = m.indexed_var("x", &items).binary().build();
-    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
-    m.maximize(sum_over(&items, |i: usize| x[i]));
+    variable!(m, x[i in items], Bin);
+    constraint!(m, cap, sum!(x[i] for i in items) <= 2.0);
+    objective!(m, Max, sum!(x[i] for i in items));
 
     let cfg = GamsSolverConfig::Cplex(GamsCplexOptions {
         raw: vec![

--- a/crates/oximo/tests/solve_gurobi.rs
+++ b/crates/oximo/tests/solve_gurobi.rs
@@ -16,9 +16,9 @@ fn gurobi_multi_optima_returns_pool() {
     // surfaced through the multi-solution API, best first.
     let m = Model::new("multi");
     let items = Set::range(0..4usize);
-    let x = m.indexed_var("x", &items).binary().build();
-    m.constraint("cap", sum_over(&items, |i: usize| x[i]).le(2.0));
-    m.maximize(sum_over(&items, |i: usize| x[i]));
+    variable!(m, x[i in items], Bin);
+    constraint!(m, cap, sum!(x[i] for i in items) <= 2.0);
+    objective!(m, Max, sum!(x[i] for i in items));
 
     let opts = GurobiOptions::default().pool_search_mode(2).pool_solutions(10);
     let r = Gurobi.solve(&m, &opts).unwrap();
@@ -42,10 +42,10 @@ fn gurobi_qp_duals_linear_constraint() {
     // Optimum: (1, 1), obj 2. KKT: 2x = lambda => dual of cap = 2,
     // reduced costs 0 (both variables interior to their bounds).
     let m = Model::new("qp_dual");
-    let x = m.var("x").lb(-10.0).ub(10.0).build();
-    let y = m.var("y").lb(-10.0).ub(10.0).build();
-    let cap = m.constraint("cap", (x + y).ge(2.0));
-    m.minimize(x * x + y * y);
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    let cap = constraint!(m, cap, x + y >= 2.0);
+    objective!(m, Min, x * x + y * y);
 
     let result = Gurobi.solve(&m, &GurobiOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);
@@ -65,10 +65,10 @@ fn gurobi_qcp_duals_quadratic_constraint() {
     // => dual of ball = 1/2 (QCPi). Gurobi computes QCP duals only when the
     // we set .qcp_dual(1).
     let m = Model::new("qcp_dual");
-    let x = m.var("x").lb(-10.0).ub(10.0).build();
-    let y = m.var("y").lb(-10.0).ub(10.0).build();
-    let ball = m.constraint("ball", (x * x + y * y).le(2.0));
-    m.minimize(x + y);
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    let ball = constraint!(m, ball, x * x + y * y <= 2.0);
+    objective!(m, Min, x + y);
 
     let opts = GurobiOptions::default().qcp_dual(1);
     let result = Gurobi.solve(&m, &opts).unwrap();
@@ -85,10 +85,10 @@ fn gurobi_qcp_duals_skipped_by_default() {
     // Same convex QCP without .qcp_dual(1): the backend leaves Gurobi's
     // QCPDual default (0) untouched, so no duals are computed.
     let m = Model::new("qcp_no_dual");
-    let x = m.var("x").lb(-10.0).ub(10.0).build();
-    let y = m.var("y").lb(-10.0).ub(10.0).build();
-    m.constraint("ball", (x * x + y * y).le(2.0));
-    m.minimize(x + y);
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    constraint!(m, ball, x * x + y * y <= 2.0);
+    objective!(m, Min, x + y);
 
     let result = Gurobi.solve(&m, &GurobiOptions::default()).unwrap();
     assert_eq!(result.status, SolverStatus::Optimal);


### PR DESCRIPTION
## Description

This PR adds a new macro-based API for creating models, using proc-macros. The builder API is deprecated and will be removed in v0.4.0.
This code is inspired by both JuMP (Julia) and the good_lp crate.

I still want to change a lot of the code and add new features, but I am happy with it already.

Some of the code was generated using GitHub Copilot, check the commit trailers for more information.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Warm-start support for variables via `set_initial()`.
  * Macro-based modeling API (`variable!`, `constraint!`, `objective!`, `sum!`, `param!`) is now standardized and re-exported for direct use.
* **Improvements**
  * Indexed variables now support dense-grid storage with enhanced querying (`is_dense`, `shape`, `at`/`get_at`) while preserving sparse behavior.
  * Typed indexing/summation improvements, including `sum!` filtering and better indexed/ranged summation support; anonymous constraint auto-naming is improved.
* **Documentation**
  * Updated core docs, solver READMEs, and examples to use the macro-based API instead of builder-style calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->