### PR TITLE
oximo-macros: Share index-family masking helpers

### DIFF
--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -198,6 +198,24 @@ param!(m, rate = 0.05);     // binds a re-bindable `rate: Expr<'_>`
 rate.set_param_value(0.07); // change between solves without rebuilding
 ```
 
+### Indexed parameters
+
+Mirror indexed variables: one re-bindable scalar parameter per key, bound as an
+`IndexedParam`. The right-hand side is evaluated per key and may reference the
+index.
+
+```rust,ignore
+let items = Set::range(0..3);
+param!(m, cost[i in items] = base_cost[i]); // one parameter per key
+param!(m, w[(i, j) in rc] = weight(i, j));  // multi-index
+param!(m, c[p in plants] = price[p]);       // string-keyed (sparse)
+
+let unit = cost[1];             // index for a param `Expr`
+cost[1].set_param_value(9.0);   // re-bind one entry via its handle
+m.set_param_idx(&cost, 1, 9.0); // ...or by key on the model
+m.param_value_idx(&cost, 1);    // -> Some(9.0)
+```
+
 ## Model kind
 
 Inferred automatically from variables and expressions, cached and invalidated on change:

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 
 use crate::set::{Axis, FromIndexKey, IndexKey};
 
-/// Backing storage for an [`IndexedVar`].
+/// Backing storage for an [`IndexedFamily`].
 ///
 /// `Dense` is used when the domain is a contiguous integer grid (a range, or a
 /// product of ranges). `Sparse` (string sets, sparse `from_ints`, or any
@@ -17,37 +17,77 @@ pub(crate) enum Storage<'a> {
     Sparse(FxHashMap<IndexKey, Expr<'a>>),
 }
 
-/// Indexed variable: maps an `IndexKey` to a single-variable `Expr`, tagged with
-/// the key type `K` its domain decodes to.
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker selecting which kind of indexed family an [`IndexedFamily`] is.
 ///
-/// Constructed by the indexed form of the `variable!` macro. `K` is
-/// a phantom marker, carried so the type of an indexed family is visible and
-/// typed iteration via [`Self::keys`] is possible.
+/// Sealed implementation detail: implemented only for [`VarFamily`] and
+/// [`ParamFamily`]. It exists so [`IndexedVar`] and [`IndexedParam`] are distinct
+/// types (only a parameter family can be re-bound) while sharing one
+/// implementation.
+#[doc(hidden)]
+pub trait Family: sealed::Sealed {
+    /// Type name used in [`Debug`](std::fmt::Debug) output.
+    const NAME: &'static str;
+}
+
+/// Marker for an indexed family of decision variables ([`IndexedVar`]).
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct VarFamily;
+
+/// Marker for an indexed family of parameters ([`IndexedParam`]).
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct ParamFamily;
+
+impl sealed::Sealed for VarFamily {}
+impl sealed::Sealed for ParamFamily {}
+impl Family for VarFamily {
+    const NAME: &'static str = "IndexedVar";
+}
+impl Family for ParamFamily {
+    const NAME: &'static str = "IndexedParam";
+}
+
+/// Indexed family: maps an `IndexKey` to a single-element `Expr` (a variable or a
+/// parameter), tagged with the key type `K` its domain decodes to and the family
+/// kind `F`.
+///
+/// You normally name this through the [`IndexedVar`]/[`IndexedParam`] aliases,
+/// constructed by the indexed form of the `variable!`/`param!` macros.
 ///
 /// When the domain is a contiguous integer range (or a Cartesian product of
 /// ranges) the family is stored densely (see [`Storage`]).
 /// String, sparse, and `filter`ed families fall back to a hash map.
-pub struct IndexedVar<'a, K = IndexKey> {
+pub struct IndexedFamily<'a, K = IndexKey, F = VarFamily> {
     pub(crate) storage: Storage<'a>,
-    pub(crate) _k: PhantomData<fn() -> K>,
+    pub(crate) _marker: PhantomData<fn() -> (K, F)>,
 }
 
-impl<'a, K> Clone for IndexedVar<'a, K> {
+/// Indexed family of decision variables; see [`IndexedFamily`].
+pub type IndexedVar<'a, K = IndexKey> = IndexedFamily<'a, K, VarFamily>;
+
+/// Indexed family of re-bindable parameters; see [`IndexedFamily`].
+///
+/// Re-bind a single entry with [`Model::set_param_idx`](crate::Model::set_param_idx).
+pub type IndexedParam<'a, K = IndexKey> = IndexedFamily<'a, K, ParamFamily>;
+
+impl<'a, K, F> Clone for IndexedFamily<'a, K, F> {
     fn clone(&self) -> Self {
-        Self { storage: self.storage.clone(), _k: PhantomData }
+        Self { storage: self.storage.clone(), _marker: PhantomData }
     }
 }
 
-impl<'a, K> std::fmt::Debug for IndexedVar<'a, K> {
+impl<'a, K, F: Family> std::fmt::Debug for IndexedFamily<'a, K, F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IndexedVar")
-            .field("len", &self.len())
-            .field("dense", &self.is_dense())
-            .finish()
+        f.debug_struct(F::NAME).field("len", &self.len()).field("dense", &self.is_dense()).finish()
     }
 }
 
-impl<'a, K> IndexedVar<'a, K> {
+impl<'a, K, F> IndexedFamily<'a, K, F> {
     pub fn len(&self) -> usize {
         match &self.storage {
             Storage::Dense { data, .. } => data.len(),
@@ -97,7 +137,7 @@ impl<'a, K> IndexedVar<'a, K> {
     /// # Panics
     /// Panics if the coordinates are out of range/not present.
     pub fn at<const N: usize>(&self, coords: [usize; N]) -> Expr<'a> {
-        *self.get_ref(&coords).expect("IndexedVar: coordinates not present")
+        *self.get_ref(&coords).expect("indexed family: coordinates not present")
     }
 
     /// Fallible form of [`Self::at`].
@@ -115,43 +155,73 @@ impl<'a, K> IndexedVar<'a, K> {
     }
 }
 
-impl<'a, K: FromIndexKey> IndexedVar<'a, K> {
+impl<'a, K: FromIndexKey, F> IndexedFamily<'a, K, F> {
     /// Iterate the family's entries with each key decoded to the typed `K`.
     pub fn keys(&self) -> impl Iterator<Item = (K, Expr<'a>)> + '_ {
         self.iter().map(|(k, e)| (K::from_index_key(k), *e))
     }
 }
 
-impl<'a, K, Q: Into<IndexKey>> Index<Q> for IndexedVar<'a, K> {
+impl<'a, K, F, Q: Into<IndexKey>> Index<Q> for IndexedFamily<'a, K, F> {
     type Output = Expr<'a>;
     fn index(&self, key: Q) -> &Self::Output {
         match &self.storage {
-            Storage::Sparse(m) => m.get(&key.into()).expect("IndexedVar: key not present"),
+            Storage::Sparse(m) => m.get(&key.into()).expect("indexed family: key not present"),
             Storage::Dense { data, axes, .. } => {
-                let off = grid_offset(axes, &key.into()).expect("IndexedVar: key not present");
+                let off = grid_offset(axes, &key.into()).expect("indexed family: key not present");
                 &data[off]
             }
         }
     }
 }
 
-impl<'a, K> Index<&IndexKey> for IndexedVar<'a, K> {
+impl<'a, K, F> Index<&IndexKey> for IndexedFamily<'a, K, F> {
     type Output = Expr<'a>;
     fn index(&self, key: &IndexKey) -> &Self::Output {
         match &self.storage {
-            Storage::Sparse(m) => m.get(key).expect("IndexedVar: key not present"),
+            Storage::Sparse(m) => m.get(key).expect("indexed family: key not present"),
             Storage::Dense { data, axes, .. } => {
-                let off = grid_offset(axes, key).expect("IndexedVar: key not present");
+                let off = grid_offset(axes, key).expect("indexed family: key not present");
                 &data[off]
             }
         }
     }
 }
 
-impl<'a, K, const N: usize> Index<[usize; N]> for IndexedVar<'a, K> {
+impl<'a, K, F, const N: usize> Index<[usize; N]> for IndexedFamily<'a, K, F> {
     type Output = Expr<'a>;
     fn index(&self, coords: [usize; N]) -> &Self::Output {
-        self.get_ref(&coords).expect("IndexedVar: coordinates not present")
+        self.get_ref(&coords).expect("indexed family: coordinates not present")
+    }
+}
+
+/// Build [`Storage`] from a family's keys and optional dense axes, registering
+/// each element through `make`.
+pub(crate) fn build_storage<'a>(
+    keys: Vec<IndexKey>,
+    axes: Option<Box<[Axis]>>,
+    mut make: impl FnMut(&IndexKey) -> Expr<'a>,
+) -> Storage<'a> {
+    if let Some(axes) = axes {
+        let total = keys.len();
+        let mut data: Vec<Option<Expr<'a>>> = vec![None; total];
+        let mut kept: Vec<Option<IndexKey>> = vec![None; total];
+        for key in keys {
+            let expr = make(&key);
+            let off = grid_offset(&axes, &key).expect("dense grid key out of range");
+            data[off] = Some(expr);
+            kept[off] = Some(key);
+        }
+        let data = data.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
+        let kept = kept.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
+        Storage::Dense { data, keys: kept, axes }
+    } else {
+        let mut entries = FxHashMap::default();
+        for key in keys {
+            let expr = make(&key);
+            entries.insert(key, expr);
+        }
+        Storage::Sparse(entries)
     }
 }
 
@@ -191,7 +261,7 @@ fn grid_offset_coords(axes: &[Axis], coords: &[usize]) -> Option<usize> {
 }
 
 /// Build the `IndexKey` a coordinate array would hash to (sparse fallback for
-/// [`IndexedVar::get_ref`]).
+/// [`IndexedFamily::get_ref`]).
 fn coords_to_key(coords: &[usize]) -> IndexKey {
     if let [single] = coords {
         IndexKey::from(*single)

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod var;
 pub use constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
 pub use domain::Domain;
 pub use error::{Error, Result};
-pub use indexed::IndexedVar;
+pub use indexed::{IndexedParam, IndexedVar};
 pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -276,7 +276,8 @@ impl Model {
     ///
     /// # Panics
     ///
-    /// Panics if `key` is not present in the family.
+    /// Panics if `key` is not present in the family, or if `params` was built on
+    /// a different `Model`.
     pub fn set_param_idx<K, Q: Into<IndexKey>>(
         &self,
         params: &IndexedParam<'_, K>,
@@ -284,6 +285,10 @@ impl Model {
         value: f64,
     ) {
         let e = params.get(key).expect("set_param_idx: key not present in indexed parameter");
+        assert!(
+            std::ptr::eq(e.arena, std::ptr::from_ref(&self.arena)),
+            "set_param_idx: indexed parameter belongs to a different model"
+        );
         let id = e.param_id().expect("indexed parameter entry is not a parameter handle");
         self.set_param_id(id, value);
     }
@@ -768,6 +773,16 @@ mod tests {
         assert!((coeff(&m) - 99.0).abs() < f64::EPSILON);
         assert!((m.param_value_idx(&cost, 1usize).unwrap() - 99.0).abs() < f64::EPSILON);
         assert!((m.param_value_idx(&cost, 0usize).unwrap() - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    #[should_panic(expected = "different model")]
+    fn set_param_idx_rejects_foreign_family() {
+        let a = Model::new("a");
+        let b = Model::new("b");
+        let items = Set::range(0..2);
+        let pa = a.__indexed_param("p", &items, |_i: usize| 1.0);
+        b.set_param_idx(&pa, 0usize, 5.0);
     }
 
     #[test]

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -8,7 +8,7 @@ use smol_str::SmolStr;
 use crate::constraint::{Constraint, ConstraintExpr, ConstraintId};
 use crate::domain::Domain;
 use crate::error::{Error, Result};
-use crate::indexed::{IndexedVar, Storage, grid_offset};
+use crate::indexed::{IndexedFamily, IndexedParam, IndexedVar, build_storage};
 use crate::objective::{Objective, ObjectiveSense};
 use crate::param::Parameter;
 use crate::set::{Axis, FromIndexKey, IndexKey, Set};
@@ -214,7 +214,17 @@ impl Model {
     /// Panics if a parameter with the same name is already registered.
     #[doc(hidden)]
     pub fn __param<'a>(&'a self, name: impl Into<SmolStr>, value: f64) -> Expr<'a> {
-        let name = name.into();
+        self.register_param(name.into(), value)
+    }
+
+    /// Register one scalar parameter named `name` initialized to `value` and
+    /// return its `Expr` handle. Shared by [`Self::__param`] and the indexed
+    /// builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a parameter with the same name is already registered.
+    fn register_param(&self, name: SmolStr, value: f64) -> Expr<'_> {
         assert!(
             !self.param_names.borrow().contains_key(&name),
             "parameter name {name:?} already registered"
@@ -228,6 +238,64 @@ impl Model {
         self.param_names.borrow_mut().insert(name, id);
         self.cached_kind.set(None);
         Expr::new(node, &self.arena)
+    }
+
+    /// Macro-facing entry point backing the indexed form of the `param!` macro
+    /// (`param!(m, cost[i in items] = data[i])`). Registers one scalar parameter
+    /// per key, evaluating `value` on the typed key, and returns an
+    /// [`IndexedParam`]. Not part of the stable public API.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a per-key parameter name collides with one already registered.
+    #[doc(hidden)]
+    pub fn __indexed_param<'a, K, F>(
+        &'a self,
+        name: impl Into<String>,
+        set: &Set<K>,
+        mut value: F,
+    ) -> IndexedParam<'a, K>
+    where
+        K: FromIndexKey,
+        F: FnMut(K) -> f64,
+    {
+        let base = name.into();
+        let axes = set.axes().map(Box::from);
+        let keys: Vec<IndexKey> = set.iter().collect();
+        let make = |key: &IndexKey| -> Expr<'a> {
+            let pname: SmolStr = format_index_name(&base, key).into();
+            let v = value(K::from_index_key(key));
+            self.register_param(pname, v)
+        };
+        let storage = build_storage(keys, axes, make);
+        IndexedFamily { storage, _marker: PhantomData }
+    }
+
+    /// Re-bind the parameter at `key` of an indexed family to `value`. Takes
+    /// effect on the next solve.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key` is not present in the family.
+    pub fn set_param_idx<K, Q: Into<IndexKey>>(
+        &self,
+        params: &IndexedParam<'_, K>,
+        key: Q,
+        value: f64,
+    ) {
+        let e = params.get(key).expect("set_param_idx: key not present in indexed parameter");
+        let id = e.param_id().expect("indexed parameter entry is not a parameter handle");
+        self.set_param_id(id, value);
+    }
+
+    /// Current value bound to the parameter at `key` of an indexed family, or
+    /// `None` if the key is absent.
+    pub fn param_value_idx<K, Q: Into<IndexKey>>(
+        &self,
+        params: &IndexedParam<'_, K>,
+        key: Q,
+    ) -> Option<f64> {
+        params.get(key).and_then(|e| self.param_value_of(e))
     }
 
     /// Re-bind the parameter referenced by handle `p` to `value`.
@@ -567,31 +635,8 @@ impl<'a, K> IndexedVarBuilder<'a, K> {
             model.__var(scalar_name).lb(lo).ub(hi).domain(domain).build()
         };
 
-        let storage = if let Some(axes) = axes {
-            // Dense grid: place each scalar at its computed row-major offset,
-            // so the storage cannot be silently mis-built if `Set` iteration
-            // vever changes.
-            let total = keys.len();
-            let mut data: Vec<Option<Expr<'a>>> = vec![None; total];
-            let mut kept: Vec<Option<IndexKey>> = vec![None; total];
-            for key in keys {
-                let expr = make(&key);
-                let off = grid_offset(&axes, &key).expect("dense grid key out of range");
-                data[off] = Some(expr);
-                kept[off] = Some(key);
-            }
-            let data = data.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
-            let kept = kept.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
-            Storage::Dense { data, keys: kept, axes }
-        } else {
-            let mut entries = FxHashMap::default();
-            for key in keys {
-                let expr = make(&key);
-                entries.insert(key, expr);
-            }
-            Storage::Sparse(entries)
-        };
-        IndexedVar { storage, _k: PhantomData }
+        let storage = build_storage(keys, axes, make);
+        IndexedFamily { storage, _marker: PhantomData }
     }
 }
 
@@ -633,6 +678,7 @@ mod tests {
     use oximo_expr::extract_linear;
 
     use super::*;
+    use crate::Set;
     use crate::constraint::Relate;
 
     #[test]
@@ -694,5 +740,46 @@ mod tests {
         let m = Model::new("p");
         let _a = m.__param("dup", 1.0);
         let _b = m.__param("dup", 2.0);
+    }
+
+    #[test]
+    fn indexed_param_dense_value_and_per_key_rebind() {
+        let m = Model::new("ip");
+        let items = Set::range(0..3);
+        let data = [10.0, 20.0, 30.0];
+        let cost = m.__indexed_param("cost", &items, |i: usize| data[i]);
+
+        assert!(cost.is_dense());
+        assert_eq!(cost.len(), 3);
+        assert_eq!(m.num_parameters(), 3);
+        assert!(m.parameter_id("cost[0]").is_some());
+        assert!(m.parameter_id("cost[2]").is_some());
+        assert!((m.param_value_idx(&cost, 1usize).unwrap() - 20.0).abs() < f64::EPSILON);
+
+        let x = m.__var("x").lb(0.0).build();
+        let obj = cost.at([1]) * x;
+        let coeff = |m: &Model| {
+            let arena = m.arena();
+            extract_linear(&arena, obj.id).expect("linear").coeffs[0].1
+        };
+        assert!((coeff(&m) - 20.0).abs() < f64::EPSILON);
+
+        m.set_param_idx(&cost, 1usize, 99.0);
+        assert!((coeff(&m) - 99.0).abs() < f64::EPSILON);
+        assert!((m.param_value_idx(&cost, 1usize).unwrap() - 99.0).abs() < f64::EPSILON);
+        assert!((m.param_value_idx(&cost, 0usize).unwrap() - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn indexed_param_sparse_string_keyed() {
+        let m = Model::new("ips");
+        let plants = Set::strings(["a", "b"]);
+        let price =
+            m.__indexed_param("price", &plants, |p: String| if p == "a" { 1.5 } else { 2.5 });
+        assert!(!price.is_dense());
+        assert_eq!(price.len(), 2);
+        assert!((m.param_value_idx(&price, "a").unwrap() - 1.5).abs() < f64::EPSILON);
+        assert!((m.param_value_idx(&price, "b").unwrap() - 2.5).abs() < f64::EPSILON);
+        assert!(m.param_value_idx(&price, "z").is_none());
     }
 }

--- a/crates/oximo-core/src/param.rs
+++ b/crates/oximo-core/src/param.rs
@@ -9,12 +9,13 @@ use smol_str::SmolStr;
 /// keep two copies in sync. Read it with [`Model::param_value`] /
 /// [`Model::param_value_of`].
 ///
-/// For now, we support scalar parameters only.
-///
-/// TODO: Add support for more parameters
+/// An indexed family of parameters (one `Parameter` per key) is built by the
+/// indexed form of the `param!` macro and surfaced as an
+/// [`IndexedParam`](crate::IndexedParam).
 ///
 /// [`Model::param_value`]: crate::Model::param_value
 /// [`Model::param_value_of`]: crate::Model::param_value_of
+/// [`Model::set_param_idx`]: crate::Model::set_param_idx
 #[derive(Clone, Debug)]
 pub struct Parameter {
     pub id: ParamId,

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
 pub use crate::domain::Domain;
 pub use crate::error::Error;
-pub use crate::indexed::IndexedVar;
+pub use crate::indexed::{IndexedParam, IndexedVar};
 pub use crate::model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;

--- a/crates/oximo-core/tests/indexed_param.rs
+++ b/crates/oximo-core/tests/indexed_param.rs
@@ -1,0 +1,78 @@
+//! Indexed parameters built with `param!(m, name[i in dom[, ...]][ if cond] = value)`.
+
+#![allow(clippy::float_cmp)]
+
+use oximo_core::prelude::*;
+
+#[test]
+fn dense_indexed_param_used_in_model() {
+    let m = Model::new("ip");
+    let items = Set::range(0..3);
+    let cap = [10.0, 20.0, 30.0];
+    param!(m, c[i in items] = cap[i]);
+    variable!(m, x[i in 0..3] >= 0.0);
+
+    assert!(c.is_dense());
+    assert_eq!(c.len(), 3);
+    assert_eq!(m.num_parameters(), 3);
+
+    constraint!(m, lim[i in 0..3], c[i] * x[i] <= 100.0);
+    objective!(m, Max, sum!(c[i] * x[i] for i in 0..3));
+    assert_eq!(m.kind(), ModelKind::LP);
+    assert_eq!(m.num_constraints(), 3);
+
+    assert!((m.param_value_idx(&c, 2usize).unwrap() - 30.0).abs() < f64::EPSILON);
+    m.set_param_idx(&c, 2usize, 5.0);
+    assert!((m.param_value_idx(&c, 2usize).unwrap() - 5.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn multi_index_param_is_dense() {
+    let m = Model::new("ipm");
+    let w = [[1.0, 2.0], [3.0, 4.0]];
+    param!(m, weight[i in 0..2, j in 0..2] = w[i][j]);
+    assert!(weight.is_dense());
+    assert_eq!(weight.shape().as_deref(), Some(&[2usize, 2][..]));
+    assert_eq!(weight.len(), 4);
+    assert!((m.param_value_idx(&weight, (1usize, 1usize)).unwrap() - 4.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn string_keyed_indexed_param_is_sparse() {
+    let m = Model::new("ips");
+    let plants = Set::strings(["a", "b", "c"]);
+    let prices = [1.0, 2.0, 3.0];
+    param!(m, cost[p: String in plants] = price_for(&p, &prices));
+    assert!(!cost.is_dense());
+    assert_eq!(cost.shape(), None);
+    assert_eq!(cost.len(), 3);
+    assert!((m.param_value_idx(&cost, "b").unwrap() - 2.0).abs() < f64::EPSILON);
+    assert!(m.param_value_idx(&cost, "z").is_none());
+}
+
+#[test]
+fn constant_indexed_param_does_not_reference_index() {
+    let m = Model::new("ipc");
+    param!(m, k[i in 0..3] = 7.0);
+    assert_eq!(k.len(), 3);
+    assert!((m.param_value_idx(&k, 0usize).unwrap() - 7.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn filtered_indexed_param_is_sparse() {
+    let m = Model::new("ipf");
+    let v = [0.0, 1.0, 2.0, 3.0, 4.0];
+    param!(m, even[i in 0..5 if i % 2 == 0] = v[i]);
+    assert!(!even.is_dense());
+    assert_eq!(even.len(), 3);
+    assert!(m.param_value_idx(&even, 1usize).is_none());
+    assert!((m.param_value_idx(&even, 4usize).unwrap() - 4.0).abs() < f64::EPSILON);
+}
+
+fn price_for(p: &str, prices: &[f64; 3]) -> f64 {
+    match p {
+        "a" => prices[0],
+        "b" => prices[1],
+        _ => prices[2],
+    }
+}

--- a/crates/oximo-macros/src/bind.rs
+++ b/crates/oximo-macros/src/bind.rs
@@ -1,7 +1,7 @@
 //! Parsing for index bindings (`pat in domain`, optionally `pat: ty in domain`)
 //! shared by `variable!`, `constraint!`, and `sum!`.
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{Expr, Pat, Token, Type};
@@ -111,6 +111,55 @@ pub(crate) fn filtered_set(
             quote!( #root::__macro_support::filter_keys(&(#set), |#param| #cond) )
         }
     }
+}
+
+/// Closure parameter for a per-key expression (a `.lb_by`/`.ub_by` bound or an
+/// indexed `param!` value): each index the expression does not reference is
+/// replaced with `_`, so the generated closure never has an unused parameter.
+/// The family's key type pins the parameter, so it is left bare for inference
+/// unless the user annotated every binding.
+pub(crate) fn masked_closure_param(binds: &[IndexBind], expr: &TokenStream2) -> TokenStream2 {
+    let masked = binds.iter().map(|b| mask_pat(&b.pat, expr));
+    let pattern = if binds.len() == 1 {
+        let p = mask_pat(&binds[0].pat, expr);
+        quote!(#p)
+    } else {
+        quote!( (#(#masked),*) )
+    };
+
+    let tys: Option<Vec<&Type>> = binds.iter().map(|b| b.ty.as_ref()).collect();
+    match tys {
+        Some(tys) if binds.len() == 1 => {
+            let ty = tys[0];
+            quote!(#pattern: #ty)
+        }
+        Some(tys) => quote!( #pattern: (#(#tys),*) ),
+        None => pattern,
+    }
+}
+
+/// Replace each bare-ident sub-pattern that `expr` does not reference with `_`,
+/// recursing into tuple patterns.
+fn mask_pat(pat: &Pat, expr: &TokenStream2) -> TokenStream2 {
+    match pat {
+        Pat::Tuple(t) => {
+            let elems = t.elems.iter().map(|e| mask_pat(e, expr));
+            quote!( (#(#elems),*) )
+        }
+        Pat::Ident(pi) if pi.subpat.is_none() && pi.by_ref.is_none() => {
+            if references_any(expr, &[pi.ident.to_string()]) { quote!(#pat) } else { quote!(_) }
+        }
+        _ => quote!(#pat),
+    }
+}
+
+/// Whether a token stream references any of the given identifiers.
+pub(crate) fn references_any(ts: &TokenStream2, idents: &[String]) -> bool {
+    ts.clone().into_iter().any(|tt| match tt {
+        TokenTree::Ident(id) => idents.contains(&id.to_string()),
+        TokenTree::Group(g) => references_any(&g.stream(), idents),
+        _ => false,
+    })
 }
 
 /// Build the closure parameter for an index family decoded as a whole key.

--- a/crates/oximo-macros/src/param.rs
+++ b/crates/oximo-macros/src/param.rs
@@ -1,29 +1,67 @@
-//! `param!(model, name = value)`.
+//! `param!(model, name = value)` and its indexed form
+//! `param!(model, name[i in dom[, ...]][ if cond] = value)`.
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
-use syn::parse::{Parse, ParseStream};
-use syn::{Expr, Ident, Token};
+use syn::Expr;
 
-struct ParamInput {
-    model: Expr,
-    name: Ident,
-    value: Expr,
-}
+use crate::bind::{filtered_set, masked_closure_param};
+use crate::{Named, build_set, oximo_root, parse_named, split_top_commas};
 
-impl Parse for ParamInput {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let model = input.parse::<Expr>()?;
-        input.parse::<Token![,]>()?;
-        let name = input.parse::<Ident>()?;
-        input.parse::<Token![=]>()?;
-        let value = input.parse::<Expr>()?;
-        Ok(Self { model, name, value })
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let mut parts = split_top_commas(input).into_iter();
+    let model = parts.next().ok_or_else(|| {
+        syn::Error::new(Span::call_site(), "param! needs a model and `name = value`")
+    })?;
+    let model: Expr = syn::parse2(model)?;
+
+    let spec = parts
+        .next()
+        .ok_or_else(|| syn::Error::new(Span::call_site(), "param! needs `name = value`"))?;
+    // Tolerate a single trailing empty segment (trailing comma); reject real extra args.
+    for seg in parts {
+        if !seg.is_empty() {
+            return Err(syn::Error::new(Span::call_site(), "unexpected trailing tokens in param!"));
+        }
+    }
+
+    let (core, value_ts) = split_assignment(spec)?;
+    let Named { name, binds, cond } = parse_named(core)?;
+    let name_str = name.to_string();
+
+    match binds {
+        None => {
+            let value: Expr = syn::parse2(value_ts)?;
+            Ok(quote!( let #name = (#model).__param(#name_str, f64::from(#value)); ))
+        }
+        Some(binds) => {
+            let root = oximo_root();
+            let value = crate::index::rewrite_index_subscripts(value_ts);
+            let param = masked_closure_param(&binds, &value);
+            let set = build_set(&binds, &root);
+            let set = filtered_set(set, &binds, cond.as_ref(), &root);
+            Ok(quote! {
+                let #name = {
+                    let __set = #set;
+                    (#model).__indexed_param(#name_str, &__set, move |#param| f64::from(#value))
+                };
+            })
+        }
     }
 }
 
-pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
-    let ParamInput { model, name, value } = syn::parse2(input)?;
-    let name_str = name.to_string();
-    Ok(quote!( let #name = (#model).__param(#name_str, f64::from(#value)); ))
+/// Split a `param!` spec on its top-level assignment `=`, returning the
+/// `name`/`name[...]` core and the value tokens.
+fn split_assignment(spec: TokenStream2) -> syn::Result<(TokenStream2, TokenStream2)> {
+    let tts: Vec<TokenTree> = spec.into_iter().collect();
+    let pos = tts
+        .iter()
+        .position(|tt| matches!(tt, TokenTree::Punct(p) if p.as_char() == '='))
+        .ok_or_else(|| syn::Error::new(Span::call_site(), "param! needs `name = value`"))?;
+    let core: TokenStream2 = tts[..pos].iter().cloned().collect();
+    let value: TokenStream2 = tts[pos + 1..].iter().cloned().collect();
+    if value.is_empty() {
+        return Err(syn::Error::new(Span::call_site(), "param! value is missing after `=`"));
+    }
+    Ok((core, value))
 }

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -14,12 +14,9 @@
 
 use proc_macro2::{Spacing, TokenStream as TokenStream2, TokenTree};
 use quote::{ToTokens, quote};
-use syn::Pat;
 
-use crate::bind::filtered_set;
-use crate::{
-    IndexBind, Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas,
-};
+use crate::bind::{filtered_set, masked_closure_param, references_any};
+use crate::{Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas};
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let mut parts = split_top_commas(input).into_iter();
@@ -100,7 +97,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let bound_method = |val: &TokenStream2, kind: BoundKind| -> TokenStream2 {
         match binds_slice {
             Some(bs) if references_any(val, &idents) => {
-                let param = bound_closure_param(bs, val);
+                let param = masked_closure_param(bs, val);
                 match kind {
                     BoundKind::Lb => quote!(.lb_by(move |#param| f64::from(#val))),
                     BoundKind::Ub => quote!(.ub_by(move |#param| f64::from(#val))),
@@ -296,45 +293,6 @@ enum BoundKind {
     Ub,
 }
 
-/// Closure parameter for a per-key (`.lb_by`/`.ub_by`) bound: each index the
-/// bound does not reference is replaced with `_`, so the generated closure never
-/// has an unused parameter. The builder's key type pins the parameter, so it is
-/// left bare for inference unless the user annotated every binding.
-fn bound_closure_param(binds: &[IndexBind], bound: &TokenStream2) -> TokenStream2 {
-    let masked = binds.iter().map(|b| mask_pat(&b.pat, bound));
-    let pattern = if binds.len() == 1 {
-        let p = mask_pat(&binds[0].pat, bound);
-        quote!(#p)
-    } else {
-        quote!( (#(#masked),*) )
-    };
-
-    let tys: Option<Vec<&syn::Type>> = binds.iter().map(|b| b.ty.as_ref()).collect();
-    match tys {
-        Some(tys) if binds.len() == 1 => {
-            let ty = tys[0];
-            quote!(#pattern: #ty)
-        }
-        Some(tys) => quote!( #pattern: (#(#tys),*) ),
-        None => pattern,
-    }
-}
-
-/// Replace each bare-ident sub-pattern the bound does not reference with `_`,
-/// recursing into tuple patterns.
-fn mask_pat(pat: &Pat, bound: &TokenStream2) -> TokenStream2 {
-    match pat {
-        Pat::Tuple(t) => {
-            let elems = t.elems.iter().map(|e| mask_pat(e, bound));
-            quote!( (#(#elems),*) )
-        }
-        Pat::Ident(pi) if pi.subpat.is_none() && pi.by_ref.is_none() => {
-            if references_any(bound, &[pi.ident.to_string()]) { quote!(#pat) } else { quote!(_) }
-        }
-        _ => quote!(#pat),
-    }
-}
-
 /// Collect every identifier appearing in a token stream (recursing into groups).
 fn collect_idents(ts: &TokenStream2, out: &mut Vec<String>) {
     for tt in ts.clone() {
@@ -344,13 +302,4 @@ fn collect_idents(ts: &TokenStream2, out: &mut Vec<String>) {
             _ => {}
         }
     }
-}
-
-/// Whether a token stream references any of the given identifiers.
-fn references_any(ts: &TokenStream2, idents: &[String]) -> bool {
-    ts.clone().into_iter().any(|tt| match tt {
-        TokenTree::Ident(id) => idents.contains(&id.to_string()),
-        TokenTree::Group(g) => references_any(&g.stream(), idents),
-        _ => false,
-    })
 }

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -37,6 +37,31 @@ fn highs_multi_optima_returns_single_best() {
 }
 
 #[test]
+fn indexed_param_rebind_changes_solution() {
+    // maximize sum_i price[i] * x[i] s.t. sum_i x[i] <= 1, 0 <= x <= 1.
+    // With price = [1, 3, 2] the optimum loads x[1] (price 3) -> obj 3.
+    // Re-binding price[2] to 5 shifts the optimum to x[2] -> obj 5.
+    let m = Model::new("ip_solve");
+    let items = Set::range(0..3usize);
+    let price = [1.0, 3.0, 2.0];
+    param!(m, p[i in items] = price[i]);
+    variable!(m, 0.0 <= x[i in items] <= 1.0);
+    constraint!(m, budget, sum!(x[i] for i in items) <= 1.0);
+    objective!(m, Max, sum!(p[i] * x[i] for i in items));
+
+    let r1 = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(r1.termination, TerminationStatus::Optimal);
+    assert!((r1.objective().unwrap() - 3.0).abs() < 1e-6);
+    assert!((r1.value_of_idx(&x, 1usize).unwrap() - 1.0).abs() < 1e-6);
+
+    m.set_param_idx(&p, 2usize, 5.0);
+    let r2 = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(r2.termination, TerminationStatus::Optimal);
+    assert!((r2.objective().unwrap() - 5.0).abs() < 1e-6);
+    assert!((r2.value_of_idx(&x, 2usize).unwrap() - 1.0).abs() < 1e-6);
+}
+
+#[test]
 fn highs_rejects_semi_domains() {
     // HiGHS can't represent the semicontinuity gap through the `highs` crate, so
     // a semicontinuous (or semi-integer) variable must error.


### PR DESCRIPTION
## Description

This PR adds support for indexed parameters.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for indexed parameters, including dense and sparse parameter families.
  * Read and rebind indexed parameter values by key (supports single, multi-dimensional, and string-keyed indices).
  * The parameter macro now accepts indexed and conditional forms for flexible definitions.
* **Bug Fixes**
  * Indexed parameter rebindings now correctly affect objective values and solver results.
* **Documentation**
  * Expanded parameter documentation with an “Indexed parameters” guide and usage examples.
* **Tests**
  * Added coverage for dense/sparse indexed parameters and verified rebind-driven solution changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->