### PR TITLE
Add support for Semi-Continuous/Semi-Integer variables

### DIFF
--- a/crates/oximo-core/src/domain.rs
+++ b/crates/oximo-core/src/domain.rs
@@ -24,4 +24,28 @@ impl Domain {
     pub fn is_integer(self) -> bool {
         matches!(self, Self::Integer | Self::Binary | Self::SemiInteger { .. })
     }
+
+    /// The semicontinuity gap floor: `Some(threshold)` for `SemiContinuous` /
+    /// `SemiInteger`, `None` otherwise. Such a variable takes either 0 or a
+    /// value `>= threshold`, so backends emit `threshold` as the lower bound.
+    pub fn semi_threshold(self) -> Option<f64> {
+        match self {
+            Self::SemiContinuous { threshold } | Self::SemiInteger { threshold } => Some(threshold),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Domain;
+
+    #[test]
+    fn semi_threshold_only_for_semi_domains() {
+        assert_eq!(Domain::Real.semi_threshold(), None);
+        assert_eq!(Domain::Integer.semi_threshold(), None);
+        assert_eq!(Domain::Binary.semi_threshold(), None);
+        assert_eq!(Domain::SemiContinuous { threshold: 2.0 }.semi_threshold(), Some(2.0));
+        assert_eq!(Domain::SemiInteger { threshold: 1.0 }.semi_threshold(), Some(1.0));
+    }
 }

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -540,14 +540,18 @@ fn write_preamble(gms: &mut String) {
     writeln!(gms).unwrap();
 }
 
-/// Emit `Variables`, `Binary Variables`, `Integer Variables` sections.
+/// Emit `Variables`, `Binary Variables`, `Integer Variables`,
+/// `Semicont Variables`, `Semiint Variables` sections.
 fn write_var_declarations(gms: &mut String, vars: &[Variable]) {
-    let (mut cont, mut bin, mut int) = (Vec::new(), Vec::new(), Vec::new());
+    let (mut cont, mut bin, mut int, mut semicont, mut semiint) =
+        (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new());
     for v in vars {
         match v.domain {
             Domain::Binary => bin.push(v),
-            Domain::Integer | Domain::SemiInteger { .. } => int.push(v),
-            _ => cont.push(v),
+            Domain::Integer => int.push(v),
+            Domain::SemiContinuous { .. } => semicont.push(v),
+            Domain::SemiInteger { .. } => semiint.push(v),
+            Domain::Real => cont.push(v),
         }
     }
 
@@ -559,6 +563,8 @@ fn write_var_declarations(gms: &mut String, vars: &[Variable]) {
 
     write_typed_var_section(gms, "Binary Variables", &bin);
     write_typed_var_section(gms, "Integer Variables", &int);
+    write_typed_var_section(gms, "Semicont Variables", &semicont);
+    write_typed_var_section(gms, "Semiint Variables", &semiint);
     writeln!(gms).unwrap();
 }
 
@@ -600,6 +606,15 @@ fn write_var_bounds(gms: &mut String, v: &Variable) {
             writeln!(gms, "v{i}.lo = {};", fmt(v.lb)).unwrap();
         }
         if (v.ub - 1.0).abs() > f64::EPSILON {
+            writeln!(gms, "v{i}.up = {};", fmt(v.ub)).unwrap();
+        }
+        return;
+    }
+    // Semicont/semiint variables: GAMS reads `.lo` as the gap floor (the value
+    // is 0 or in `[.lo, .up]`), so emit the threshold there rather than `lb`.
+    if let Some(thr) = v.domain.semi_threshold() {
+        writeln!(gms, "v{i}.lo = {};", fmt(thr)).unwrap();
+        if v.ub.is_finite() {
             writeln!(gms, "v{i}.up = {};", fmt(v.ub)).unwrap();
         }
         return;

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -112,9 +112,12 @@ fn add_variables(
             Domain::SemiContinuous { .. } => VarType::SemiCont,
             Domain::SemiInteger { .. } => VarType::SemiInt,
         };
+        // For a semi-continuous/semi-integer variable the gap floor (`threshold`)
+        // is Gurobi's lower bound: the value is 0 or in `[lb, ub]`.
+        let floor = v.domain.semi_threshold().unwrap_or(v.lb);
         // `add_var!` expands the f64 bounds with an `as f64` cast.
         #[allow(clippy::unnecessary_cast)]
-        let gvar = add_var!(grb_model, vtype, bounds: v.lb..v.ub, name: &format!("x{i}"))
+        let gvar = add_var!(grb_model, vtype, bounds: floor..v.ub, name: &format!("x{i}"))
             .map_err(map_grb_err)?;
         gurobi_vars.push(gvar);
         if let Some(val) = v.initial {

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use highs::{HessianFormat, HighsModelStatus, RowProblem, Sense as HighsSense};
-use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, Sense, VarId};
+use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable};
 use oximo_expr::{
     ExprArena, ExprId, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,
 };
@@ -19,7 +19,9 @@ use crate::options::apply as apply_options;
 /// Hessian is passed via `Highs_passHessian`. Nonlinear constraints or
 /// objectives, quadratic constraints (HiGHS has no quadratic constraints), and
 /// integer + quadratic (MIQP) models produce [`SolverError::Nonlinear`] or
-/// [`SolverError::UnsupportedKind`].
+/// [`SolverError::UnsupportedKind`]. Semicontinuous / semi-integer variables are
+/// rejected with [`SolverError::Backend`] (the `highs` crate exposes no way to
+/// set them).
 ///
 /// HiGHS supports only convex QPs.
 /// For minimization, `Q` must be positive semidefinite (PSD),
@@ -34,6 +36,7 @@ use crate::options::apply as apply_options;
 /// # Panics
 ///
 /// Panics if model variable IDs overflow `u32`.
+#[allow(clippy::too_many_lines)]
 pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {
     let kind = model.kind();
     if !matches!(kind, ModelKind::LP | ModelKind::MILP | ModelKind::QP) {
@@ -42,6 +45,7 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
 
     let arena = model.arena();
     let vars = model.variables();
+    reject_semi_domains(&vars)?;
     let constraints = model.constraints();
     let objective = model.try_objective().map_err(SolverError::Core)?;
 
@@ -150,6 +154,22 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
         raw_log: None,
         solver_name: Some(crate::NAME.into()),
     })
+}
+
+/// HiGHS supports semicontinuous/semi-integer variables, but the `highs` crate
+/// only exposes continuous/integer integrality, so we cannot mark them. Reject
+/// such a model.
+fn reject_semi_domains(vars: &[Variable]) -> Result<(), SolverError> {
+    for v in vars {
+        if v.domain.semi_threshold().is_some() {
+            return Err(SolverError::Backend(format!(
+                "variable x{} has a semicontinuous/semi-integer domain, \
+                 which the HiGHS backend does not support yet",
+                v.id.index()
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// HiGHS Hessian in compressed-sparse-column form: one `(row, value)` list per

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -57,6 +57,7 @@ Fixed-format MPS (fixed-column, 10-char field width). Widely supported by commer
 |-------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | Objective row     | Named `OBJ`, maximization models are negated with a `* sense: maximize` comment so re-importers can recover the original sense |
 | Integer variables | Wrapped in `INTORG`/`INTEND` markers                                                                                           |
+| Semicont variables| `LO` (threshold) + upper-bound semi marker: `SC` for semi-continuous, `SI` for semi-integer                                    |
 | Bounds            | `FR` (free), `MI`+`UP` (lower=-inf), `LO`/`UP` as needed. Default lb=0 omitted                                                 |
 | Constant terms    | Objective constant written to `RHS OBJ`, constraint constants folded into `RHS`                                                |
 
@@ -75,12 +76,13 @@ write_mps(&model, &mut f)?;
 
 ### LP (CPLEX LP format)
 
-Human-readable CPLEX LP format. Sections emitted: header comment, `Minimize`/`Maximize`, `Subject To`, `Bounds` (non-default only), `General`, `Binaries`, `End`.
+Human-readable CPLEX LP format. Sections emitted: header comment, `Minimize`/`Maximize`, `Subject To`, `Bounds` (non-default only), `General`, `Binaries`, `Semi-Continuous`, `End`.
 
 | Feature            | Behavior                                                           |
 |--------------------|--------------------------------------------------------------------|
 | Objective sense    | `Minimize` / `Maximize` keyword, no negation needed                |
 | Integer variables  | `General` section (integer/semi-integer), `Binaries` section       |
+| Semicont variables | `Semi-Continuous` section, threshold emitted as the lower bound    |
 | Bounds             | Free variables declared with `free`; default lb=0, ub=+inf omitted |
 | Objective constant | Written as a comment if non-zero                                   |
 

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -77,6 +77,20 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         if matches!(v.domain, Domain::Binary) {
             continue;
         }
+        // Semicont/semiint: the gap floor (`threshold`) is the LP lower bound.
+        // The `Semi-Continuous` section below marks the gap.
+        if let Some(thr) = v.domain.semi_threshold() {
+            if !wrote_bounds_header {
+                writeln!(out, "Bounds")?;
+                wrote_bounds_header = true;
+            }
+            if v.ub == f64::INFINITY {
+                writeln!(out, " {} >= {}", v.name, thr)?;
+            } else {
+                writeln!(out, " {} <= {} <= {}", thr, v.name, v.ub)?;
+            }
+            continue;
+        }
         if v.lb.is_finite() && (v.lb - v.ub).abs() < f64::EPSILON {
             if !wrote_bounds_header {
                 writeln!(out, "Bounds")?;
@@ -123,6 +137,18 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     if !binary_vars.is_empty() {
         writeln!(out, "Binaries")?;
         writeln!(out, " {}", binary_vars.join(" "))?;
+    }
+
+    // Semicontinuous and semi-integer vars. A var that is also in `General`
+    // (the SemiInteger filter above) is read back as semi-integer.
+    let semi_vars: Vec<&str> = vars
+        .iter()
+        .filter(|v| v.domain.semi_threshold().is_some())
+        .map(|v| v.name.as_str())
+        .collect();
+    if !semi_vars.is_empty() {
+        writeln!(out, "Semi-Continuous")?;
+        writeln!(out, " {}", semi_vars.join(" "))?;
     }
 
     writeln!(out, "End")?;

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -83,7 +83,8 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     writeln!(out, "COLUMNS")?;
     let mut int_open = false;
     for v in vars.iter() {
-        let needs_marker = v.domain.is_integer();
+        // Semi-integer columns carry their integrality via the `SI` bound
+        let needs_marker = v.domain.is_integer() && v.domain.semi_threshold().is_none();
         if needs_marker && !int_open {
             writeln!(out, "    MARKER                 'MARKER'                 'INTORG'")?;
             int_open = true;
@@ -117,6 +118,14 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     for v in vars.iter() {
         let lb = v.lb;
         let ub = v.ub;
+        if let Some(thr) = v.domain.semi_threshold() {
+            writeln!(out, " LO BND       {:<10}{}", v.name, thr)?;
+            let semi_ub = if ub.is_finite() { ub } else { 1e30 };
+            // `is_integer()` distinguishes the two semi domains here.
+            let code = if v.domain.is_integer() { "SI" } else { "SC" };
+            writeln!(out, " {code} BND       {:<10}{}", v.name, semi_ub)?;
+            continue;
+        }
         if lb.is_finite() && (lb - ub).abs() < f64::EPSILON {
             writeln!(out, " FX BND       {:<10}{lb}", v.name)?;
             continue;

--- a/crates/oximo-io/tests/semi_domains.rs
+++ b/crates/oximo-io/tests/semi_domains.rs
@@ -1,0 +1,47 @@
+//! Writer coverage for semicontinuous/semi-integer variables in the LP and
+//! MPS exporters.
+
+use oximo_core::prelude::*;
+use oximo_io::{to_lp_string, to_mps_string};
+
+/// The variable list written on the line after a section `header`.
+fn section_list<'a>(text: &'a str, header: &str) -> Option<&'a str> {
+    text.lines().skip_while(|l| !l.starts_with(header)).nth(1)
+}
+
+/// Build: min s + t  s.t. s + t >= 3, with s semicontinuous (0 or [2, 10]) and
+/// t semi-integer (0 or integer in [1, 5]).
+fn semi_model() -> Model {
+    let m = Model::new("semi");
+    variable!(m, s <= 10.0, SemiCont(2.0));
+    variable!(m, t <= 5.0, SemiInt(1.0));
+    objective!(m, Min, s + t);
+    constraint!(m, c0, s + t >= 3.0);
+    m
+}
+
+#[test]
+fn lp_emits_semi_continuous_section_and_threshold_bounds() {
+    let lp = to_lp_string(&semi_model()).expect("lp writer");
+
+    assert!(lp.contains("2 <= s <= 10"), "missing semicont bound:\n{lp}");
+    assert!(lp.contains("1 <= t <= 5"), "missing semiint bound:\n{lp}");
+
+    let semi_line = section_list(&lp, "Semi-Continuous").expect("Semi-Continuous section");
+    assert!(semi_line.contains('s') && semi_line.contains('t'), "semi list: {semi_line:?}");
+
+    let general_line = section_list(&lp, "General").expect("General section");
+    assert!(general_line.contains('t'), "general list: {general_line:?}");
+}
+
+#[test]
+fn mps_emits_sc_and_si_bounds() {
+    let mps = to_mps_string(&semi_model()).expect("mps writer");
+    let has = |tokens: &[&str]| mps.lines().any(|l| tokens.iter().all(|t| l.contains(t)));
+
+    assert!(has(&["SC BND", "s", "10"]), "missing SC for s:\n{mps}");
+    assert!(has(&["LO BND", "s", "2"]), "missing LO threshold for s:\n{mps}");
+    assert!(has(&["SI BND", "t", "5"]), "missing SI for t:\n{mps}");
+    assert!(has(&["LO BND", "t", "1"]), "missing LO threshold for t:\n{mps}");
+    assert!(!mps.contains("INTORG"), "semi-integer must not be integer-marked:\n{mps}");
+}

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -37,6 +37,19 @@ fn highs_multi_optima_returns_single_best() {
 }
 
 #[test]
+fn highs_rejects_semi_domains() {
+    // HiGHS can't represent the semicontinuity gap through the `highs` crate, so
+    // a semicontinuous (or semi-integer) variable must error.
+    let m = Model::new("semi");
+    variable!(m, s <= 10.0, SemiCont(2.0));
+    constraint!(m, c, s >= 3.0);
+    objective!(m, Min, s);
+
+    let err = Highs.solve(&m, &HighsOptions::default()).unwrap_err();
+    assert!(matches!(err, SolverError::Backend(_)), "expected Backend error, got {err:?}");
+}
+
+#[test]
 fn param_coefficient_lp_rebinds_without_rebuild() {
     let m = Model::new("param_lp");
     param!(m, price = 3.0);

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -123,6 +123,27 @@ fn gams_knapsack_milp() {
 }
 
 #[test]
+fn gams_semicontinuous_respects_threshold_gap() {
+    // min s + t  s.t.  s >= 3,  t >= 3
+    // s is semicontinuous (0 or [5, 10]), t is semi-integer (0 or int in [5, 10]).
+    // The >= 3 constraints forbid 0 and the gap forbids (0, 5), so both jump to
+    // 5 -> obj 10. A dropped threshold would let the solver settle at 3.
+    let m = Model::new("semi");
+    variable!(m, s <= 10.0, SemiCont(5.0));
+    variable!(m, t <= 10.0, SemiInt(5.0));
+    constraint!(m, cs, s >= 3.0);
+    constraint!(m, ct, t >= 3.0);
+    objective!(m, Min, s + t);
+
+    let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
+    let result = Gams::new().solve(&m, &opts).unwrap();
+    assert_eq!(result.status, SolverStatus::Optimal);
+    assert!((result.objective().unwrap() - 10.0).abs() < 1e-4, "obj={:?}", result.objective());
+    assert!((result.value_of(s).unwrap() - 5.0).abs() < 1e-4, "s={:?}", result.value_of(s));
+    assert!((result.value_of(t).unwrap() - 5.0).abs() < 1e-4, "t={:?}", result.value_of(t));
+}
+
+#[test]
 fn gams_infeasible_returns_status() {
     let m = Model::new("infeas");
     variable!(m, 0.0 <= x <= 1.0);

--- a/crates/oximo/tests/solve_gurobi.rs
+++ b/crates/oximo/tests/solve_gurobi.rs
@@ -81,6 +81,26 @@ fn gurobi_qcp_duals_quadratic_constraint() {
 }
 
 #[test]
+fn gurobi_semicontinuous_respects_threshold_gap() {
+    // min s + t  s.t.  s >= 3,  t >= 3
+    // s is semicontinuous (0 or [5, 10]), t is semi-integer (0 or int in [5, 10]).
+    // The >= 3 constraints forbid 0, and the gap forbids (0, 5), so both jump to
+    // 5 -> obj 10. If the threshold were dropped, the solver would settle at 3.
+    let m = Model::new("semi");
+    variable!(m, s <= 10.0, SemiCont(5.0));
+    variable!(m, t <= 10.0, SemiInt(5.0));
+    constraint!(m, cs, s >= 3.0);
+    constraint!(m, ct, t >= 3.0);
+    objective!(m, Min, s + t);
+
+    let result = Gurobi.solve(&m, &GurobiOptions::default()).unwrap();
+    assert_eq!(result.status, SolverStatus::Optimal);
+    assert!((result.objective().unwrap() - 10.0).abs() < 1e-5, "obj={:?}", result.objective());
+    assert!((result.value_of(s).unwrap() - 5.0).abs() < 1e-5, "s={:?}", result.value_of(s));
+    assert!((result.value_of(t).unwrap() - 5.0).abs() < 1e-5, "t={:?}", result.value_of(t));
+}
+
+#[test]
 fn gurobi_qcp_duals_skipped_by_default() {
     // Same convex QCP without .qcp_dual(1): the backend leaves Gurobi's
     // QCPDual default (0) untouched, so no duals are computed.


### PR DESCRIPTION
## Description

This PR adds support for Semi-Continuous/Semi-Integer variables in:"
- GAMS
- Gurobi
- IO

For `oximo-highs`, we throw an error since the `highs` crate does not support SC/SI for now (See https://github.com/rust-or/highs-sys/issues/52)

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for semicontinuous and semi-integer variable domains in Gurobi and GAMS solvers with proper threshold gap handling.
  * LP and MPS export formats now correctly represent semicontinuous and semi-integer variables with appropriate bounds.

* **Documentation**
  * Updated format documentation to describe semicontinuous and semi-integer variable support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->