### PR TITLE
Replace Solver Status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,12 @@ For a quick, model-aware summary, print `result.report(&m)`. For programmatic ac
 ```rust,ignore
 let result = Highs.solve(&m, &HighsOptions::default())?;
 
-match result.status {
-    SolverStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
-    SolverStatus::Infeasible => println!("infeasible"),
-    SolverStatus::TimeLimit => println!("time limit, best = {:?}", result.objective()),
+match result.termination {
+    TerminationStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
+    TerminationStatus::Infeasible => println!("infeasible"),
+    TerminationStatus::TimeLimit if result.has_solution() => {
+        println!("time limit, best = {:?}", result.objective());
+    }
     _ => {}
 }
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,13 @@ For a quick, model-aware summary, print `result.report(&m)`. For programmatic ac
 let result = Highs.solve(&m, &HighsOptions::default())?;
 
 match result.termination {
-    TerminationStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
+    TerminationStatus::Optimal => {
+        // `objective()` is `Option` (a model may have no objective), so print it
+        // only when present.
+        if let Some(obj) = result.objective() {
+            println!("optimal: {obj}");
+        }
+    }
     TerminationStatus::Infeasible => println!("infeasible"),
     TerminationStatus::TimeLimit if result.has_solution() => {
         println!("time limit, best = {:?}", result.objective());

--- a/crates/oximo-baron/README.md
+++ b/crates/oximo-baron/README.md
@@ -51,8 +51,9 @@ constraint!(m, c, x + y <= 8.0);
 objective!(m, Max, (1.0 + x).log() + 2.0 * y);
 
 let result = Baron::new().solve(&m, &BaronOptions::default())?;
-println!("status = {:?}", result.status);
-println!("obj    = {:?}", result.objective());
+println!("termination = {:?}", result.termination);
+println!("primal      = {:?}", result.primal_status);
+println!("obj         = {:?}", result.objective());
 ```
 
 Run the bundled example:

--- a/crates/oximo-baron/README.md
+++ b/crates/oximo-baron/README.md
@@ -120,12 +120,15 @@ BARON's `.bar` format has no trigonometric intrinsics, so a model whose objectiv
 
 ## Result
 
-`SolverResult` fields populated on `Optimal` or `Feasible`:
+`SolverResult` fields, populated whenever a usable point is available (`primal_status` is `FeasiblePoint` or `OptimalPoint`):
 
 - `solutions`: primal points (`Vec<SolutionPoint>`), best first. Each point holds its `primal` values keyed by `VarId` and its `objective`. With `.num_sol(n)` BARON enumerates up to `n` distinct solutions into the pool, otherwise the vector holds the single incumbent. Access the best point via `result.objective()` / `result.value_of(var)` and the rest via `result.solution(i)`
 - `dual`: constraint marginals at the best point, keyed by `ConstraintId`, access via `result.dual_of(c)`
 - `reduced_costs`: variable marginals at the best point, keyed by `VarId`
-- `status`: mapped from BARON solver/model status codes
+- `termination`: why the solve stopped, read from BARON's `res.lst` termination banner
+- `primal_status`: whether a usable point came back (`NoSolution` / `FeasiblePoint` / `OptimalPoint`), `result.has_solution()` is the shortcut
+- `best_bound`: BARON's relaxation/dual bound (the bound opposite the incumbent)
+- `gap`: relative optimality gap from BARON's lower/upper bounds, when both are finite
 - `solve_time`: wall time around the BARON process invocation
 - `iterations`: branch-and-reduce iteration count from `tim.lst`
 - `raw_log`: BARON stdout/stderr, captured when BARON exits non-zero in quiet mode. With `verbose(true)` the output is streamed live to the terminal and not captured (`raw_log` is `None`)

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -8,7 +8,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, Objective, ObjectiveSense, Sense, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
-use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
+use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
 use rustc_hash::FxHashMap;
 
 use crate::BaronOptions;
@@ -506,9 +506,10 @@ fn fmt(v: f64) -> String {
 ///
 /// The times file is a single whitespace-separated line. Field positions follow
 /// the BARON convention (0-indexed here):
-/// `[5]` lower bound, `[6]` upper bound, `[7]` solver status, `[8]` model status,
-/// `[10]` branch-and-reduce iterations, `[11]` node where the optimum was found
-/// (`-3` => no solution), last = wall time.
+/// `[5]` lower bound, `[6]` upper bound, `[8]` model status, `[10]`
+/// branch-and-reduce iterations, `[11]` node where the optimum was found
+/// (`-3` => no solution), last = wall time. The termination reason comes from
+/// the `res.lst` banner (see [`map_status`]), not the numeric `[7]` solver status.
 fn parse_solution(
     tim: &str,
     res: &str,
@@ -521,15 +522,17 @@ fn parse_solution(
     let int_at = |i: usize| tokens.get(i).and_then(|s| s.parse::<i64>().ok());
     let float_at = |i: usize| tokens.get(i).and_then(|s| parse_baron_float(s));
 
-    let solver_status = int_at(7).unwrap_or(99);
     let model_status = int_at(8).unwrap_or(5);
     let lower = float_at(5);
     let upper = float_at(6);
     let iterations = int_at(10).and_then(|n| u64::try_from(n).ok()).unwrap_or(0);
     let nodeopt = int_at(11);
 
-    let status = map_status(solver_status, model_status);
-    let has_sol = status.has_solution();
+    let termination = map_status(res, model_status);
+    // BARON has a usable point when the model status says optimal (`1`) or
+    // intermediate-feasible (`4`). The solution node (`nodeopt`) only 
+    // controls whether a primal vector is available.
+    let has_sol = matches!(model_status, 1 | 4);
 
     // For minimization the incumbent is the upper bound, for maximization the
     // lower bound (the other field is the dual/relaxation bound).
@@ -538,11 +541,8 @@ fn parse_solution(
         ObjectiveSense::Maximize => lower,
     };
 
-    let mut solutions = if has_sol && nodeopt != Some(-3) {
-        parse_results(res, var_order, sense)
-    } else {
-        Vec::new()
-    };
+    let mut solutions =
+        if has_sol && nodeopt != Some(-3) { parse_results(res, var_order, sense) } else { Vec::new() };
 
     // BARON prints each solution's exact objective. Only when the status says a
     // solution exists but no primal block was parsed do we fall back to the times
@@ -557,11 +557,21 @@ fn parse_solution(
         (FxHashMap::default(), FxHashMap::default())
     };
 
+    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
+    let best_bound = match sense {
+        ObjectiveSense::Minimize => lower,
+        ObjectiveSense::Maximize => upper,
+    };
+    let gap = relative_gap(lower, upper);
+
     SolverResult {
         solutions,
         dual,
         reduced_costs,
-        status,
+        termination,
+        primal_status,
+        best_bound,
+        gap,
         solve_time: elapsed,
         iterations,
         raw_log,
@@ -569,30 +579,76 @@ fn parse_solution(
     }
 }
 
-/// Map BARON solver/model status codes to [`SolverStatus`].
+/// Relative optimality gap from BARON's lower/upper bounds, `None` unless both
+/// are finite. Normalized by the larger-magnitude bound (+ epsilon) so it is
+/// comparable across models.
+fn relative_gap(lower: Option<f64>, upper: Option<f64>) -> Option<f64> {
+    match (lower, upper) {
+        (Some(lo), Some(hi)) if lo.is_finite() && hi.is_finite() => {
+            let g = (hi - lo).abs() / (lo.abs().max(hi.abs()) + 1e-10);
+            g.is_finite().then_some(g)
+        }
+        _ => None,
+    }
+}
+
+/// Determine the [`TerminationStatus`] from BARON's results-file termination banner
+/// (BARON manual, Section 5.2 "Termination messages, model and solver statuses").
 ///
-/// We prefer the model status when it indicates a solution (optimal/feasible) so
-/// a run that hit a time or iteration limit but found an incumbent still reports
-/// `Feasible` and keeps its primal. Status code tables (BARON manual):
-/// Solver `1`=normal, `4`=time limit, `5`=numerical, `11`=licensing. Model
-/// `1`=optimal, `2`=infeasible, `3`=unbounded, `4`=intermediate feasible,
-/// `5`=unknown.
-fn map_status(solver_status: i64, model_status: i64) -> SolverStatus {
+/// BARON prints exactly one `*** ... ***` banner at the end of `res.lst`. We map
+/// it to a termination reason. `Normal completion` carries no limit/error reason,
+/// so it (and any unrecognized output) defers to the numeric model status via
+/// [`model_status_termination`]. Whether a usable point exists is tracked
+/// separately via [`PrimalStatus`], so a limit- or heuristic-terminated run still
+/// keeps its incumbent.
+fn map_status(res: &str, model_status: i64) -> TerminationStatus {
+    let log = res.to_ascii_lowercase();
+    let has = |needle: &str| log.contains(needle);
+
+    if has("nodes in memory") {
+        // *** Max. allowable nodes in memory reached ***
+        TerminationStatus::NodeLimit
+    } else if has("bar iterations") {
+        // *** Max. allowable BaR iterations reached ***
+        TerminationStatus::IterationLimit
+    } else if has("time exceeded") {
+        // *** Max. allowable time exceeded ***
+        TerminationStatus::TimeLimit
+    } else if has("numerically sensitive") {
+        // *** Problem is numerically sensitive ***
+        TerminationStatus::NumericError
+    } else if has("search interrupted by user") || has("access violation") {
+        // *** Search interrupted by user *** / *** ... access violation ... ***
+        TerminationStatus::Interrupted
+    } else if has("heuristic termination") {
+        // *** Heuristic termination ***, feasible found, global optimality not
+        // guaranteed (DeltaTerm).
+        TerminationStatus::Interrupted
+    } else if has("insufficient memory") {
+        // *** Insufficient Memory for Data structures ***
+        TerminationStatus::Other("baron_insufficient_memory".into())
+    } else if has("appropriate variable bounds") {
+        // *** User did not provide appropriate variable bounds ***, relaxation
+        // bounds may be invalid, so neither globality nor infeasibility is
+        // guaranteed. Feasibility, if any, is still reflected in the primal status.
+        TerminationStatus::Other("baron_missing_bounds".into())
+    } else {
+        // *** Normal completion *** or no recognizable banner.
+        // The model status is the authoritative outcome.
+        model_status_termination(model_status)
+    }
+}
+
+/// Outcome implied by BARON's numeric model status, used on normal completion or
+/// when `res.lst` carries no recognizable termination banner. `1`=optimal,
+/// `2`=infeasible, `3`=unbounded, `4`=intermediate feasible (a normal completion
+/// that reports a feasible point is a solved global optimum), `5`=unknown.
+fn model_status_termination(model_status: i64) -> TerminationStatus {
     match model_status {
-        1 => SolverStatus::Optimal,
-        2 => SolverStatus::Infeasible,
-        3 => SolverStatus::Unbounded,
-        4 => SolverStatus::Feasible,
-        // Model status unknown: fall back to the solver-level termination reason.
-        // TODO: This can be improved, we need to redefine SolverStatus.
-        _ => match solver_status {
-            4 => SolverStatus::TimeLimit,
-            5 => SolverStatus::NumericError,
-            3 => SolverStatus::Other("baron_iteration_limit".into()),
-            11 => SolverStatus::Other("baron_license_error".into()),
-            1 => SolverStatus::Other("baron_unknown".into()),
-            n => SolverStatus::Other(format!("baron_solver_status_{n}")),
-        },
+        1 | 4 => TerminationStatus::Optimal,
+        2 => TerminationStatus::Infeasible,
+        3 => TerminationStatus::Unbounded,
+        n => TerminationStatus::Other(format!("baron_model_status_{n}")),
     }
 }
 
@@ -995,15 +1051,46 @@ mod tests {
     }
 
     #[test]
-    fn map_status_table() {
-        assert_eq!(map_status(1, 1), SolverStatus::Optimal);
-        assert_eq!(map_status(1, 2), SolverStatus::Infeasible);
-        assert_eq!(map_status(1, 3), SolverStatus::Unbounded);
-        assert_eq!(map_status(4, 4), SolverStatus::Feasible); // time limit but feasible
-        assert_eq!(map_status(4, 5), SolverStatus::TimeLimit);
-        assert_eq!(map_status(5, 5), SolverStatus::NumericError);
-        assert_eq!(map_status(11, 5), SolverStatus::Other("baron_license_error".into()));
-        assert_eq!(map_status(3, 5), SolverStatus::Other("baron_iteration_limit".into()));
+    fn termination_from_banner() {
+        // `map_status(res, model_status)`. The results-file banner
+        // (manual, Section 5.2) drives the termination reason,
+        // the model status is the fallback.
+        let nc = "*** Normal completion ***";
+        assert_eq!(map_status(nc, 1), TerminationStatus::Optimal);
+        assert_eq!(map_status(nc, 2), TerminationStatus::Infeasible);
+        assert_eq!(map_status(nc, 3), TerminationStatus::Unbounded);
+        // Limit / interrupt banners are authoritative regardless of model status,
+        // and a feasible incumbent is kept via the primal status.
+        assert_eq!(
+            map_status("*** Max. allowable nodes in memory reached ***", 4),
+            TerminationStatus::NodeLimit
+        );
+        assert_eq!(
+            map_status("*** Max. allowable BaR iterations reached ***", 4),
+            TerminationStatus::IterationLimit
+        );
+        assert_eq!(
+            map_status("*** Max. allowable time exceeded ***", 4),
+            TerminationStatus::TimeLimit
+        );
+        assert_eq!(
+            map_status("*** Problem is numerically sensitive ***", 4),
+            TerminationStatus::NumericError
+        );
+        assert_eq!(
+            map_status("*** Search interrupted by user ***", 4),
+            TerminationStatus::Interrupted
+        );
+        assert_eq!(
+            map_status("*** Heuristic termination ***", 4),
+            TerminationStatus::Interrupted
+        );
+        assert_eq!(
+            map_status("*** User did not provide appropriate variable bounds ***", 4),
+            TerminationStatus::Other("baron_missing_bounds".into())
+        );
+        // No recognizable banner falls back to the model status.
+        assert_eq!(map_status("", 1), TerminationStatus::Optimal);
     }
 
     #[test]
@@ -1012,7 +1099,7 @@ mod tests {
         let tim = "m 1 2 0 0 1.5 9.5 1 1 0 42 7 0 0 0.42";
         let r =
             parse_solution(tim, "", ObjectiveSense::Minimize, std::time::Duration::ZERO, None, &[]);
-        assert_eq!(r.status, SolverStatus::Optimal);
+        assert_eq!(r.termination, TerminationStatus::Optimal);
         assert_eq!(r.objective(), Some(9.5)); // upper bound for minimize
         assert_eq!(r.iterations, 42); // branch-and-reduce iterations from tim[10]
         let r =

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -530,7 +530,7 @@ fn parse_solution(
 
     let termination = map_status(res, model_status);
     // BARON has a usable point when the model status says optimal (`1`) or
-    // intermediate-feasible (`4`). The solution node (`nodeopt`) only 
+    // intermediate-feasible (`4`). The solution node (`nodeopt`) only
     // controls whether a primal vector is available.
     let has_sol = matches!(model_status, 1 | 4);
 
@@ -541,8 +541,11 @@ fn parse_solution(
         ObjectiveSense::Maximize => lower,
     };
 
-    let mut solutions =
-        if has_sol && nodeopt != Some(-3) { parse_results(res, var_order, sense) } else { Vec::new() };
+    let mut solutions = if has_sol && nodeopt != Some(-3) {
+        parse_results(res, var_order, sense)
+    } else {
+        Vec::new()
+    };
 
     // BARON prints each solution's exact objective. Only when the status says a
     // solution exists but no primal block was parsed do we fall back to the times
@@ -1081,10 +1084,7 @@ mod tests {
             map_status("*** Search interrupted by user ***", 4),
             TerminationStatus::Interrupted
         );
-        assert_eq!(
-            map_status("*** Heuristic termination ***", 4),
-            TerminationStatus::Interrupted
-        );
+        assert_eq!(map_status("*** Heuristic termination ***", 4), TerminationStatus::Interrupted);
         assert_eq!(
             map_status("*** User did not provide appropriate variable bounds ***", 4),
             TerminationStatus::Other("baron_missing_bounds".into())

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -560,7 +560,9 @@ fn parse_solution(
         (FxHashMap::default(), FxHashMap::default())
     };
 
-    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
+    // A point is only usable if it carries primal values.
+    let has_usable_primal = solutions.iter().any(|s| !s.primal.is_empty());
+    let primal_status = PrimalStatus::infer(&termination, has_usable_primal);
     let best_bound = match sense {
         ObjectiveSense::Minimize => lower,
         ObjectiveSense::Maximize => upper,
@@ -1304,8 +1306,9 @@ The above solution has an objective value of:  0.0
 
     #[test]
     fn no_solution_node_minus_three_leaves_primal_empty() {
-        // solver=1 model=1 (optimal) but nodeopt = -3 => no solution vector. We
-        // still surface a single point (objective known, variables unavailable).
+        // model=1 (optimal) but nodeopt = -3 => no solution vector. We surface a
+        // single objective-only point, but it carries no primal data,
+        // so it must NOT count as a usable solution.
         let tim = "m 1 1 0 0 0 0 1 1 0 0 -3 0 0 0.01";
         let res = "The best solution found is:\n\n\n  x0  0  9.9\n";
         let r = parse_solution(
@@ -1322,5 +1325,10 @@ The above solution has an objective value of:  0.0
             "nodeopt -3 must skip primal: {:?}",
             r.solution(0)
         );
+        assert_eq!(r.primal_status, PrimalStatus::NoSolution);
+        assert!(!r.has_solution(), "nodeopt -3 must not report a usable solution");
+        let primal = r.primal().expect("objective-only point is present");
+        assert!(primal.is_empty(), "nodeopt -3 must expose no primal values: {primal:?}");
+        assert!(r.value(VarId(0)).is_none(), "nodeopt -3 must not yield a variable value");
     }
 }

--- a/crates/oximo-gams/README.md
+++ b/crates/oximo-gams/README.md
@@ -55,8 +55,9 @@ constraint!(m, c3, x - y <= 2.0);
 objective!(m, Max, 3.0 * x + 4.0 * y);
 
 let result = Gams::new().solve(&m, &GamsOptions::default())?;
-println!("status = {:?}", result.status);
-println!("obj    = {:?}", result.objective());
+println!("termination = {:?}", result.termination);
+println!("primal      = {:?}", result.primal_status);
+println!("obj         = {:?}", result.objective());
 ```
 
 Run the bundled example:

--- a/crates/oximo-gams/README.md
+++ b/crates/oximo-gams/README.md
@@ -152,12 +152,14 @@ For any other solver, use `GamsSolverConfig::Named(GamsSolver::Custom("NAME".int
 
 ## Result
 
-`SolverResult` fields populated on `Optimal` or `Feasible`:
+`SolverResult` fields, populated whenever a usable point is available (`primal_status` is `FeasiblePoint` or `OptimalPoint`):
 
 - `solutions` - primal points (`Vec<SolutionPoint>`), best first. Each point holds its `primal` values keyed by `VarId` and its `objective`. The vector holds the incumbent, plus any alternative points read from a sub-solver solution pool (e.g. CPLEX `solnpool`). Access the best point via `result.objective()` / `result.value_of(var)` and the rest via `result.solution(i)`
 - `dual` - constraint marginals (GAMS `.m`), keyed by `ConstraintId`, access via `result.dual_of(c)`
 - `reduced_costs` - variable marginals, keyed by `VarId`
-- `status` - mapped from GAMS model-status codes (`1=Optimal`, `4=Infeasible`, `3=Unbounded`, ...)
+- `termination` - why the solve stopped, driven by the GAMS solve status (`solvestat`), with the model status (`modelstat`) resolving the outcome on normal completion (`Optimal`, `Infeasible`, `Unbounded`, `TimeLimit`, `IterationLimit`, ...)
+- `primal_status` - whether a usable point came back (`NoSolution` / `FeasiblePoint` / `OptimalPoint`), `result.has_solution()` is the shortcut
+- `best_bound` / `gap` - left unset (`None`), not exposed in the GAMS PUT solution file
 - `solve_time` - wall time around the GAMS process invocation
 - `iterations` - iterations used, read from the GAMS model attribute `oximo_m.iterusd`
 - `solver_name` - `GAMS/<sub-solver>` when one is selected via `GamsOptions::solver` (e.g. `GAMS/CPLEX`, `GAMS/BARON`), otherwise just `GAMS`

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -13,7 +13,7 @@ use oximo_core::{
     Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
-use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
+use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
 use rustc_hash::FxHashMap;
 
 use crate::GamsOptions;
@@ -170,7 +170,7 @@ pub fn solve(
         // If a sub-solver wrote a solution pool (e.g. CPLEX `solnpool`), surface
         // every pooled point. The model itself emits no GDX, so any pool GDX in
         // the run directory came from the user's option file.
-        if result.status.has_solution() {
+        if result.has_solution() {
             let pool = read_solution_pool(&tmp_dir, gams_exec, sense);
             if !pool.is_empty() {
                 result.solutions = pool;
@@ -300,18 +300,23 @@ fn parseoximo_solution(
         }
     }
 
-    let status = map_status(modelstat.unwrap_or(13), solvestat.unwrap_or(0));
-    let has_sol = status.has_solution();
+    let modelstat = modelstat.unwrap_or(13);
+    let termination = map_status(modelstat, solvestat.unwrap_or(0));
+    let has_sol = modelstat_has_solution(modelstat);
 
     // The PUT solution file holds only the incumbent. `solve` augments this with
     // a sub-solver solution pool (if one was written) read from the run dir's GDX.
     let solutions =
         if has_sol { vec![SolutionPoint { primal, objective: obj_val }] } else { Vec::new() };
+    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
     SolverResult {
         solutions,
         dual: if has_sol { dual } else { FxHashMap::default() },
         reduced_costs: if has_sol { reduced_costs } else { FxHashMap::default() },
-        status,
+        termination,
+        primal_status,
+        best_bound: None,
+        gap: None,
         solve_time: elapsed,
         iterations,
         raw_log,
@@ -417,50 +422,71 @@ fn parse_gdx_level(line: &str) -> f64 {
     0.0
 }
 
-/// Map GAMS model-status to `SolverStatus`.
+/// Map a GAMS solve to a [`TerminationStatus`].
+///
+/// GAMS reports two orthogonal codes, which line up with our two-axis result:
+/// `solvestat` (the *solver termination condition* — why the run stopped) drives
+/// the [`TerminationStatus`], while `modelstat` (the *model status* — what kind
+/// of solution exists) drives feasibility/primal status (see
+/// [`modelstat_has_solution`]) and disambiguates the outcome on normal
+/// completion.
+///
+/// `solvestat` table:
+///  1 = Normal, 2 = Iteration, 3 = Resource (time), 4 = Terminated by solver,
+///  5 = Evaluation error, 6 = Capability (model beyond solver), 7 = License,
+///  8 = User (interrupt), 9 = Setup error, 10 = Solver error,
+///  11 = Internal error, 12 = Skipped, 13 = System error.
+///
+/// On a normal completion the `solvestat` carries no outcome, so we defer to
+/// [`modelstat_termination`].
+///
+/// Reference: GAMS `SolveStat` codes,
+/// <https://www.gams.com/latest/docs/apis/python/classgams_1_1control_1_1workspace_1_1SolveStat.html>
+fn map_status(modelstat: i32, solvestat: i32) -> TerminationStatus {
+    match solvestat {
+        1 => modelstat_termination(modelstat),
+        2 => TerminationStatus::IterationLimit,
+        3 => TerminationStatus::TimeLimit,
+        // "Terminated by solver" / "User request": abnormal early stops that may
+        // still carry an incumbent.
+        4 | 8 => TerminationStatus::Interrupted,
+        // Evaluation / solver / internal / system errors.
+        5 | 10 | 11 | 13 => TerminationStatus::NumericError,
+        6 => TerminationStatus::Other("gams_solver_capability".into()),
+        7 => TerminationStatus::Other("gams_license_error".into()),
+        9 => TerminationStatus::Other("gams_setup_error".into()),
+        12 => TerminationStatus::NotSolved,
+        n => TerminationStatus::Other(format!("gams_solvestat_{n}")),
+    }
+}
+
+/// Termination from the GAMS `modelstat` when the solver completed normally
+/// (`solvestat == 1`), so the model status is the authoritative outcome.
 ///
 /// Full modelstat table (codes 1-19):
-///  1 = Optimal,
-///  2 = Locally Optimal,
-///  3 = Unbounded,
-///  4 = Infeasible,
-///  5 = Locally Infeasible,
-///  6 = Intermediate Infeasible,
-///  7 = Feasible Solution,
-///  8 = Integer Solution,
-///  9 = Intermediate Non-integer,
-///  10 = Integer Infeasible,
-///  11 = Lic Problem No Solution,
-///  12 = Error Unknown,
-///  13 = Error No Solution,
-///  14 = No Solution Returned,
-///  15 = Solved Unique,
-///  16 = Solved,
-///  17 = Solved Singular,
-///  18 = Unbounded-No Solution,
-///  19 = Infeasible-No Solution.
+///  1 = Optimal, 2 = Locally Optimal, 3 = Unbounded, 4 = Infeasible,
+///  5 = Locally Infeasible, 6 = Intermediate Infeasible, 7 = Feasible Solution,
+///  8 = Integer Solution, 9 = Intermediate Non-integer, 10 = Integer Infeasible,
+///  11 = Lic Problem No Solution, 12 = Error Unknown, 13 = Error No Solution,
+///  14 = No Solution Returned, 15 = Solved Unique, 16 = Solved,
+///  17 = Solved Singular, 18 = Unbounded-No Solution, 19 = Infeasible-No Solution.
 ///
-/// References:
-/// "GAMS Output - Model Status," GAMS Development Corporation.
-/// <https://www.gams.com/latest/docs/UG_GAMSOutput.html#UG_GAMSOutput_ModelStatus> (accessed May 14, 2026).
-fn map_status(modelstat: i32, solvestat: i32) -> SolverStatus {
-    // TODO: Could refine this mapping if we modify the `SolverStatus` enum.
+/// Reference: GAMS `ModelStat` codes,
+/// <https://www.gams.com/latest/docs/apis/python/classgams_1_1control_1_1workspace_1_1ModelStat.html>
+fn modelstat_termination(modelstat: i32) -> TerminationStatus {
     match modelstat {
-        1 | 15 | 16 => SolverStatus::Optimal,
-        2 | 7 | 9 | 17 => SolverStatus::Feasible,
-        3 | 18 => SolverStatus::Unbounded,
-        4 | 5 | 6 | 10 | 19 => SolverStatus::Infeasible,
-        // MIP integer solution: proven optimal when solvestat == 1 (normal completion)
-        8 => {
-            if solvestat == 1 {
-                SolverStatus::Optimal
-            } else {
-                SolverStatus::Feasible
-            }
-        }
-        11 => SolverStatus::Other("gams_license_error".into()),
-        _ => SolverStatus::Other(format!("gams_modelstat_{modelstat}")),
+        1 | 8 | 15 | 16 | 17 => TerminationStatus::Optimal,
+        2 | 7 | 9 => TerminationStatus::LocallyOptimal,
+        3 | 18 => TerminationStatus::Unbounded,
+        4 | 5 | 6 | 10 | 19 => TerminationStatus::Infeasible,
+        11 => TerminationStatus::Other("gams_license_error".into()),
+        n => TerminationStatus::Other(format!("gams_modelstat_{n}")),
     }
+}
+
+/// GAMS model-status codes that carry a usable primal point.
+fn modelstat_has_solution(modelstat: i32) -> bool {
+    matches!(modelstat, 1 | 2 | 7 | 8 | 9 | 15 | 16 | 17)
 }
 
 // - Helpers
@@ -904,8 +930,26 @@ mod tests {
         // The PUT solution file emits `ITER=` from `oximo_m.iterusd`.
         let content = "STATUS=1\nSOLVESTAT=1\nITER=42\nOBJVAL=10.0\n0=2.5\n";
         let r = parseoximo_solution(content, std::time::Duration::ZERO, None);
-        assert_eq!(r.status, SolverStatus::Optimal);
+        assert_eq!(r.termination, TerminationStatus::Optimal);
         assert_eq!(r.iterations, 42);
+    }
+
+    #[test]
+    fn termination_is_driven_by_solvestat() {
+        // solvestat (args are `(modelstat, solvestat)`).
+        // Normal completion defers to modelstat.
+        assert_eq!(map_status(1, 1), TerminationStatus::Optimal);
+        assert_eq!(map_status(2, 1), TerminationStatus::LocallyOptimal);
+        assert_eq!(map_status(8, 1), TerminationStatus::Optimal);
+        assert_eq!(map_status(4, 1), TerminationStatus::Infeasible);
+        assert_eq!(map_status(3, 1), TerminationStatus::Unbounded);
+        assert_eq!(map_status(8, 2), TerminationStatus::IterationLimit);
+        assert_eq!(map_status(7, 3), TerminationStatus::TimeLimit);
+        assert_eq!(map_status(8, 8), TerminationStatus::Interrupted);
+        assert_eq!(map_status(8, 4), TerminationStatus::Interrupted);
+        assert_eq!(map_status(1, 5), TerminationStatus::NumericError);
+        assert_eq!(map_status(1, 12), TerminationStatus::NotSolved);
+        assert_eq!(map_status(1, 7), TerminationStatus::Other("gams_license_error".into()));
     }
 
     #[test]

--- a/crates/oximo-gurobi/README.md
+++ b/crates/oximo-gurobi/README.md
@@ -61,8 +61,9 @@ constraint!(m, cap, sum!(weights[i] * x[i] for i in 0..4) <= 7.0);
 objective!(m, Max, sum!(values[i] * x[i] for i in 0..4));
 
 let result = Gurobi.solve(&m, &GurobiOptions::default())?;
-println!("status = {:?}", result.status);
-println!("obj    = {:?}", result.objective());
+println!("termination = {:?}", result.termination);
+println!("primal      = {:?}", result.primal_status);
+println!("obj         = {:?}", result.objective());
 ```
 
 Run the bundled example:

--- a/crates/oximo-gurobi/README.md
+++ b/crates/oximo-gurobi/README.md
@@ -124,11 +124,15 @@ let opts = GurobiOptions::default()
 
 ## Result
 
-`SolverResult` fields populated on `Optimal` or `Feasible`:
+`SolverResult` fields, populated whenever a usable point is available (`primal_status` is `FeasiblePoint` or `OptimalPoint`):
 
 - `solutions` - primal points (`Vec<SolutionPoint>`), best first. Each point holds its `primal` values keyed by `VarId` and its `objective` (adjusted for any constant term). Gurobi's solution pool fills the vector during a MIP solve (tune with `PoolSearchMode`/`PoolSolutions`); continuous solves return a single point. Access the best point via `result.objective()` / `result.value_of(var)` and the rest via `result.solution(i)`
 - `dual` - constraint duals (`Pi` for linear rows, `QCPi` for quadratic rows), keyed by `ConstraintId`, access via `result.dual_of(c)`. Returned for continuous models (LP, QP). For quadratically constrained models Gurobi skips duals by default, opt in with `.qcp_dual(1)`. Whenever Gurobi reports no duals (e.g. a nonconvex QP solved via spatial branching) the maps stay empty
 - `reduced_costs` - variable reduced costs (`RC`), keyed by `VarId`, continuous models only
+- `termination` - why the solve stopped (`Optimal`, `Infeasible`, `Unbounded`, `InfeasibleOrUnbounded`, `TimeLimit`, `IterationLimit`, `NodeLimit`, `Interrupted`, ...), mapped from Gurobi's `Status`
+- `primal_status` - whether a usable point came back (`NoSolution` / `FeasiblePoint` / `OptimalPoint`), `result.has_solution()` is the shortcut. Gurobi keeps an incumbent (`SolCount > 0`) even at a limit
+- `best_bound` - Gurobi's best objective bound (`ObjBound`), `None` when unavailable (e.g. continuous models)
+- `gap` - relative MIP gap (`MIPGap`), `None` when unavailable
 - `iterations` - simplex iteration count (`IterCount`)
 - `solve_time` - wall time measured around the Gurobi optimize call
 

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -76,14 +76,8 @@ pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, Solver
     let termination = map_status(&grb_model)?;
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let iterations = grb_model.get_attr(attr::IterCount).unwrap_or(0.0) as u64;
-    let (solutions, reduced_costs, dual) = collect_solution(
-        termination.admits_primal(),
-        kind,
-        &mut grb_model,
-        &gurobi_vars,
-        &gurobi_constrs,
-        obj_constant,
-    );
+    let (solutions, reduced_costs, dual) =
+        collect_solution(kind, &mut grb_model, &gurobi_vars, &gurobi_constrs, obj_constant);
 
     let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
     let best_bound = grb_model.get_attr(attr::ObjBound).ok().filter(|b| b.is_finite());
@@ -267,23 +261,21 @@ fn set_objective(
 /// for continuous models (`LP` and `QP`). For quadratically constrained models
 /// Gurobi computes duals only with `QCPDual=1`.
 fn collect_solution(
-    admits_primal: bool,
     kind: ModelKind,
     model: &mut grb::Model,
     vars: &[grb::Var],
     constrs: &[GrbRow],
     obj_constant: f64,
 ) -> (Vec<SolutionPoint>, FxHashMap<VarId, f64>, FxHashMap<ConstraintId, f64>) {
-    // Gurobi often holds an incumbent (SolCount > 0) on TimeLimit/IterationLimit/
-    // NodeLimit, so trust SolCount first and fall back to whether the termination
-    // reason admits a primal point at all.
+    // A primal point exists only when Gurobi actually stored one. `SolCount` is
+    // the number of available solutions and it stays `> 0` for an incumbent
+    // kept at a time/iteration/node limit.
     let sol_count = model.get_attr(attr::SolCount).unwrap_or(0);
-    let n = if sol_count > 0 { sol_count } else { i32::from(admits_primal) };
-    if n == 0 {
+    if sol_count <= 0 {
         return (Vec::new(), FxHashMap::default(), FxHashMap::default());
     }
 
-    let solutions = collect_pool(model, vars, obj_constant, n);
+    let solutions = collect_pool(model, vars, obj_constant, sol_count);
 
     // Skip retrieval of duals and reduced costs for any model
     // class where Gurobi will either return zeros or refuse the attribute.

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -6,7 +6,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, extract_linear};
-use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
+use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
 use rustc_hash::FxHashMap;
 
 use crate::GurobiOptions;
@@ -73,11 +73,11 @@ pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, Solver
     grb_model.optimize().map_err(map_grb_err)?;
     let elapsed = started.elapsed();
 
-    let status = map_status(&grb_model)?;
+    let termination = map_status(&grb_model)?;
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let iterations = grb_model.get_attr(attr::IterCount).unwrap_or(0.0) as u64;
     let (solutions, reduced_costs, dual) = collect_solution(
-        &status,
+        termination.admits_primal(),
         kind,
         &mut grb_model,
         &gurobi_vars,
@@ -85,11 +85,18 @@ pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, Solver
         obj_constant,
     );
 
+    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
+    let best_bound = grb_model.get_attr(attr::ObjBound).ok().filter(|b| b.is_finite());
+    let gap = grb_model.get_attr(attr::MIPGap).ok().filter(|g| g.is_finite());
+
     Ok(SolverResult {
-        status,
+        termination,
+        primal_status,
         solutions,
         dual,
         reduced_costs,
+        best_bound,
+        gap,
         solve_time: elapsed,
         iterations,
         raw_log: None,
@@ -260,17 +267,18 @@ fn set_objective(
 /// for continuous models (`LP` and `QP`). For quadratically constrained models
 /// Gurobi computes duals only with `QCPDual=1`.
 fn collect_solution(
-    status: &SolverStatus,
+    admits_primal: bool,
     kind: ModelKind,
     model: &mut grb::Model,
     vars: &[grb::Var],
     constrs: &[GrbRow],
     obj_constant: f64,
 ) -> (Vec<SolutionPoint>, FxHashMap<VarId, f64>, FxHashMap<ConstraintId, f64>) {
-    // `has_solution` only flags Optimal/Feasible, but Gurobi often holds an
-    // incumbent (SolCount > 0) on TimeLimit/IterationLimit/NodeLimit too.
+    // Gurobi often holds an incumbent (SolCount > 0) on TimeLimit/IterationLimit/
+    // NodeLimit, so trust SolCount first and fall back to whether the termination
+    // reason admits a primal point at all.
     let sol_count = model.get_attr(attr::SolCount).unwrap_or(0);
-    let n = if sol_count > 0 { sol_count } else { i32::from(status.has_solution()) };
+    let n = if sol_count > 0 { sol_count } else { i32::from(admits_primal) };
     if n == 0 {
         return (Vec::new(), FxHashMap::default(), FxHashMap::default());
     }
@@ -341,16 +349,20 @@ fn index_map(vals: &[f64]) -> FxHashMap<VarId, f64> {
     vals.iter().enumerate().map(|(i, &val)| (VarId(u32::try_from(i).unwrap()), val)).collect()
 }
 
-fn map_status(model: &grb::Model) -> Result<SolverStatus, SolverError> {
+fn map_status(model: &grb::Model) -> Result<TerminationStatus, SolverError> {
     let status = model.get_attr(attr::Status).map_err(map_grb_err)?;
     Ok(match status {
-        Status::Optimal => SolverStatus::Optimal,
-        Status::Infeasible => SolverStatus::Infeasible,
-        Status::Unbounded | Status::InfOrUnbd => SolverStatus::Unbounded,
-        Status::Numeric => SolverStatus::NumericError,
-        Status::TimeLimit | Status::IterationLimit | Status::NodeLimit => SolverStatus::TimeLimit,
-        Status::SubOptimal => SolverStatus::Feasible,
-        Status::Loaded => SolverStatus::NotSolved,
-        _ => SolverStatus::Other(format!("Status: {status:?}")),
+        Status::Optimal => TerminationStatus::Optimal,
+        Status::Infeasible => TerminationStatus::Infeasible,
+        Status::Unbounded => TerminationStatus::Unbounded,
+        Status::InfOrUnbd => TerminationStatus::InfeasibleOrUnbounded,
+        Status::Numeric => TerminationStatus::NumericError,
+        Status::TimeLimit => TerminationStatus::TimeLimit,
+        Status::IterationLimit => TerminationStatus::IterationLimit,
+        Status::NodeLimit => TerminationStatus::NodeLimit,
+        // Gurobi could not meet optimality tolerances but holds a usable point.
+        Status::SubOptimal => TerminationStatus::Interrupted,
+        Status::Loaded => TerminationStatus::NotSolved,
+        _ => TerminationStatus::Other(format!("Status: {status:?}")),
     })
 }

--- a/crates/oximo-gurobi/tests/nonlinear.rs
+++ b/crates/oximo-gurobi/tests/nonlinear.rs
@@ -9,12 +9,7 @@ fn close(a: f64, b: f64, tol: f64) -> bool {
 }
 
 fn assert_solved(r: &oximo_solver::SolverResult) {
-    assert!(
-        r.has_solution(),
-        "termination = {:?}, primal = {:?}",
-        r.termination,
-        r.primal_status
-    );
+    assert!(r.has_solution(), "termination = {:?}, primal = {:?}", r.termination, r.primal_status);
 }
 
 #[test]

--- a/crates/oximo-gurobi/tests/nonlinear.rs
+++ b/crates/oximo-gurobi/tests/nonlinear.rs
@@ -2,7 +2,7 @@
 
 use oximo_core::prelude::*;
 use oximo_gurobi::{Gurobi, GurobiOptions};
-use oximo_solver::{Solver, SolverStatus};
+use oximo_solver::Solver;
 
 fn close(a: f64, b: f64, tol: f64) -> bool {
     (a - b).abs() < tol
@@ -10,9 +10,10 @@ fn close(a: f64, b: f64, tol: f64) -> bool {
 
 fn assert_solved(r: &oximo_solver::SolverResult) {
     assert!(
-        matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible),
-        "status = {:?}",
-        r.status
+        r.has_solution(),
+        "termination = {:?}, primal = {:?}",
+        r.termination,
+        r.primal_status
     );
 }
 
@@ -27,7 +28,7 @@ fn qp_min_sum_of_squares() {
     objective!(m, Min, x.powi(2) + y.powi(2));
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
-    assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
+    assert!(r.has_solution());
     let obj = r.objective().expect("obj");
     assert!(close(obj, 0.5, 1e-4), "obj = {obj}");
 }
@@ -42,7 +43,7 @@ fn nlp_with_sin_objective() {
     objective!(m, Min, (x - 1.0).powi(2) + 0.1 * x.sin().powi(2));
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
-    assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
+    assert!(r.has_solution());
     let primal_x = r.value(VarId(0)).expect("primal");
     assert!(close(primal_x, 1.0, 0.1), "x = {primal_x}");
 }
@@ -74,7 +75,7 @@ fn minlp_binary_with_log() {
     objective!(m, Min, (x - 1.0).powi(2) + b * (1.0 + x).log());
 
     let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
-    assert!(matches!(r.status, SolverStatus::Optimal | SolverStatus::Feasible));
+    assert!(r.has_solution());
     let obj = r.objective().expect("obj");
     assert!(close(obj, 0.0, 1e-3), "obj = {obj}");
 }

--- a/crates/oximo-highs/README.md
+++ b/crates/oximo-highs/README.md
@@ -27,7 +27,7 @@ oximo-solver = "0.3"
 ```rust,no_run
 use oximo_core::prelude::*;
 use oximo_highs::{Highs, HighsOptions};
-use oximo_solver::{Solver, SolverStatus};
+use oximo_solver::{Solver, TerminationStatus};
 
 let m = Model::new("toy");
 variable!(m, x >= 0.0);
@@ -37,7 +37,7 @@ constraint!(m, c2, 3.0 * x - y >= 0.0);
 objective!(m, Max, 3.0 * x + 4.0 * y);
 
 let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-assert_eq!(result.status, SolverStatus::Optimal);
+assert_eq!(result.termination, TerminationStatus::Optimal);
 println!("obj = {}", result.objective().unwrap()); // 34.0
 println!("x   = {}", result.value_of(x).unwrap()); // 6.0
 println!("y   = {}", result.value_of(y).unwrap()); // 4.0
@@ -53,7 +53,7 @@ detected as `QP` and solved by uploading the Hessian `Q` via
 ```rust,no_run
 use oximo_core::prelude::*;
 use oximo_highs::{Highs, HighsOptions};
-use oximo_solver::{Solver, SolverStatus};
+use oximo_solver::{Solver, TerminationStatus};
 
 let m = Model::new("qp");
 variable!(m, -10.0 <= x <= 10.0);
@@ -62,7 +62,7 @@ constraint!(m, c, x + y == 1.0);
 objective!(m, Min, x.powi(2) + y.powi(2)); // min x^2 + y^2
 
 let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-assert_eq!(result.status, SolverStatus::Optimal); // x = y = 0.5, obj = 0.5
+assert_eq!(result.termination, TerminationStatus::Optimal); // x = y = 0.5, obj = 0.5
 ```
 
 > **Convexity.** HiGHS supports only convex QPs.

--- a/crates/oximo-highs/README.md
+++ b/crates/oximo-highs/README.md
@@ -108,11 +108,15 @@ let opts = HighsOptions::default()
 
 ## Result
 
-`SolverResult` fields populated on `Optimal` or `Feasible`:
+`SolverResult` fields, populated whenever a usable point is available (`primal_status` is `FeasiblePoint` or `OptimalPoint`):
 
 - `solutions` - primal points (`Vec<SolutionPoint>`). This backend returns a single point holding the `primal` values keyed by `VarId` and the `objective` (adjusted for any constant term). Access via `result.objective()` / `result.value_of(var)`
 - `dual` - constraint duals, keyed by `ConstraintId`, access via `result.dual_of(c)`.
 - `reduced_costs` - variable reduced costs, keyed by `VarId`
+- `termination` - why the solve stopped (`Optimal`, `Infeasible`, `Unbounded`, `InfeasibleOrUnbounded`, `TimeLimit`, `IterationLimit`, ...), mapped from the HiGHS model status
+- `primal_status` - whether a usable point came back (`NoSolution` / `FeasiblePoint` / `OptimalPoint`), taken from HiGHS's own primal-solution flag, `result.has_solution()` is the shortcut
+- `best_bound` - the MIP dual bound (`mip_dual_bound`), `None` for LP/QP
+- `gap` - relative MIP gap (`mip_gap`), `None` for LP/QP
 - `solve_time` - wall time measured around the HiGHS solve call
 - `iterations` - total solver iterations, summed across HiGHS's per-algorithm counters (`simplex` / `qp` / `ipm` / `pdlp` / `crossover`). HiGHS populates only the counter for the method it ran, so the sum is whichever applies; `0` when the model is solved entirely in presolve
 

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -1,11 +1,11 @@
 use std::time::Instant;
 
-use highs::{HessianFormat, HighsModelStatus, RowProblem, Sense as HighsSense};
+use highs::{HessianFormat, HighsModelStatus, HighsSolutionStatus, RowProblem, Sense as HighsSense};
 use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable};
 use oximo_expr::{
     ExprArena, ExprId, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,
 };
-use oximo_solver::{SolutionPoint, SolverError, SolverResult, SolverStatus};
+use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
 use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
@@ -126,10 +126,11 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
         .map_err(|e| SolverError::Backend(format!("HiGHS solve failed: {e:?}")))?;
     let elapsed = started.elapsed();
 
-    let status = map_status(solved.status());
+    let termination = map_status(solved.status());
+    let has_point = solved.primal_solution_status() == HighsSolutionStatus::Feasible;
     let solution = solved.get_solution();
     let (primal, reduced_costs, dual) = collect_solution(
-        &status,
+        has_point,
         solution.columns(),
         solution.dual_columns(),
         solution.dual_rows(),
@@ -137,18 +138,25 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
     );
 
     let objective_value =
-        if status.has_solution() { Some(solved.objective_value() + obj_constant) } else { None };
+        if has_point { Some(solved.objective_value() + obj_constant) } else { None };
 
-    let solutions = if status.has_solution() {
+    let solutions = if has_point {
         vec![SolutionPoint { primal, objective: objective_value }]
     } else {
         Vec::new()
     };
+    let primal_status = PrimalStatus::infer(&termination, has_point);
+    let raw_gap = solved.mip_gap();
+    let gap = raw_gap.is_finite().then_some(raw_gap);
+    let best_bound = solved.double_info_value(c"mip_dual_bound").ok().filter(|b| b.is_finite());
     Ok(SolverResult {
-        status,
+        termination,
+        primal_status,
         solutions,
         dual,
         reduced_costs,
+        best_bound,
+        gap,
         solve_time: elapsed,
         iterations: total_iterations(&solved),
         raw_log: None,
@@ -223,13 +231,13 @@ fn hessian_columns(quad: &QuadraticTerms, num_vars: usize) -> HessianCols {
 }
 
 fn collect_solution(
-    status: &SolverStatus,
+    has_point: bool,
     cols: &[f64],
     dcols: &[f64],
     drows_full: &[f64],
     num_constraints: usize,
 ) -> (FxHashMap<VarId, f64>, FxHashMap<VarId, f64>, FxHashMap<ConstraintId, f64>) {
-    if !status.has_solution() {
+    if !has_point {
         return (FxHashMap::default(), FxHashMap::default(), FxHashMap::default());
     }
     let drows = &drows_full[..num_constraints.min(drows_full.len())];
@@ -286,28 +294,25 @@ fn total_iterations(solved: &highs::SolvedModel) -> u64 {
     .sum()
 }
 
-fn map_status(s: HighsModelStatus) -> SolverStatus {
+fn map_status(s: HighsModelStatus) -> TerminationStatus {
     match s {
-        // TODO: Improve this mapping
-        HighsModelStatus::Optimal => SolverStatus::Optimal,
-        HighsModelStatus::Infeasible => SolverStatus::Infeasible,
-        HighsModelStatus::UnboundedOrInfeasible | HighsModelStatus::Unbounded => {
-            SolverStatus::Unbounded
-        }
-        HighsModelStatus::ReachedTimeLimit | HighsModelStatus::ReachedIterationLimit => {
-            SolverStatus::TimeLimit
-        }
-        HighsModelStatus::ModelEmpty => SolverStatus::Other("model_empty".into()),
-        HighsModelStatus::NotSet | HighsModelStatus::Unknown => SolverStatus::NotSolved,
+        HighsModelStatus::Optimal => TerminationStatus::Optimal,
+        HighsModelStatus::Infeasible => TerminationStatus::Infeasible,
+        HighsModelStatus::UnboundedOrInfeasible => TerminationStatus::InfeasibleOrUnbounded,
+        HighsModelStatus::Unbounded => TerminationStatus::Unbounded,
+        HighsModelStatus::ReachedTimeLimit => TerminationStatus::TimeLimit,
+        HighsModelStatus::ReachedIterationLimit => TerminationStatus::IterationLimit,
         HighsModelStatus::ObjectiveBound | HighsModelStatus::ObjectiveTarget => {
-            SolverStatus::Feasible
+            TerminationStatus::Interrupted
         }
+        HighsModelStatus::ModelEmpty => TerminationStatus::Other("model_empty".into()),
+        HighsModelStatus::NotSet | HighsModelStatus::Unknown => TerminationStatus::NotSolved,
         HighsModelStatus::LoadError
         | HighsModelStatus::ModelError
         | HighsModelStatus::PresolveError
         | HighsModelStatus::SolveError
-        | HighsModelStatus::PostsolveError => SolverStatus::NumericError,
-        _ => SolverStatus::Other("unknown_highs_status".into()),
+        | HighsModelStatus::PostsolveError => TerminationStatus::NumericError,
+        _ => TerminationStatus::Other("unknown_highs_status".into()),
     }
 }
 
@@ -329,7 +334,7 @@ mod tests {
         assert_eq!(m.kind(), ModelKind::QP);
 
         let res = solve(&m, &HighsOptions::default()).unwrap();
-        assert_eq!(res.status, SolverStatus::Optimal);
+        assert_eq!(res.termination, TerminationStatus::Optimal);
         assert!((res.value_of(x).unwrap() - 0.5).abs() < 1e-6);
         assert!((res.value_of(y).unwrap() - 0.5).abs() < 1e-6);
         assert!((res.objective().unwrap() - 0.5).abs() < 1e-6);
@@ -346,7 +351,7 @@ mod tests {
         objective!(m, Min, 2.0 * x0.powi(2) + x0 * x1 + x1.powi(2) + x0 + x1);
 
         let res = solve(&m, &HighsOptions::default()).unwrap();
-        assert_eq!(res.status, SolverStatus::Optimal);
+        assert_eq!(res.termination, TerminationStatus::Optimal);
         assert!((res.value_of(x0).unwrap() - 0.25).abs() < 1e-6);
         assert!((res.value_of(x1).unwrap() - 0.75).abs() < 1e-6);
         assert!((res.objective().unwrap() - 1.875).abs() < 1e-6);
@@ -361,7 +366,7 @@ mod tests {
         assert_eq!(m.kind(), ModelKind::QP);
 
         let res = solve(&m, &HighsOptions::default()).unwrap();
-        assert_eq!(res.status, SolverStatus::Optimal);
+        assert_eq!(res.termination, TerminationStatus::Optimal);
         assert!((res.value_of(x).unwrap() - 1.0).abs() < 1e-6);
         assert!(res.objective().unwrap().abs() < 1e-6);
     }

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -1,6 +1,8 @@
 use std::time::Instant;
 
-use highs::{HessianFormat, HighsModelStatus, HighsSolutionStatus, RowProblem, Sense as HighsSense};
+use highs::{
+    HessianFormat, HighsModelStatus, HighsSolutionStatus, RowProblem, Sense as HighsSense,
+};
 use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable};
 use oximo_expr::{
     ExprArena, ExprId, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,

--- a/crates/oximo-solver/README.md
+++ b/crates/oximo-solver/README.md
@@ -28,14 +28,18 @@ Each backend defines its own `Options` type. Users get compile-time validation a
 
 ## `SolverResult`
 
-Populated by the backend on `Optimal` or `Feasible`. Sparse maps (`FxHashMap`) mean backends that don't return duals or reduced costs simply leave those fields empty.
+`termination` records why the solve stopped, while `primal_status` records whether a usable
+point came back.
 
 | Field           | Type                           | Description                                       |
 |-----------------|--------------------------------|---------------------------------------------------|
-| `status`        | `SolverStatus`                 | Outcome of the solve                              |
+| `termination`   | `TerminationStatus`            | Why the solve stopped                             |
+| `primal_status` | `PrimalStatus`                 | Whether a usable primal point is available        |
 | `solutions`     | `Vec<SolutionPoint>`           | Primal points, best first (empty if no solution)  |
 | `dual`          | `FxHashMap<ConstraintId, f64>` | Constraint duals at the best point                |
 | `reduced_costs` | `FxHashMap<VarId, f64>`        | Variable reduced costs at the best point          |
+| `best_bound`    | `Option<f64>`                  | Dual/relaxation bound (branch-and-bound backends) |
+| `gap`           | `Option<f64>`                  | Relative optimality gap, when reported            |
 | `solve_time`    | `Duration`                     | Wall time around the solve call                   |
 | `iterations`    | `u64`                          | Simplex iteration count (if reported)             |
 | `raw_log`       | `Option<String>`               | Solver stdout/stderr                              |
@@ -45,15 +49,15 @@ Each `SolutionPoint` holds the `primal` variable values (`FxHashMap<VarId, f64>`
 ### Accessors
 
 ```rust,ignore
-result.objective()           // Option<f64>, best solution's objective
-result.value_of(expr)        // Option<f64>, primal value for a Var expr (best solution)
-result.value(var_id)         // Option<f64>, primal value by VarId (best solution)
-result.dual_of(c_id)         // Option<f64>, dual for a constraint
-result.best()                // Option<&SolutionPoint>, same as .solution(0)
-result.solution(i)           // Option<&SolutionPoint>, i-th pooled point
-result.result_count()        // usize, number of returned points
-result.status.has_solution() // true if Optimal or Feasible
-result.report(&model)        // Display: model-aware summary (status, vars, duals)
+result.objective()    // Option<f64>, best solution's objective
+result.value_of(expr) // Option<f64>, primal value for a Var expr (best solution)
+result.value(var_id)  // Option<f64>, primal value by VarId (best solution)
+result.dual_of(c_id)  // Option<f64>, dual for a constraint
+result.best()         // Option<&SolutionPoint>, same as .solution(0)
+result.solution(i)    // Option<&SolutionPoint>, i-th pooled point
+result.result_count() // usize, number of returned points
+result.has_solution() // true when a usable primal point is available
+result.report(&model) // Display: model-aware summary (status, vars, duals)
 
 // Indexed variables
 result.value_of_idx(&flow, "nyc")                  // Option<f64>, value at a specific index
@@ -61,18 +65,32 @@ result.values_of(&flow)                            // Iterator<(&IndexKey, f64)>
 result.values_of(&flow).filter(|(_, v)| *v != 0.0) // nonzero only (sparse solutions)
 ```
 
-## `SolverStatus`
+## `TerminationStatus`
 
-| Variant         | Meaning                                                          |
-|-----------------|------------------------------------------------------------------|
-| `Optimal`       | Proven optimal                                                   |
-| `Feasible`      | Feasible but not proven optimal (e.g. time limit with incumbent) |
-| `Infeasible`    | No feasible solution exists                                      |
-| `Unbounded`     | Objective is unbounded                                           |
-| `TimeLimit`     | Time limit reached with no feasible solution                     |
-| `NumericError`  | Solver reported numerical difficulties                           |
-| `NotSolved`     | Default, solve not yet called                                    |
-| `Other(String)` | Backend-specific status not covered above                        |
+Why the solve stopped (complementary to whether a point was returned).
+
+| Variant                 | Meaning                                                |
+|-------------------------|--------------------------------------------------------|
+| `Optimal`               | Proven globally optimal                                |
+| `LocallyOptimal`        | A local optimum                                        |
+| `Infeasible`            | No feasible solution exists                            |
+| `Unbounded`             | Objective is unbounded                                 |
+| `InfeasibleOrUnbounded` | Infeasible or unbounded; solver could not tell which   |
+| `IterationLimit`        | Stopped at an iteration limit                          |
+| `TimeLimit`             | Stopped at a time limit                                |
+| `NodeLimit`             | Stopped at a branch-and-bound node limit               |
+| `Interrupted`           | Stopped early (user limit/interrupt, sub-optimal stop) |
+| `NumericError`          | Solver reported numerical difficulties                 |
+| `NotSolved`             | Default, solve not yet called                          |
+| `Other(String)`         | Backend-specific status not covered above              |
+
+## `PrimalStatus`
+
+| Variant         | Meaning                                           |
+|-----------------|---------------------------------------------------|
+| `NoSolution`    | No primal point is available                      |
+| `FeasiblePoint` | A feasible point is available, not proven optimal |
+| `OptimalPoint`  | A proven-optimal point is available               |
 
 ## `SolverError`
 
@@ -98,11 +116,11 @@ let opts = MyBackendOptions::default()
     .verbose(true);
 ```
 
-| Method                  | Field        | Type                |
-|-------------------------|--------------|---------------------|
-| `.time_limit(Duration)` | `time_limit` | `Option<Duration>`  |
-| `.threads(u32)`         | `threads`    | `Option<u32>`       |
-| `.verbose(bool)`        | `verbose`    | `Option<bool>`      |
+| Method                  | Field        | Type               |
+|-------------------------|--------------|--------------------|
+| `.time_limit(Duration)` | `time_limit` | `Option<Duration>` |
+| `.threads(u32)`         | `threads`    | `Option<u32>`      |
+| `.verbose(bool)`        | `verbose`    | `Option<bool>`     |
 
 ### Implementing `HasUniversal` for a new backend
 

--- a/crates/oximo-solver/src/lib.rs
+++ b/crates/oximo-solver/src/lib.rs
@@ -9,4 +9,4 @@ pub mod status;
 pub use options::{HasUniversal, UniversalOptions, UniversalOptionsExt};
 pub use result::{ModelReport, SolutionPoint, SolverResult};
 pub use solver::Solver;
-pub use status::{SolverError, SolverStatus};
+pub use status::{PrimalStatus, SolverError, TerminationStatus};

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -6,7 +6,7 @@ use oximo_core::{
 };
 use rustc_hash::FxHashMap;
 
-use crate::status::SolverStatus;
+use crate::status::{PrimalStatus, TerminationStatus};
 
 /// A single primal point returned by a solver.
 ///
@@ -63,16 +63,22 @@ impl SolutionPoint {
 
 /// A solver's final result on a model.
 ///
-/// Primal points are held in `solutions` (index `0` is the best/incumbent,
-/// empty when no solution was found). `dual` and `reduced_costs` apply to the
-/// best continuous point and are sparse maps, so a solver that does not return
-/// duals (e.g. MILP) can simply leave them empty.
+/// `termination` expresses why the solver stopped and `primal_status` says
+/// whether the point in `solutions` is usable. Primal points are held in
+/// `solutions` (index `0` is the best/incumbent, empty when no solution was
+/// found). `dual` and `reduced_costs` apply to the best continuous point and are
+/// sparse maps, so a solver that does not return duals (e.g. MILP) can simply
+/// leave them empty. `best_bound` and `gap` are populated by branch-and-bound
+/// backends when available.
 #[derive(Clone, Debug)]
 pub struct SolverResult {
-    pub status: SolverStatus,
+    pub termination: TerminationStatus,
+    pub primal_status: PrimalStatus,
     pub solutions: Vec<SolutionPoint>,
     pub dual: FxHashMap<ConstraintId, f64>,
     pub reduced_costs: FxHashMap<VarId, f64>,
+    pub best_bound: Option<f64>,
+    pub gap: Option<f64>,
     pub solve_time: Duration,
     pub iterations: u64,
     pub raw_log: Option<String>,
@@ -82,10 +88,13 @@ pub struct SolverResult {
 impl Default for SolverResult {
     fn default() -> Self {
         Self {
-            status: SolverStatus::NotSolved,
+            termination: TerminationStatus::NotSolved,
+            primal_status: PrimalStatus::NoSolution,
             solutions: Vec::new(),
             dual: FxHashMap::default(),
             reduced_costs: FxHashMap::default(),
+            best_bound: None,
+            gap: None,
             solve_time: Duration::ZERO,
             iterations: 0,
             raw_log: None,
@@ -109,6 +118,13 @@ impl SolverResult {
     /// The best primal point, or `None` when no solution was found.
     pub fn best(&self) -> Option<&SolutionPoint> {
         self.solutions.first()
+    }
+
+    /// Whether a usable primal point is available, regardless of why the solver
+    /// stopped. Driven by [`PrimalStatus`], so an incumbent returned at a time
+    /// or iteration limit still counts.
+    pub fn has_solution(&self) -> bool {
+        self.primal_status.has_solution()
     }
 
     /// The objective value of the best solution, or `None` when none was found.
@@ -200,11 +216,18 @@ impl std::fmt::Display for ModelReport<'_> {
         writeln!(f, "solution summary")?;
         writeln!(f, "  solver     : {}", r.solver_name.as_deref().unwrap_or("(unknown)"))?;
         writeln!(f, "  model      : {}  ({:?}, {sense})", m.name, m.kind())?;
-        writeln!(f, "  status     : {:?}", r.status)?;
+        writeln!(f, "  termination: {:?}", r.termination)?;
+        writeln!(f, "  primal     : {:?}", r.primal_status)?;
         writeln!(f, "  solutions  : {}", r.result_count())?;
         match r.objective() {
             Some(v) => writeln!(f, "  objective  : {}", num(v))?,
             None => writeln!(f, "  objective  : (none)")?,
+        }
+        if let Some(b) = r.best_bound {
+            writeln!(f, "  best bound : {}", num(b))?;
+        }
+        if let Some(g) = r.gap {
+            writeln!(f, "  gap        : {}", num(g))?;
         }
         writeln!(f, "  solve time : {:?}", r.solve_time)?;
         writeln!(f, "  iterations : {}", r.iterations)?;
@@ -266,7 +289,8 @@ mod tests {
         let mut p1 = FxHashMap::default();
         p1.insert(VarId(0), 2.5);
         let r = SolverResult {
-            status: SolverStatus::Optimal,
+            termination: TerminationStatus::Optimal,
+            primal_status: PrimalStatus::OptimalPoint,
             solutions: vec![
                 SolutionPoint { primal: p0, objective: Some(10.0) },
                 SolutionPoint { primal: p1, objective: Some(9.0) },
@@ -294,7 +318,8 @@ mod tests {
         dual.insert(c, 1.0);
 
         let r = SolverResult {
-            status: SolverStatus::Optimal,
+            termination: TerminationStatus::Optimal,
+            primal_status: PrimalStatus::OptimalPoint,
             solutions: vec![SolutionPoint { primal, objective: Some(5.0) }],
             dual,
             solver_name: Some("TestSolver".into()),
@@ -303,7 +328,8 @@ mod tests {
 
         let out = r.report(&m).to_string();
         assert!(out.contains("solver     : TestSolver"), "{out}");
-        assert!(out.contains("status     : Optimal"), "{out}");
+        assert!(out.contains("termination: Optimal"), "{out}");
+        assert!(out.contains("primal     : OptimalPoint"), "{out}");
         assert!(out.contains("objective  : 5"), "{out}");
         assert!(out.contains("(LP, maximize)"), "{out}");
         assert!(out.contains("x = 5"), "{out}");

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -106,3 +106,81 @@ impl std::fmt::Debug for SolverError {
         std::fmt::Display::fmt(self, f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The contract for a single termination: whether it admits a primal point
+    /// ([`TerminationStatus::admits_primal`]) and what [`PrimalStatus::infer`]
+    /// yields when a point is present.
+    fn contract(t: &TerminationStatus) -> (bool, PrimalStatus) {
+        use TerminationStatus as T;
+        match t {
+            T::Optimal => (true, PrimalStatus::OptimalPoint),
+            T::LocallyOptimal | T::IterationLimit | T::TimeLimit | T::NodeLimit | T::Interrupted => {
+                (true, PrimalStatus::FeasiblePoint)
+            }
+            T::Infeasible
+            | T::Unbounded
+            | T::InfeasibleOrUnbounded
+            | T::NumericError
+            | T::NotSolved
+            | T::Other(_) => (false, PrimalStatus::FeasiblePoint),
+        }
+    }
+
+    fn all_terminations() -> Vec<TerminationStatus> {
+        use TerminationStatus as T;
+        vec![
+            T::Optimal,
+            T::LocallyOptimal,
+            T::Infeasible,
+            T::Unbounded,
+            T::InfeasibleOrUnbounded,
+            T::IterationLimit,
+            T::TimeLimit,
+            T::NodeLimit,
+            T::Interrupted,
+            T::NumericError,
+            T::NotSolved,
+            T::Other("backend_specific".into()),
+        ]
+    }
+
+    #[test]
+    fn admits_primal_and_infer_match_contract() {
+        for t in all_terminations() {
+            let (admits, with_point) = contract(&t);
+            assert_eq!(t.admits_primal(), admits, "admits_primal for {t:?}");
+            assert_eq!(PrimalStatus::infer(&t, true), with_point, "infer(.., true) for {t:?}");
+            assert_eq!(
+                PrimalStatus::infer(&t, false),
+                PrimalStatus::NoSolution,
+                "infer(.., false) for {t:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn admits_primal_drives_inference_for_status_driven_backends() {
+        for t in all_terminations() {
+            let has_point = t.admits_primal();
+            let primal = PrimalStatus::infer(&t, has_point);
+            assert_eq!(primal.has_solution(), has_point, "has_solution mirrors admits_primal for {t:?}");
+            let expected = match (has_point, &t) {
+                (false, _) => PrimalStatus::NoSolution,
+                (true, TerminationStatus::Optimal) => PrimalStatus::OptimalPoint,
+                (true, _) => PrimalStatus::FeasiblePoint,
+            };
+            assert_eq!(primal, expected, "inferred primal for {t:?}");
+        }
+    }
+
+    #[test]
+    fn primal_status_has_solution() {
+        assert!(!PrimalStatus::NoSolution.has_solution());
+        assert!(PrimalStatus::FeasiblePoint.has_solution());
+        assert!(PrimalStatus::OptimalPoint.has_solution());
+    }
+}

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -1,20 +1,85 @@
 use thiserror::Error;
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum SolverStatus {
+/// Why a solver stopped, independent of whether a usable point was returned.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TerminationStatus {
+    /// Proven globally optimal.
     Optimal,
-    Feasible,
+    /// A local optimum.
+    LocallyOptimal,
+    /// Proven infeasible.
     Infeasible,
+    /// Proven unbounded.
     Unbounded,
+    /// Infeasible or unbounded, the backend can't differentiate.
+    InfeasibleOrUnbounded,
+    /// Stopped at an iteration limit.
+    IterationLimit,
+    /// Stopped at a time limit.
     TimeLimit,
+    /// Stopped at a branch-and-bound node limit.
+    NodeLimit,
+    /// Stopped by an external interrupt or solver-specific user limit.
+    Interrupted,
+    /// The solver hit a numerical problem (singular basis, presolve error, ...).
     NumericError,
+    /// No solve has been attempted yet.
     NotSolved,
+    /// A backend status with no direct mapping. Carries the raw label.
     Other(String),
 }
 
-impl SolverStatus {
-    pub fn has_solution(&self) -> bool {
-        matches!(self, Self::Optimal | Self::Feasible)
+impl TerminationStatus {
+    /// Whether a solver that stopped for this reason may still return a usable
+    /// primal point. `true` for optimality and for the various limits (which
+    /// keep the best incumbent found so far), `false` for infeasible/unbounded/
+    /// error/unsolved states.
+    pub fn admits_primal(&self) -> bool {
+        matches!(
+            self,
+            Self::Optimal
+                | Self::LocallyOptimal
+                | Self::IterationLimit
+                | Self::TimeLimit
+                | Self::NodeLimit
+                | Self::Interrupted
+        )
+    }
+}
+
+/// The status of the primal point held in a [`SolverResult`].
+///
+/// Decoupled from [`TerminationStatus`] so a result that stopped at a limit can
+/// still carry a usable incumbent.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PrimalStatus {
+    /// No primal point is available.
+    NoSolution,
+    /// A feasible point is available, but not proven optimal.
+    FeasiblePoint,
+    /// A proven-optimal point is available.
+    OptimalPoint,
+}
+
+impl PrimalStatus {
+    /// Classify the primal status from the termination reason and whether a
+    /// point was actually returned. `Optimal` termination with a point yields
+    /// [`PrimalStatus::OptimalPoint`]; any other termination with a point yields
+    /// [`PrimalStatus::FeasiblePoint`]; no point yields
+    /// [`PrimalStatus::NoSolution`].
+    pub fn infer(termination: &TerminationStatus, has_point: bool) -> Self {
+        if !has_point {
+            Self::NoSolution
+        } else if matches!(termination, TerminationStatus::Optimal) {
+            Self::OptimalPoint
+        } else {
+            Self::FeasiblePoint
+        }
+    }
+
+    /// Whether a usable primal point is available.
+    pub fn has_solution(self) -> bool {
+        !matches!(self, Self::NoSolution)
     }
 }
 

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -118,9 +118,11 @@ mod tests {
         use TerminationStatus as T;
         match t {
             T::Optimal => (true, PrimalStatus::OptimalPoint),
-            T::LocallyOptimal | T::IterationLimit | T::TimeLimit | T::NodeLimit | T::Interrupted => {
-                (true, PrimalStatus::FeasiblePoint)
-            }
+            T::LocallyOptimal
+            | T::IterationLimit
+            | T::TimeLimit
+            | T::NodeLimit
+            | T::Interrupted => (true, PrimalStatus::FeasiblePoint),
             T::Infeasible
             | T::Unbounded
             | T::InfeasibleOrUnbounded
@@ -167,7 +169,11 @@ mod tests {
         for t in all_terminations() {
             let has_point = t.admits_primal();
             let primal = PrimalStatus::infer(&t, has_point);
-            assert_eq!(primal.has_solution(), has_point, "has_solution mirrors admits_primal for {t:?}");
+            assert_eq!(
+                primal.has_solution(),
+                has_point,
+                "has_solution mirrors admits_primal for {t:?}"
+            );
             let expected = match (has_point, &t) {
                 (false, _) => PrimalStatus::NoSolution,
                 (true, TerminationStatus::Optimal) => PrimalStatus::OptimalPoint,

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -264,10 +264,12 @@ For a quick, model-aware summary, print `result.report(&m)`. For programmatic ac
 ```rust,ignore
 let result = Highs.solve(&m, &HighsOptions::default())?;
 
-match result.status {
-    SolverStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
-    SolverStatus::Infeasible => println!("infeasible"),
-    SolverStatus::TimeLimit => println!("time limit, best = {:?}", result.objective()),
+match result.termination {
+    TerminationStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
+    TerminationStatus::Infeasible => println!("infeasible"),
+    TerminationStatus::TimeLimit if result.has_solution() => {
+        println!("time limit, best = {:?}", result.objective());
+    }
     _ => {}
 }
 

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -265,7 +265,13 @@ For a quick, model-aware summary, print `result.report(&m)`. For programmatic ac
 let result = Highs.solve(&m, &HighsOptions::default())?;
 
 match result.termination {
-    TerminationStatus::Optimal => println!("optimal: {}", result.objective().unwrap()),
+    TerminationStatus::Optimal => {
+        // `objective()` is `Option` (a model may have no objective), so print it
+        // only when present.
+        if let Some(obj) = result.objective() {
+            println!("optimal: {obj}");
+        }
+    }
     TerminationStatus::Infeasible => println!("infeasible"),
     TerminationStatus::TimeLimit if result.has_solution() => {
         println!("time limit, best = {:?}", result.objective());

--- a/crates/oximo/examples/baron_robot.rs
+++ b/crates/oximo/examples/baron_robot.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         BaronOptions::default().time_limit(Duration::from_secs(120)).num_sol(20).verbose(true);
     let result = Baron::new().solve(&m, &opts)?;
 
-    println!("status = {:?}", result.status);
+    println!("status = {:?}", result.termination);
     println!("solutions found = {}", result.result_count());
 
     // BARON enumerates the distinct solutions of this feasibility system,

--- a/crates/oximo/examples/lot_sizing.rs
+++ b/crates/oximo/examples/lot_sizing.rs
@@ -103,7 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     println!("\nLot-Sizing Result");
-    println!("Status    : {:?}", result.status);
+    println!("Status    : {:?}", result.termination);
     if let Some(obj) = result.objective() {
         println!("Total cost: {obj:.2}");
     }

--- a/crates/oximo/examples/parametric_pricing.rs
+++ b/crates/oximo/examples/parametric_pricing.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         p1.set_param_value(price);
 
         let result = Highs.solve(&m, &HighsOptions::default())?;
-        assert_eq!(result.status, SolverStatus::Optimal);
+        assert_eq!(result.termination, TerminationStatus::Optimal);
 
         let x1v = result.value_of(x1).unwrap_or(0.0);
         let x2v = result.value_of(x2).unwrap_or(0.0);

--- a/crates/oximo/examples/process_selection.rs
+++ b/crates/oximo/examples/process_selection.rs
@@ -71,7 +71,7 @@ mod model {
 
         if let Some(obj) = result.objective() {
             println!("--- {label} ---");
-            println!("status = {:?}", result.status);
+            println!("status = {:?}", result.termination);
             println!("profit = {obj:.4} M$/yr");
 
             println!("units selected:");
@@ -102,7 +102,7 @@ mod model {
             );
         } else {
             println!("--- {label} ---");
-            println!("status = {:?}", result.status);
+            println!("status = {:?}", result.termination);
             println!("no objective value");
         }
 

--- a/crates/oximo/examples/reaction_path.rs
+++ b/crates/oximo/examples/reaction_path.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(feature = "highs", not(feature = "gams")))]
     let result = Highs.solve(&m, &HighsOptions::default().verbose(true))?;
 
-    println!("Status : {:?}", result.status);
+    println!("Status : {:?}", result.termination);
     if let Some(obj) = result.objective() {
         println!(
             "Acetone (y06, ch3coch3): {}",

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -44,8 +44,8 @@ pub mod prelude {
     //! Glob-import target. Brings the modeling and solver surface into scope.
     pub use oximo_core::prelude::*;
     pub use oximo_solver::{
-        HasUniversal, ModelReport, SolutionPoint, Solver, SolverError, SolverResult, SolverStatus,
-        UniversalOptions, UniversalOptionsExt,
+        HasUniversal, ModelReport, PrimalStatus, SolutionPoint, Solver, SolverError, SolverResult,
+        TerminationStatus, UniversalOptions, UniversalOptionsExt,
     };
 
     #[cfg(feature = "highs")]

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -12,7 +12,7 @@ fn lp_canonical() {
     objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
@@ -29,7 +29,7 @@ fn highs_multi_optima_returns_single_best() {
     objective!(m, Max, sum!(x[i] for i in items));
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert_eq!(r.result_count(), 1);
     assert!((r.objective().unwrap() - 2.0).abs() < 1e-6);
     let chosen: f64 = (0..4).filter_map(|i| r.value_of_idx(&x, i)).sum();
@@ -58,7 +58,7 @@ fn param_coefficient_lp_rebinds_without_rebuild() {
     assert_eq!(m.kind(), ModelKind::LP);
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert!((r.objective().unwrap() - 30.0).abs() < 1e-6);
 
     m.set_param(price, 5.0);
@@ -75,7 +75,7 @@ fn param_coefficient_qp_rebinds() {
     assert_eq!(m.kind(), ModelKind::QP);
 
     let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert!((r.value_of(x).unwrap() - 2.0).abs() < 1e-5);
 
     m.set_param(t, 4.0);
@@ -129,7 +129,7 @@ fn knapsack_milp() {
     objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 47.0).abs() < 1e-6);
 }
 
@@ -146,7 +146,7 @@ fn lp_initial_values_do_not_affect_optimum() {
     objective!(m, Max, 3.0 * x + 4.0 * y);
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
@@ -170,7 +170,7 @@ fn milp_warm_start_finds_optimum() {
     objective!(m, Max, sum!(values[i] * x[i] for i in 0..n));
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 47.0).abs() < 1e-6);
 }
 
@@ -181,7 +181,7 @@ fn infeasible_returns_status() {
     constraint!(m, c1, x >= 5.0);
     objective!(m, Min, x);
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Infeasible);
+    assert_eq!(result.termination, TerminationStatus::Infeasible);
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn presolve_off_gives_correct_result() {
     constraint!(m, c3, x - y <= 2.0);
     objective!(m, Max, 3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().presolve(HighsPresolve::Off)).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
@@ -210,7 +210,7 @@ fn ipm_method_gives_correct_result() {
     constraint!(m, c3, x - y <= 2.0);
     objective!(m, Max, 3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().method(HighsMethod::Ipm)).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
@@ -226,7 +226,7 @@ fn threads_one_gives_correct_result() {
     constraint!(m, c3, x - y <= 2.0);
     objective!(m, Max, 3.0 * x + 4.0 * y);
     let result = Highs.solve(&m, &HighsOptions::default().threads(1)).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-6);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-6);
@@ -245,9 +245,10 @@ fn mip_gap_accepted_and_solves() {
     let opts = HighsOptions::default().mip_gap(0.5).verbose(false);
     let result = Highs.solve(&m, &opts).unwrap();
     assert!(
-        matches!(result.status, SolverStatus::Optimal | SolverStatus::Feasible),
-        "unexpected status: {:?}",
-        result.status
+        result.has_solution(),
+        "unexpected status: {:?} / {:?}",
+        result.termination,
+        result.primal_status
     );
     assert!(result.objective().unwrap() > 0.0);
 }
@@ -263,7 +264,7 @@ fn indexed_var_retrieval() {
     objective!(m, Min, flow["a"] + flow["b"]);
 
     let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
 
     assert!((result.value_of_idx(&flow, "a").unwrap() - 3.0).abs() < 1e-6);
     assert!((result.value_of_idx(&flow, "b").unwrap() - 7.0).abs() < 1e-6);

--- a/crates/oximo/tests/solve_baron.rs
+++ b/crates/oximo/tests/solve_baron.rs
@@ -27,7 +27,7 @@ fn baron_enumerates_multiple_solutions() {
 
     let opts = BaronOptions::default().num_sol(10).time_limit(Duration::from_secs(60));
     let r = Baron::new().solve(&m, &opts).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert!(r.result_count() > 1, "expected multiple solutions, got {}", r.result_count());
 
     assert!((r.objective().unwrap() - 2.0).abs() < 1e-4, "best obj={:?}", r.objective());
@@ -49,7 +49,7 @@ fn baron_lp_duals_and_reduced_costs() {
 
     let opts = BaronOptions::default().want_dual(true).time_limit(Duration::from_secs(30));
     let result = Baron::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 5.0).abs() < 1e-6);
     assert!((result.value_of(x).unwrap() - 5.0).abs() < 1e-6);
 
@@ -75,7 +75,7 @@ fn baron_milp_duals_at_best_point() {
 
     let opts = BaronOptions::default().want_dual(true).time_limit(Duration::from_secs(30));
     let result = Baron::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 3.0).abs() < 1e-6);
     assert!(result.dual_of(cap).is_some(), "dual missing for cap");
     assert!(!result.reduced_costs.is_empty(), "reduced costs missing");

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -30,7 +30,7 @@ fn gams_lp_canonical() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective());
     assert!((result.value_of(x).unwrap() - 6.0).abs() < 1e-4);
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-4);
@@ -47,7 +47,7 @@ fn gams_lp_duals_and_reduced_costs() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 5.0).abs() < 1e-6);
 
     let d = result.dual_of(c).expect("dual missing for cap constraint");
@@ -71,9 +71,10 @@ fn gams_nlp_duals_at_local_point() {
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert!(
-        matches!(result.status, SolverStatus::Optimal | SolverStatus::Feasible),
-        "status={:?}",
-        result.status
+        result.has_solution(),
+        "termination={:?}, primal={:?}",
+        result.termination,
+        result.primal_status
     );
     assert!((result.objective().unwrap() - std::f64::consts::E).abs() < 1e-5);
     assert!((result.value_of(x).unwrap() - 1.0).abs() < 1e-5);
@@ -99,7 +100,7 @@ fn gams_mip_duals_at_fixed_point() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 3.0).abs() < 1e-6);
     assert!(result.dual_of(cap).is_some(), "dual missing for cap");
     assert!(!result.reduced_costs.is_empty(), "reduced costs missing");
@@ -118,7 +119,7 @@ fn gams_knapsack_milp() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 47.0).abs() < 1e-4, "obj={:?}", result.objective());
 }
 
@@ -137,7 +138,7 @@ fn gams_semicontinuous_respects_threshold_gap() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 10.0).abs() < 1e-4, "obj={:?}", result.objective());
     assert!((result.value_of(s).unwrap() - 5.0).abs() < 1e-4, "s={:?}", result.value_of(s));
     assert!((result.value_of(t).unwrap() - 5.0).abs() < 1e-4, "t={:?}", result.value_of(t));
@@ -152,7 +153,7 @@ fn gams_infeasible_returns_status() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Infeasible);
+    assert_eq!(result.termination, TerminationStatus::Infeasible);
 }
 
 #[test]
@@ -167,9 +168,10 @@ fn gams_mip_gap_option() {
 
     let result = Gams::new().solve(&m, &GamsOptions::default().mip_gap(0.5)).unwrap();
     assert!(
-        matches!(result.status, SolverStatus::Optimal | SolverStatus::Feasible),
-        "unexpected status: {:?}",
-        result.status
+        result.has_solution(),
+        "unexpected status: {:?} / {:?}",
+        result.termination,
+        result.primal_status
     );
     assert!(result.objective().unwrap() > 0.0);
 }
@@ -193,7 +195,7 @@ fn gams_highs_opt_file_simplex() {
         ..Default::default()
     }));
     let result = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 34.0).abs() < 1e-4, "obj={:?}", result.objective());
 }
 
@@ -209,7 +211,7 @@ fn gams_multi_optima_returns_single_best() {
 
     let opts = GamsOptions::default().time_limit(Duration::from_secs(60));
     let r = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert_eq!(r.result_count(), 1);
     assert!((r.objective().unwrap() - 2.0).abs() < 1e-4);
     let chosen: f64 = (0..4).filter_map(|i| r.value_of_idx(&x, i)).sum();
@@ -238,7 +240,7 @@ fn gams_reads_cplex_solution_pool() {
     });
     let opts = GamsOptions::default().solver(cfg).time_limit(Duration::from_secs(60));
     let r = Gams::new().solve(&m, &opts).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert!(r.result_count() > 1, "expected a solution pool, got {}", r.result_count());
 
     assert!((r.objective().unwrap() - 2.0).abs() < 1e-4);

--- a/crates/oximo/tests/solve_gurobi.rs
+++ b/crates/oximo/tests/solve_gurobi.rs
@@ -22,7 +22,7 @@ fn gurobi_multi_optima_returns_pool() {
 
     let opts = GurobiOptions::default().pool_search_mode(2).pool_solutions(10);
     let r = Gurobi.solve(&m, &opts).unwrap();
-    assert_eq!(r.status, SolverStatus::Optimal);
+    assert_eq!(r.termination, TerminationStatus::Optimal);
     assert!(r.result_count() > 1, "expected a solution pool, got {}", r.result_count());
 
     assert!((r.objective().unwrap() - 2.0).abs() < 1e-6);
@@ -48,7 +48,7 @@ fn gurobi_qp_duals_linear_constraint() {
     objective!(m, Min, x * x + y * y);
 
     let result = Gurobi.solve(&m, &GurobiOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 2.0).abs() < 1e-5);
     assert!((result.value_of(x).unwrap() - 1.0).abs() < 1e-5);
 
@@ -72,7 +72,7 @@ fn gurobi_qcp_duals_quadratic_constraint() {
 
     let opts = GurobiOptions::default().qcp_dual(1);
     let result = Gurobi.solve(&m, &opts).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() + 2.0).abs() < 1e-5);
     assert!((result.value_of(x).unwrap() + 1.0).abs() < 1e-5);
 
@@ -94,7 +94,7 @@ fn gurobi_semicontinuous_respects_threshold_gap() {
     objective!(m, Min, s + t);
 
     let result = Gurobi.solve(&m, &GurobiOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 10.0).abs() < 1e-5, "obj={:?}", result.objective());
     assert!((result.value_of(s).unwrap() - 5.0).abs() < 1e-5, "s={:?}", result.value_of(s));
     assert!((result.value_of(t).unwrap() - 5.0).abs() < 1e-5, "t={:?}", result.value_of(t));
@@ -111,7 +111,7 @@ fn gurobi_qcp_duals_skipped_by_default() {
     objective!(m, Min, x + y);
 
     let result = Gurobi.solve(&m, &GurobiOptions::default()).unwrap();
-    assert_eq!(result.status, SolverStatus::Optimal);
+    assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() + 2.0).abs() < 1e-5);
     assert!(result.dual.is_empty(), "QCP duals must be empty without .qcp_dual(1)");
 }


### PR DESCRIPTION
## Description

This PR replaces the `SolverStatus` with two enums: `TerminationStatus` (why the solver stopped) and `PrimalStatus` (whether a usable point came back).

This is a breaking change.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solver results now expose separate `termination` (why the solve stopped) and `primal_status` (usable solution availability), plus `has_solution()`.
  * Added `best_bound` and `gap` when finite bounds are available.
* **Bug Fixes**
  * Improved termination/primal inference across solvers, including more reliable time-limit reporting (best objective only when a usable solution exists).
  * Refined backend outcome mappings (e.g., Gurobi/GAMS/BARON parsing and categorization).
* **Documentation**
  * Updated READMEs and examples to use `termination` / `primal_status` instead of the prior status field.
* **Tests**
  * Updated unit and integration tests to validate the new semantics and mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->