### PR TITLE
Support single-row range constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ subtraction, and nonlinear operations (see [Nonlinear Expressions](#nonlinear-ex
 constraint!(m, cap, 2.0 * x + 3.0 * y <= 100.0);
 constraint!(m, demand, x >= 5.0);
 constraint!(m, balance, x - y == 0.0);
-constraint!(m, band, 1.0 <= x + y <= 10.0); // two-sided range -> band_lo + band_hi
+constraint!(m, band, 1.0 <= x + y <= 10.0); // two-sided range -> one constraint
 
 objective!(m, Min, 3.0 * x + 5.0 * y);
 // or

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -42,7 +42,7 @@ pub fn solve(
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
     let sense = model.objective().as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
-    let (bar, var_order) = build_bar(model, opts)?;
+    let (bar, var_order, con_order) = build_bar(model, opts)?;
 
     // - Temp directory. Combine a timestamp with a per-process atomic counter so
     //   concurrent invocations never share a directory.
@@ -120,7 +120,7 @@ pub fn solve(
     let tim = fs::read_to_string(&tim_path)
         .map_err(|e| SolverError::Backend(format!("cannot read times file: {e}")))?;
     let res = fs::read_to_string(tmp_dir.join(RES_NAME)).unwrap_or_default();
-    let result = parse_solution(&tim, &res, sense, elapsed, raw_log, &var_order);
+    let result = parse_solution(&tim, &res, sense, elapsed, raw_log, &var_order, &con_order);
 
     let _ = fs::remove_dir_all(&tmp_dir);
     Ok(result)
@@ -128,8 +128,12 @@ pub fn solve(
 
 /// Build the full `.bar` file text for `model`, returning it alongside the
 /// variable declaration order (see [`write_var_declarations`]) used to decode
-/// BARON's numeric solution-pool blocks.
-fn build_bar(model: &Model, opts: &BaronOptions) -> Result<(String, Vec<VarId>), SolverError> {
+/// BARON's numeric solution-pool blocks, and the constraint emit-order (see
+/// [`write_equations`]) used to fold range duals back onto their `ConstraintId`.
+fn build_bar(
+    model: &Model,
+    opts: &BaronOptions,
+) -> Result<(String, Vec<VarId>, Vec<ConstraintId>), SolverError> {
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
@@ -139,10 +143,10 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<(String, Vec<VarId>),
     write_options(&mut bar, opts, RES_NAME, TIM_NAME);
     let var_order = write_var_declarations(&mut bar, &vars)?;
     write_bounds(&mut bar, &vars);
-    write_equations(&mut bar, &arena, &constraints)?;
+    let con_order = write_equations(&mut bar, &arena, &constraints)?;
     write_objective(&mut bar, &arena, objective.as_ref())?;
     write_starting_point(&mut bar, &vars);
-    Ok((bar, var_order))
+    Ok((bar, var_order, con_order))
 }
 
 // - .bar writers
@@ -247,29 +251,38 @@ fn upper_bound_to_emit(v: &Variable) -> Option<f64> {
     }
 }
 
+/// Write the `EQUATIONS` block, returning the emit-order map.
+/// The `ConstraintId` behind each emitted equation, in BARON's 1-based
+/// "Constraint no." order. BARON has no two-sided equation,
+/// so a range emits two rows (`c{i}_lo`/`c{i}_hi`) that both map back
+/// to the one `ConstraintId`. The dual parser folds them together so
+/// positional indices stay correct.
 fn write_equations(
     bar: &mut String,
     arena: &ExprArena,
     constraints: &[Constraint],
-) -> Result<(), SolverError> {
+) -> Result<Vec<ConstraintId>, SolverError> {
+    let mut emit_map: Vec<ConstraintId> = Vec::with_capacity(constraints.len());
     if constraints.is_empty() {
-        return Ok(());
+        return Ok(emit_map);
     }
-    write!(bar, "EQUATIONS ").unwrap();
-    for i in 0..constraints.len() {
-        if i > 0 {
-            write!(bar, ", ").unwrap();
+
+    let mut names: Vec<String> = Vec::with_capacity(constraints.len());
+    for (i, c) in constraints.iter().enumerate() {
+        let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
+        if c.is_range() {
+            names.push(format!("c{i}_lo"));
+            names.push(format!("c{i}_hi"));
+            emit_map.push(id);
+            emit_map.push(id);
+        } else {
+            names.push(format!("c{i}"));
+            emit_map.push(id);
         }
-        write!(bar, "c{i}").unwrap();
     }
-    writeln!(bar, ";").unwrap();
+    writeln!(bar, "EQUATIONS {};", names.join(", ")).unwrap();
 
     for (i, c) in constraints.iter().enumerate() {
-        let op = match c.sense {
-            Sense::Le => "<=",
-            Sense::Ge => ">=",
-            Sense::Eq => "==",
-        };
         // BARON rejects a constraint whose expression evaluates to a constant,
         // so surface a clear error instead of emitting an invalid `.bar`.
         if !expr_has_var(arena, c.lhs) {
@@ -279,19 +292,44 @@ fn write_equations(
                 c.name
             )));
         }
-        write!(bar, "c{i}: ").unwrap();
-        // Linear constraints fold the constant into the RHS, matching the
-        // canonical `lhs <op> rhs` shape; nonlinear ones emit the full LHS.
-        if let Some(t) = extract_linear(arena, c.lhs) {
-            let adjusted_rhs = c.rhs - t.constant;
-            write_linear(bar, &t, false);
-            writeln!(bar, " {op} {};", fmt(adjusted_rhs)).unwrap();
+        if let Some((sense, rhs)) = c.as_single() {
+            let op = match sense {
+                Sense::Le => "<=",
+                Sense::Ge => ">=",
+                Sense::Eq => "==",
+            };
+            write!(bar, "c{i}: ").unwrap();
+            write_constraint_body(bar, arena, c.lhs, op, rhs)?;
         } else {
-            write_bar_expr(bar, arena, c.lhs)?;
-            writeln!(bar, " {op} {};", fmt(c.rhs)).unwrap();
+            // Two-sided range -> `_lo` (>= lower) and `_hi` (<= upper).
+            write!(bar, "c{i}_lo: ").unwrap();
+            write_constraint_body(bar, arena, c.lhs, ">=", c.lower)?;
+            write!(bar, "c{i}_hi: ").unwrap();
+            write_constraint_body(bar, arena, c.lhs, "<=", c.upper)?;
         }
     }
     writeln!(bar).unwrap();
+    Ok(emit_map)
+}
+
+/// Emit one constraint body `<lhs> <op> <rhs>;`. Linear constraints fold the
+/// constant into the RHS (canonical `lhs <op> rhs`). Nonlinear ones emit the
+/// full LHS and keep the original RHS.
+fn write_constraint_body(
+    bar: &mut String,
+    arena: &ExprArena,
+    lhs: ExprId,
+    op: &str,
+    rhs: f64,
+) -> Result<(), SolverError> {
+    if let Some(t) = extract_linear(arena, lhs) {
+        let adjusted_rhs = rhs - t.constant;
+        write_linear(bar, &t, false);
+        writeln!(bar, " {op} {};", fmt(adjusted_rhs)).unwrap();
+    } else {
+        write_bar_expr(bar, arena, lhs)?;
+        writeln!(bar, " {op} {};", fmt(rhs)).unwrap();
+    }
     Ok(())
 }
 
@@ -517,6 +555,7 @@ fn parse_solution(
     elapsed: std::time::Duration,
     raw_log: Option<String>,
     var_order: &[VarId],
+    con_order: &[ConstraintId],
 ) -> SolverResult {
     let tokens: Vec<&str> = tim.split_whitespace().collect();
     let int_at = |i: usize| tokens.get(i).and_then(|s| s.parse::<i64>().ok());
@@ -555,7 +594,7 @@ fn parse_solution(
     }
 
     let (dual, reduced_costs) = if has_sol {
-        parse_dual_solution(res, var_order)
+        parse_dual_solution(res, var_order, con_order)
     } else {
         (FxHashMap::default(), FxHashMap::default())
     };
@@ -756,6 +795,7 @@ fn parse_solution_pool(res: &str, var_order: &[VarId]) -> Vec<SolutionPoint> {
 fn parse_dual_solution(
     res: &str,
     var_order: &[VarId],
+    con_order: &[ConstraintId],
 ) -> (FxHashMap<ConstraintId, f64>, FxHashMap<VarId, f64>) {
     let mut dual: FxHashMap<ConstraintId, f64> = FxHashMap::default();
     let mut reduced_costs: FxHashMap<VarId, f64> = FxHashMap::default();
@@ -793,8 +833,8 @@ fn parse_dual_solution(
             continue;
         }
         if in_prices {
-            if let Ok(idx) = u32::try_from(k - 1) {
-                dual.insert(ConstraintId(idx), val);
+            if let Some(&id) = con_order.get(k - 1) {
+                *dual.entry(id).or_insert(0.0) += val;
             }
         } else if k <= var_order.len() {
             reduced_costs.insert(var_order[k - 1], val);
@@ -1099,13 +1139,27 @@ mod tests {
     fn parse_tim_picks_objective_by_sense() {
         // name ncon nvar a b lower upper solver model c iters nodeopt ... wall
         let tim = "m 1 2 0 0 1.5 9.5 1 1 0 42 7 0 0 0.42";
-        let r =
-            parse_solution(tim, "", ObjectiveSense::Minimize, std::time::Duration::ZERO, None, &[]);
+        let r = parse_solution(
+            tim,
+            "",
+            ObjectiveSense::Minimize,
+            std::time::Duration::ZERO,
+            None,
+            &[],
+            &[],
+        );
         assert_eq!(r.termination, TerminationStatus::Optimal);
         assert_eq!(r.objective(), Some(9.5)); // upper bound for minimize
         assert_eq!(r.iterations, 42); // branch-and-reduce iterations from tim[10]
-        let r =
-            parse_solution(tim, "", ObjectiveSense::Maximize, std::time::Duration::ZERO, None, &[]);
+        let r = parse_solution(
+            tim,
+            "",
+            ObjectiveSense::Maximize,
+            std::time::Duration::ZERO,
+            None,
+            &[],
+            &[],
+        );
         assert_eq!(r.objective(), Some(1.5)); // lower bound for maximize
     }
 
@@ -1192,7 +1246,8 @@ The best solution found is:
 
 The above solution has an objective value of:    5.0
 ";
-        let (dual, rc) = parse_dual_solution(res, &[VarId(0), VarId(1)]);
+        let (dual, rc) =
+            parse_dual_solution(res, &[VarId(0), VarId(1)], &[ConstraintId(0), ConstraintId(1)]);
         assert_eq!(rc.get(&VarId(0)), Some(&0.0));
         assert_eq!(rc.get(&VarId(1)), Some(&-0.5));
         assert_eq!(dual.get(&ConstraintId(0)), Some(&2.0));
@@ -1233,9 +1288,25 @@ The above solution has an objective value of:    5.0
 
 The best solution found is:
 ";
-        let (dual, rc) = parse_dual_solution(res, &[VarId(0)]);
+        let (dual, rc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
         assert_eq!(rc.get(&VarId(0)), Some(&0.0));
         assert_eq!(dual.get(&ConstraintId(0)), Some(&1.0));
+    }
+
+    #[test]
+    fn parse_dual_folds_range_rows_onto_one_constraint() {
+        let res = "\
+ >>> Corresponding dual solution vector is:
+ >>> Variable no.              Marginal
+ >>>       1             0.0000000000000000000000
+ >>> Constraint no.             Price
+ >>>       1             2.0000000000000000000000
+ >>>       2            -.50000000000000000000000
+";
+        let (dual, _rc) =
+            parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0), ConstraintId(0)]);
+        assert_eq!(dual.len(), 1);
+        assert_eq!(dual.get(&ConstraintId(0)), Some(&1.5)); // 2.0 + (-0.5)
     }
 
     #[test]
@@ -1252,7 +1323,7 @@ No dual information is available.
 
 The best solution found is:
 ";
-        let (dual, rc) = parse_dual_solution(res, &[VarId(0)]);
+        let (dual, rc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
         assert!(dual.is_empty());
         assert!(rc.is_empty());
     }
@@ -1297,6 +1368,7 @@ The above solution has an objective value of:  0.0
             std::time::Duration::ZERO,
             None,
             &[VarId(0), VarId(1)],
+            &[ConstraintId(0)],
         );
         assert_eq!(r.result_count(), 2);
         assert_eq!(r.reduced_costs.get(&VarId(1)), Some(&1.5));
@@ -1318,6 +1390,7 @@ The above solution has an objective value of:  0.0
             std::time::Duration::ZERO,
             None,
             &[VarId(0)],
+            &[],
         );
         assert_eq!(r.result_count(), 1);
         assert!(

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -29,7 +29,7 @@ let m = Model::new("transport");
 variable!(m, x >= 0.0);
 variable!(m, 0.0 <= y <= 10.0);
 
-// Constraints (incl. a two-sided range -> band_lo + band_hi)
+// Constraints (incl. a two-sided range, kept as one constraint)
 constraint!(m, c1, x + 2.0 * y <= 14.0);
 constraint!(m, c2, 3.0 * x - y >= 0.0);
 constraint!(m, band, 1.0 <= x + y <= 12.0);
@@ -156,7 +156,7 @@ these are real constraint operators.
 ```rust,ignore
 constraint!(m, name, lhs <= rhs);                  // named, also >= and ==
 constraint!(m, lhs >= rhs);                        // anonymous (auto-named _c0, _c1, ...)
-constraint!(m, band, 1.0 <= e <= 3.0);             // two-sided range -> band_lo + band_hi
+constraint!(m, band, 1.0 <= e <= 3.0);             // two-sided range -> one constraint (expr bounds -> band_lo/band_hi)
 constraint!(m, name = format!("c_{k}"), e == rhs); // computed run-time name
 ```
 

--- a/crates/oximo-core/src/constraint.rs
+++ b/crates/oximo-core/src/constraint.rs
@@ -19,16 +19,53 @@ impl ConstraintId {
     }
 }
 
-/// A single algebraic constraint already canonicalized as `lhs <op> rhs`,
-/// where `rhs` is a numeric constant. RHS expressions are folded into `lhs`
-/// during construction, so backends only ever see this canonical shape.
+/// A single algebraic constraint, canonicalized as the interval
+/// `lower <= lhs <= upper` with numeric bounds. RHS expressions are folded into
+/// `lhs` during construction, so backends only ever see this canonical shape.
+///
+/// The single-sided senses map onto the interval as `Le(rhs) => [-inf, rhs]`,
+/// `Ge(rhs) => [rhs, +inf]`, `Eq(rhs) => [rhs, rhs]`. A two-sided range with
+/// constant bounds is `[lo, hi]`. Use [`Constraint::as_single`] to recover the
+/// single-sided sense (for backends without native two-sided rows) and
+/// [`Constraint::is_range`] to detect a genuine range.
 #[derive(Clone, Debug)]
 pub struct Constraint {
     pub name: SmolStr,
     pub lhs: ExprId,
-    pub sense: Sense,
-    pub rhs: f64,
+    pub lower: f64,
+    pub upper: f64,
     pub active: bool,
+}
+
+impl Constraint {
+    /// The two bounds are equal, i.e. this is an equality row. Uses `total_cmp`
+    /// for an exact comparison: the bounds are literals (`Eq` copies the same
+    /// value into both).
+    fn is_equality(&self) -> bool {
+        self.lower.total_cmp(&self.upper).is_eq()
+    }
+
+    /// Whether this is a genuine two-sided range (both bounds finite and not an
+    /// equality), as opposed to a single-sided `Le`/`Ge`/`Eq` row. An inverted
+    /// `[hi, lo]` (`lo > hi`, an infeasible user range) is also a range, so the
+    /// solver reports the infeasibility rather than it collapsing to an equality.
+    #[must_use]
+    pub fn is_range(&self) -> bool {
+        self.lower.is_finite() && self.upper.is_finite() && !self.is_equality()
+    }
+
+    /// Recover the single-sided `(sense, rhs)` view, or `None` for a genuine
+    /// range (or an unconstrained `[-inf, +inf]` row). Backends and writers
+    /// without native two-sided rows branch on this.
+    #[must_use]
+    pub fn as_single(&self) -> Option<(Sense, f64)> {
+        match (self.lower.is_finite(), self.upper.is_finite()) {
+            (false, true) => Some((Sense::Le, self.upper)),
+            (true, false) => Some((Sense::Ge, self.lower)),
+            (true, true) if self.is_equality() => Some((Sense::Eq, self.lower)),
+            _ => None,
+        }
+    }
 }
 
 /// In-progress constraint produced by [`Relate::le`] / [`Relate::ge`] /
@@ -51,17 +88,32 @@ pub trait Relate<'a> {
 /// stay as the canonical `rhs`. Expressions get subtracted into the LHS.
 pub trait IntoRhs<'a> {
     fn fold_rhs(self, lhs: Expr<'a>) -> (Expr<'a>, f64);
+
+    /// The numeric value when this RHS is a pure constant bound (a literal),
+    /// else `None`. Used by the range-constraint registration to decide whether
+    /// `lo <= e <= hi` collapses to one interval row: expression/param bounds
+    /// return `None` so they stay two general constraints (keeping the symbolic
+    /// bound re-bindable). Defaults to `None`.
+    fn const_bound(&self) -> Option<f64> {
+        None
+    }
 }
 
 impl<'a> IntoRhs<'a> for f64 {
     fn fold_rhs(self, lhs: Expr<'a>) -> (Expr<'a>, f64) {
         (lhs, self)
     }
+    fn const_bound(&self) -> Option<f64> {
+        Some(*self)
+    }
 }
 
 impl<'a> IntoRhs<'a> for i32 {
     fn fold_rhs(self, lhs: Expr<'a>) -> (Expr<'a>, f64) {
         (lhs, f64::from(self))
+    }
+    fn const_bound(&self) -> Option<f64> {
+        Some(f64::from(*self))
     }
 }
 

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -378,8 +378,8 @@ impl Model {
     ///
     /// # Panics
     ///
-    /// Panics if a constraint with the same name is already registered, or if the
-    /// constraint count exceeds `u32::MAX`.
+    /// Panics if a constraint with the same name is already registered, if a
+    /// bound is NaN, or if the constraint count exceeds `u32::MAX`.
     fn register_constraint(
         &self,
         name: SmolStr,
@@ -387,6 +387,10 @@ impl Model {
         lower: f64,
         upper: f64,
     ) -> ConstraintId {
+        assert!(
+            !lower.is_nan() && !upper.is_nan(),
+            "constraint {name:?} has NaN bound (lower={lower}, upper={upper})"
+        );
         let mut by_name = self.constraint_names.borrow_mut();
         assert!(!by_name.contains_key(&name), "constraint name {name:?} already registered");
         let mut all = self.constraints.borrow_mut();

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -1,11 +1,11 @@
 use std::cell::{Cell, Ref, RefCell};
 use std::marker::PhantomData;
 
-use oximo_expr::{Expr, ExprArena, ExprClass, ParamId, VarId, classify};
+use oximo_expr::{Expr, ExprArena, ExprClass, ExprId, ParamId, VarId, classify};
 use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
 
-use crate::constraint::{Constraint, ConstraintExpr, ConstraintId};
+use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
 use crate::domain::Domain;
 use crate::error::{Error, Result};
 use crate::indexed::{IndexedFamily, IndexedParam, IndexedVar, build_storage};
@@ -365,37 +365,55 @@ impl Model {
         name: impl Into<SmolStr>,
         c: ConstraintExpr<'_>,
     ) -> ConstraintId {
-        let name = name.into();
+        let (lower, upper) = match c.sense {
+            Sense::Le => (f64::NEG_INFINITY, c.rhs),
+            Sense::Ge => (c.rhs, f64::INFINITY),
+            Sense::Eq => (c.rhs, c.rhs),
+        };
+        self.register_constraint(name.into(), c.lhs.id, lower, upper)
+    }
+
+    /// Push a constraint row `lower <= lhs <= upper` into the registry. Shared by
+    /// [`Self::__add_constraint`] and the range entry points.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a constraint with the same name is already registered, or if the
+    /// constraint count exceeds `u32::MAX`.
+    fn register_constraint(
+        &self,
+        name: SmolStr,
+        lhs: ExprId,
+        lower: f64,
+        upper: f64,
+    ) -> ConstraintId {
         let mut by_name = self.constraint_names.borrow_mut();
         assert!(!by_name.contains_key(&name), "constraint name {name:?} already registered");
         let mut all = self.constraints.borrow_mut();
         let id = ConstraintId(u32::try_from(all.len()).expect("constraint count overflow"));
-        all.push(Constraint {
-            name: name.clone(),
-            lhs: c.lhs.id,
-            sense: c.sense,
-            rhs: c.rhs,
-            active: true,
-        });
+        all.push(Constraint { name: name.clone(), lhs, lower, upper, active: true });
         by_name.insert(name, id);
         self.cached_kind.set(None);
         id
     }
 
-    /// Register an anonymous constraint, deriving a unique name `_c{n}` from an
-    /// internal counter. Backs the name-less form of the `constraint!` macro.
-    #[doc(hidden)]
-    pub fn __add_constraint_auto(&self, c: ConstraintExpr<'_>) -> ConstraintId {
-        // Skip over any names a user may already have taken.
-        let name = loop {
+    /// A fresh unique auto-name `_c{n}`, skipping any a user already took.
+    fn next_auto_name(&self) -> SmolStr {
+        loop {
             let n = self.auto_seq.get();
             self.auto_seq.set(n + 1);
             let candidate: SmolStr = format!("_c{n}").into();
             if !self.constraint_names.borrow().contains_key(&candidate) {
                 break candidate;
             }
-        };
-        self.__add_constraint(name, c)
+        }
+    }
+
+    /// Register an anonymous constraint, deriving a unique name `_c{n}` from an
+    /// internal counter. Backs the name-less form of the `constraint!` macro.
+    #[doc(hidden)]
+    pub fn __add_constraint_auto(&self, c: ConstraintExpr<'_>) -> ConstraintId {
+        self.__add_constraint(self.next_auto_name(), c)
     }
 
     /// Bulk-register constraints. Each entry is `(name, ConstraintExpr)`.
@@ -427,19 +445,73 @@ impl Model {
         }
     }
 
-    /// Macro-facing entry point for a two-sided range family.
+    /// Macro-facing entry point for a two-sided range `lo <= mid <= hi`.
+    ///
+    /// Collapses to a single interval [`Constraint`] named `name` only when both
+    /// bounds are pure constants and the body is linear (the condition under which
+    /// one two-sided row is representable).
     #[doc(hidden)]
-    pub fn __add_range_constraints_over<'a, K, F>(&'a self, name: &str, set: &Set<K>, mut rule: F)
+    pub fn __add_range<'a, B1, B2>(&'a self, name: &str, mid: Expr<'a>, lo: B1, hi: B2)
     where
-        K: FromIndexKey,
-        F: FnMut(K) -> (ConstraintExpr<'a>, ConstraintExpr<'a>),
+        B1: IntoRhs<'a>,
+        B2: IntoRhs<'a>,
     {
-        let lo_prefix = format!("{name}_lo");
-        let hi_prefix = format!("{name}_hi");
+        if let Some((lower, upper)) = self.collapse_bounds(mid.id, &lo, &hi) {
+            self.register_constraint(name.into(), mid.id, lower, upper);
+        } else {
+            self.__add_constraint(format!("{name}_lo"), mid.ge(lo));
+            self.__add_constraint(format!("{name}_hi"), mid.le(hi));
+        }
+    }
+
+    /// Anonymous form of [`Self::__add_range`] (auto-named rows).
+    #[doc(hidden)]
+    pub fn __add_range_auto<'a, B1, B2>(&'a self, mid: Expr<'a>, lo: B1, hi: B2)
+    where
+        B1: IntoRhs<'a>,
+        B2: IntoRhs<'a>,
+    {
+        if let Some((lower, upper)) = self.collapse_bounds(mid.id, &lo, &hi) {
+            self.register_constraint(self.next_auto_name(), mid.id, lower, upper);
+        } else {
+            self.__add_constraint_auto(mid.ge(lo));
+            self.__add_constraint_auto(mid.le(hi));
+        }
+    }
+
+    /// The interval `(lower, upper)` a range collapses to, or `None` (keep two
+    /// rows). Requires both bounds to be literal constants and the body `mid` to
+    /// be linear.
+    fn collapse_bounds<'a>(
+        &self,
+        mid: ExprId,
+        lo: &impl IntoRhs<'a>,
+        hi: &impl IntoRhs<'a>,
+    ) -> Option<(f64, f64)> {
+        let lower = lo.const_bound()?;
+        let upper = hi.const_bound()?;
+        (classify(&self.arena.borrow(), mid) == ExprClass::Linear).then_some((lower, upper))
+    }
+
+    /// Macro-facing entry point for a two-sided range family. One row per key,
+    /// each collapsing to a single interval constraint when both bounds are
+    /// constant (see [`Self::__add_range`]).
+    #[doc(hidden)]
+    pub fn __add_range_constraints_over<'a, K, B1, B2, F>(
+        &'a self,
+        name: &str,
+        set: &Set<K>,
+        mut rule: F,
+    ) where
+        K: FromIndexKey,
+        B1: IntoRhs<'a>,
+        B2: IntoRhs<'a>,
+        F: FnMut(K) -> (Expr<'a>, B1, B2),
+    {
         for key in set {
-            let (lo, hi) = rule(K::from_index_key(&key));
-            self.__add_constraint(format_index_name(&lo_prefix, &key), lo);
-            self.__add_constraint(format_index_name(&hi_prefix, &key), hi);
+            let (mid, lo, hi) = rule(K::from_index_key(&key));
+            let row_name = format_index_name(name, &key);
+            self.__add_range(&row_name, mid, lo, hi);
         }
     }
 

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -117,20 +117,18 @@ fn large_filtered_sum_builds_correctly() {
 // --- Two-sided range constraints: `lo <= e <= hi` lowers to `_lo` + `_hi` rows.
 
 #[test]
-fn range_constraint_lowers_to_two_rows() {
+fn range_constraint_with_const_bounds_collapses_to_one_row() {
     let m = Model::new("range");
     variable!(m, x >= 0.0);
     variable!(m, y >= 0.0);
     constraint!(m, band, 1.0 <= x + y <= 3.0);
 
-    assert_eq!(m.num_constraints(), 2);
+    assert_eq!(m.num_constraints(), 1);
     let cons = m.constraints();
-    let lo = &cons[m.constraint_id("band_lo").expect("lo row").index()];
-    let hi = &cons[m.constraint_id("band_hi").expect("hi row").index()];
-    assert_eq!(lo.sense, Sense::Ge);
-    assert!((lo.rhs - 1.0).abs() < f64::EPSILON);
-    assert_eq!(hi.sense, Sense::Le);
-    assert!((hi.rhs - 3.0).abs() < f64::EPSILON);
+    let band = &cons[m.constraint_id("band").expect("range row").index()];
+    assert!(band.is_range());
+    assert!((band.lower - 1.0).abs() < f64::EPSILON);
+    assert!((band.upper - 3.0).abs() < f64::EPSILON);
 }
 
 #[test]
@@ -139,50 +137,90 @@ fn range_constraint_ge_form_is_equivalent() {
     variable!(m, x >= 0.0);
     constraint!(m, b, 3.0 >= x >= 1.0);
 
+    assert_eq!(m.num_constraints(), 1);
     let cons = m.constraints();
-    let lo = &cons[m.constraint_id("b_lo").unwrap().index()];
-    let hi = &cons[m.constraint_id("b_hi").unwrap().index()];
-    assert_eq!(lo.sense, Sense::Ge);
-    assert!((lo.rhs - 1.0).abs() < f64::EPSILON);
-    assert_eq!(hi.sense, Sense::Le);
-    assert!((hi.rhs - 3.0).abs() < f64::EPSILON);
+    let b = &cons[m.constraint_id("b").unwrap().index()];
+    assert!(b.is_range());
+    assert!((b.lower - 1.0).abs() < f64::EPSILON);
+    assert!((b.upper - 3.0).abs() < f64::EPSILON);
 }
 
 #[test]
-fn anonymous_range_makes_two_auto_rows() {
+fn range_constraint_with_expr_bounds_falls_back_to_two_rows() {
+    let m = Model::new("rangeexpr");
+    variable!(m, x >= 0.0);
+    variable!(m, lo >= 0.0);
+    variable!(m, hi >= 0.0);
+    constraint!(m, band, lo <= x <= hi);
+
+    assert_eq!(m.num_constraints(), 2);
+    let cons = m.constraints();
+    let lo_row = &cons[m.constraint_id("band_lo").expect("lo row").index()];
+    let hi_row = &cons[m.constraint_id("band_hi").expect("hi row").index()];
+    assert_eq!(lo_row.as_single().map(|(s, _)| s), Some(Sense::Ge));
+    assert_eq!(hi_row.as_single().map(|(s, _)| s), Some(Sense::Le));
+}
+
+#[test]
+fn anonymous_range_makes_one_auto_row() {
     let m = Model::new("anonr");
     variable!(m, x >= 0.0);
     constraint!(m, 0.0 <= x <= 5.0);
-    assert_eq!(m.num_constraints(), 2);
-    assert!(m.constraint_id("_c0").is_some());
-    assert!(m.constraint_id("_c1").is_some());
+    assert_eq!(m.num_constraints(), 1);
+    let c = &m.constraints()[m.constraint_id("_c0").expect("auto row").index()];
+    assert!(c.is_range());
 }
 
 #[test]
-fn family_range_makes_two_rows_per_element() {
+fn family_range_const_bounds_makes_one_row_per_element() {
     let m = Model::new("famr");
     let lo = [1.0, 2.0, 3.0];
     let hi = [4.0, 5.0, 6.0];
     variable!(m, x[i in 0..3] >= 0.0);
     constraint!(m, cap[i in 0..3], lo[i] <= x[i] <= hi[i]);
 
-    assert_eq!(m.num_constraints(), 6);
-    assert!(m.constraint_id("cap_lo[0]").is_some());
-    assert!(m.constraint_id("cap_hi[2]").is_some());
+    assert_eq!(m.num_constraints(), 3);
     let cons = m.constraints();
-    let c = &cons[m.constraint_id("cap_lo[1]").unwrap().index()];
-    assert_eq!(c.sense, Sense::Ge);
-    assert!((c.rhs - 2.0).abs() < f64::EPSILON);
+    let c = &cons[m.constraint_id("cap[1]").expect("range row").index()];
+    assert!(c.is_range());
+    assert!((c.lower - 2.0).abs() < f64::EPSILON);
+    assert!((c.upper - 5.0).abs() < f64::EPSILON);
 }
 
 #[test]
-fn computed_name_range_suffixes_both_rows() {
+fn inverted_range_stays_a_range_not_an_equality() {
+    let m = Model::new("inv");
+    variable!(m, x);
+    constraint!(m, c, 5.0 <= x <= 1.0);
+    assert_eq!(m.num_constraints(), 1);
+    let c = &m.constraints()[m.constraint_id("c").unwrap().index()];
+    assert!(c.is_range());
+    assert_eq!(c.as_single(), None);
+}
+
+#[test]
+fn nonlinear_range_falls_back_to_two_rows() {
+    let m = Model::new("nlr");
+    variable!(m, x);
+    constraint!(m, c, 1.0 <= x * x <= 4.0);
+    assert_eq!(m.num_constraints(), 2);
+    let cons = m.constraints();
+    let lo = &cons[m.constraint_id("c_lo").expect("lo row").index()];
+    let hi = &cons[m.constraint_id("c_hi").expect("hi row").index()];
+    assert!(!lo.is_range());
+    assert_eq!(lo.as_single().map(|(s, _)| s), Some(Sense::Ge));
+    assert_eq!(hi.as_single().map(|(s, _)| s), Some(Sense::Le));
+}
+
+#[test]
+fn computed_name_range_collapses_to_one_row() {
     let m = Model::new("crange");
     variable!(m, x >= 0.0);
     let tag = "band";
     constraint!(m, name = format!("{tag}"), 1.0 <= x <= 2.0);
-    assert!(m.constraint_id("band_lo").is_some());
-    assert!(m.constraint_id("band_hi").is_some());
+    assert_eq!(m.num_constraints(), 1);
+    let c = &m.constraints()[m.constraint_id("band").expect("range row").index()];
+    assert!(c.is_range());
 }
 
 #[test]

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -192,8 +192,7 @@ fn rhs_expr_folded_into_lhs() {
     constraint!(m, c, x <= y + 3.0);
     let cs = m.constraints();
     assert_eq!(cs.len(), 1);
-    assert_eq!(cs[0].rhs, 0.0);
-    assert_eq!(cs[0].sense, Sense::Le);
+    assert_eq!(cs[0].as_single(), Some((Sense::Le, 0.0)));
 
     // Decode the LHS and confirm the original `y + 3` made it into the linear
     // form so `coeff*x - coeff*y - 3 <= 0` is what the solver will see.

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -669,10 +669,10 @@ fn write_equations(
 ) {
     write!(gms, "Equations\n    eq_obj").unwrap();
     for (i, c) in constraints.iter().enumerate() {
-        if c.is_range() {
-            write!(gms, ", eq_c{i}_lo, eq_c{i}_hi").unwrap();
-        } else {
+        if c.as_single().is_some() {
             write!(gms, ", eq_c{i}").unwrap();
+        } else {
+            write!(gms, ", eq_c{i}_lo, eq_c{i}_hi").unwrap();
         }
     }
     writeln!(gms, ";").unwrap();

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -91,8 +91,14 @@ pub fn solve(
     for i in 0..vars.len() {
         writeln!(gms, "Put 'R{i}=' v{i}.m:0:15 /;").unwrap();
     }
-    for i in 0..constraints.len() {
-        writeln!(gms, "Put 'D{i}=' eq_c{i}.m:0:15 /;").unwrap();
+    // A two-sided range is emitted as two equations (`_lo`/`_hi`), summing their
+    // marginals into one `D{i}` keeps the dual keyed by the single `ConstraintId`.
+    for (i, c) in constraints.iter().enumerate() {
+        if c.is_range() {
+            writeln!(gms, "Put 'D{i}=' (eq_c{i}_lo.m + eq_c{i}_hi.m):0:15 /;").unwrap();
+        } else {
+            writeln!(gms, "Put 'D{i}=' eq_c{i}.m:0:15 /;").unwrap();
+        }
     }
     writeln!(gms, "Putclose oximo_sol;").unwrap();
 
@@ -662,8 +668,12 @@ fn write_equations(
     objective: &Objective,
 ) {
     write!(gms, "Equations\n    eq_obj").unwrap();
-    for i in 0..constraints.len() {
-        write!(gms, ", eq_c{i}").unwrap();
+    for (i, c) in constraints.iter().enumerate() {
+        if c.is_range() {
+            write!(gms, ", eq_c{i}_lo, eq_c{i}_hi").unwrap();
+        } else {
+            write!(gms, ", eq_c{i}").unwrap();
+        }
     }
     writeln!(gms, ";").unwrap();
     writeln!(gms).unwrap();
@@ -674,21 +684,44 @@ fn write_equations(
     writeln!(gms, ";").unwrap();
 
     for (ci, c) in constraints.iter().enumerate() {
-        let sense_str = match c.sense {
-            Sense::Le => "=l=",
-            Sense::Ge => "=g=",
-            Sense::Eq => "=e=",
-        };
-        write!(gms, "eq_c{ci}..").unwrap();
-        match ExprForm::from(arena, c.lhs) {
-            ExprForm::Linear(t) => {
-                let adjusted_rhs = c.rhs - t.constant;
-                write_linear(gms, &t, false);
-                writeln!(gms, " {sense_str} {};", fmt(adjusted_rhs)).unwrap();
+        if let Some((sense, rhs)) = c.as_single() {
+            let sense_str = match sense {
+                Sense::Le => "=l=",
+                Sense::Ge => "=g=",
+                Sense::Eq => "=e=",
+            };
+            write!(gms, "eq_c{ci}..").unwrap();
+            match ExprForm::from(arena, c.lhs) {
+                ExprForm::Linear(t) => {
+                    let adjusted_rhs = rhs - t.constant;
+                    write_linear(gms, &t, false);
+                    writeln!(gms, " {sense_str} {};", fmt(adjusted_rhs)).unwrap();
+                }
+                ExprForm::Nonlinear(id) => {
+                    write_gams_expr(gms, arena, id, true);
+                    writeln!(gms, " {sense_str} {};", fmt(rhs)).unwrap();
+                }
             }
-            ExprForm::Nonlinear(id) => {
-                write_gams_expr(gms, arena, id, true);
-                writeln!(gms, " {sense_str} {};", fmt(c.rhs)).unwrap();
+        } else {
+            match ExprForm::from(arena, c.lhs) {
+                ExprForm::Linear(t) => {
+                    let lo = c.lower - t.constant;
+                    let hi = c.upper - t.constant;
+                    write!(gms, "eq_c{ci}_lo..").unwrap();
+                    write_linear(gms, &t, false);
+                    writeln!(gms, " =g= {};", fmt(lo)).unwrap();
+                    write!(gms, "eq_c{ci}_hi..").unwrap();
+                    write_linear(gms, &t, false);
+                    writeln!(gms, " =l= {};", fmt(hi)).unwrap();
+                }
+                ExprForm::Nonlinear(id) => {
+                    write!(gms, "eq_c{ci}_lo..").unwrap();
+                    write_gams_expr(gms, arena, id, true);
+                    writeln!(gms, " =g= {};", fmt(c.lower)).unwrap();
+                    write!(gms, "eq_c{ci}_hi..").unwrap();
+                    write_gams_expr(gms, arena, id, true);
+                    writeln!(gms, " =l= {};", fmt(c.upper)).unwrap();
+                }
             }
         }
     }

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -145,34 +145,57 @@ fn add_constraints(
     gurobi_vars: &[grb::Var],
     aux_counter: &mut u32,
 ) -> Result<Vec<GrbRow>, SolverError> {
+    // One `GrbRow` per oximo constraint keeps `gurobi_constrs` 1:1 with
+    // `ConstraintId`, which `collect_solution` relies on to key duals. A
+    // two-sided range becomes a single native `add_range` row.
     let mut gurobi_constrs: Vec<GrbRow> = Vec::with_capacity(constraints.len());
     for (c_id, c) in constraints.iter().enumerate() {
-        if let Some(t) = extract_linear(arena, c.lhs) {
-            let adjusted_rhs = c.rhs - t.constant;
+        let name = format!("c{c_id}");
+        if let Some((sense, rhs)) = c.as_single() {
+            if let Some(t) = extract_linear(arena, c.lhs) {
+                let adjusted_rhs = rhs - t.constant;
+                let mut expr = LinExpr::new();
+                for (v, co) in t.coeffs {
+                    expr.add_term(co, gurobi_vars[v.index()]);
+                }
+                let constr = match sense {
+                    Sense::Le => grb_model.add_constr(&name, c!(expr <= adjusted_rhs)),
+                    Sense::Ge => grb_model.add_constr(&name, c!(expr >= adjusted_rhs)),
+                    Sense::Eq => grb_model.add_constr(&name, c!(expr == adjusted_rhs)),
+                }
+                .map_err(map_grb_err)?;
+                gurobi_constrs.push(GrbRow::Lin(constr));
+            } else {
+                let row = add_nonlinear_constraint(
+                    arena,
+                    c.lhs,
+                    sense,
+                    rhs,
+                    c_id,
+                    grb_model,
+                    gurobi_vars,
+                    aux_counter,
+                )?;
+                gurobi_constrs.push(row);
+            }
+        } else {
+            // Genuine two-sided range. Gurobi's `add_range` is linear-only.
+            let Some(t) = extract_linear(arena, c.lhs) else {
+                return Err(SolverError::Backend(format!(
+                    "Gurobi does not support a two-sided range on a nonlinear constraint ('{}')",
+                    c.name
+                )));
+            };
+            let lower = c.lower - t.constant;
+            let upper = c.upper - t.constant;
             let mut expr = LinExpr::new();
             for (v, co) in t.coeffs {
                 expr.add_term(co, gurobi_vars[v.index()]);
             }
-            let name = format!("c{c_id}");
-            let constr = match c.sense {
-                Sense::Le => grb_model.add_constr(&name, c!(expr <= adjusted_rhs)),
-                Sense::Ge => grb_model.add_constr(&name, c!(expr >= adjusted_rhs)),
-                Sense::Eq => grb_model.add_constr(&name, c!(expr == adjusted_rhs)),
-            }
-            .map_err(map_grb_err)?;
+            #[allow(clippy::unnecessary_cast)]
+            let (_slack, constr) =
+                grb_model.add_range(&name, c!(expr in lower..upper)).map_err(map_grb_err)?;
             gurobi_constrs.push(GrbRow::Lin(constr));
-        } else {
-            let row = add_nonlinear_constraint(
-                arena,
-                c.lhs,
-                c.sense,
-                c.rhs,
-                c_id,
-                grb_model,
-                gurobi_vars,
-                aux_counter,
-            )?;
-            gurobi_constrs.push(row);
         }
     }
     Ok(gurobi_constrs)

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use highs::{
     HessianFormat, HighsModelStatus, HighsSolutionStatus, RowProblem, Sense as HighsSense,
 };
-use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable};
+use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, VarId, Variable};
 use oximo_expr::{
     ExprArena, ExprId, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,
 };
@@ -82,13 +82,10 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
         .collect::<Result<Vec<_>, _>>()?;
 
     for (c, t) in constraints.iter().zip(con_terms) {
-        let adjusted_rhs = c.rhs - t.constant;
+        let lower = c.lower - t.constant;
+        let upper = c.upper - t.constant;
         let factors = t.coeffs.iter().map(|(v, co)| (cols[v.index()], *co));
-        match c.sense {
-            Sense::Le => pb.add_row(f64::NEG_INFINITY..=adjusted_rhs, factors),
-            Sense::Ge => pb.add_row(adjusted_rhs..=f64::INFINITY, factors),
-            Sense::Eq => pb.add_row(adjusted_rhs..=adjusted_rhs, factors),
-        }
+        pb.add_row(lower..=upper, factors);
     }
 
     // The arena / vars / constraints borrows are released before we move into

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -80,6 +80,11 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
             write!(out, " {}_hi:", c.name)?;
             write_linear(out, &t, &vars)?;
             writeln!(out, " <= {hi}")?;
+        } else {
+            // Free `[-inf, +inf]` row: imposes no constraint and has no valid LP
+            // representation (`>= -inf` / `<= +inf` are illegal).
+            // Leave a comment so the omission is traceable in the output.
+            writeln!(out, "\\* skipped free row: {} *\\", c.name)?;
         }
     }
 

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -71,7 +71,7 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
             write!(out, " {}:", c.name)?;
             write_linear(out, &t, &vars)?;
             writeln!(out, " {op} {adjusted_rhs}")?;
-        } else {
+        } else if c.is_range() {
             let lo = c.lower - t.constant;
             let hi = c.upper - t.constant;
             write!(out, " {}_lo:", c.name)?;

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -16,6 +16,7 @@ use std::io::Write;
 
 use oximo_core::{Domain, Model, ObjectiveSense, Sense};
 use oximo_expr::{LinearTerms, extract_linear};
+use rustc_hash::FxHashSet;
 
 use crate::error::IoError;
 
@@ -58,6 +59,12 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         writeln!(out, "\\* objective constant: {} *\\", obj_terms.constant)?;
     }
 
+    // A collapsed range row is split into `{name}_lo` / `{name}_hi` labels at
+    // export time. Those derived labels can clash with another constraint named
+    // literally `{name}_lo`, so disambiguate against every registered name.
+    let mut used_labels: FxHashSet<String> =
+        constraints.iter().map(|c| c.name.to_string()).collect();
+
     writeln!(out, "Subject To")?;
     for c in constraints.iter() {
         let t = extract_linear(&arena, c.lhs).ok_or(IoError::Nonlinear)?;
@@ -74,10 +81,12 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         } else if c.is_range() {
             let lo = c.lower - t.constant;
             let hi = c.upper - t.constant;
-            write!(out, " {}_lo:", c.name)?;
+            let lo_label = unique_label(&mut used_labels, &format!("{}_lo", c.name));
+            write!(out, " {lo_label}:")?;
             write_linear(out, &t, &vars)?;
             writeln!(out, " >= {lo}")?;
-            write!(out, " {}_hi:", c.name)?;
+            let hi_label = unique_label(&mut used_labels, &format!("{}_hi", c.name));
+            write!(out, " {hi_label}:")?;
             write_linear(out, &t, &vars)?;
             writeln!(out, " <= {hi}")?;
         } else {
@@ -184,6 +193,23 @@ pub fn to_lp_string(model: &Model) -> Result<String, IoError> {
     let mut buf = Vec::new();
     write_lp(model, &mut buf)?;
     Ok(String::from_utf8(buf).expect("LP writer emits ASCII"))
+}
+
+/// Reserve a unique row label. Returns `base` if free, otherwise appends
+/// `_2`, `_3`, ... until it no longer collides with a name in `used`. The chosen
+/// label is recorded so later split rows cannot reuse it.
+fn unique_label(used: &mut FxHashSet<String>, base: &str) -> String {
+    if used.insert(base.to_string()) {
+        return base.to_string();
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}_{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
 }
 
 /// Write a linear expression as a sequence of `+/- coeff varname` terms.

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -61,15 +61,26 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     writeln!(out, "Subject To")?;
     for c in constraints.iter() {
         let t = extract_linear(&arena, c.lhs).ok_or(IoError::Nonlinear)?;
-        let adjusted_rhs = c.rhs - t.constant;
-        let op = match c.sense {
-            Sense::Le => "<=",
-            Sense::Ge => ">=",
-            Sense::Eq => "=",
-        };
-        write!(out, " {}:", c.name)?;
-        write_linear(out, &t, &vars)?;
-        writeln!(out, " {op} {adjusted_rhs}")?;
+        if let Some((sense, rhs)) = c.as_single() {
+            let op = match sense {
+                Sense::Le => "<=",
+                Sense::Ge => ">=",
+                Sense::Eq => "=",
+            };
+            let adjusted_rhs = rhs - t.constant;
+            write!(out, " {}:", c.name)?;
+            write_linear(out, &t, &vars)?;
+            writeln!(out, " {op} {adjusted_rhs}")?;
+        } else {
+            let lo = c.lower - t.constant;
+            let hi = c.upper - t.constant;
+            write!(out, " {}_lo:", c.name)?;
+            write_linear(out, &t, &vars)?;
+            writeln!(out, " >= {lo}")?;
+            write!(out, " {}_hi:", c.name)?;
+            write_linear(out, &t, &vars)?;
+            writeln!(out, " <= {hi}")?;
+        }
     }
 
     let mut wrote_bounds_header = false;

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -72,11 +72,15 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     writeln!(out, "ROWS")?;
     writeln!(out, " N  OBJ")?;
     for c in constraints.iter() {
-        // A two-sided range is an `L` row bounded by the `RANGES` section below.
         let tag = match c.as_single() {
-            Some((Sense::Le, _)) | None => 'L',
+            Some((Sense::Le, _)) => 'L',
             Some((Sense::Ge, _)) => 'G',
             Some((Sense::Eq, _)) => 'E',
+            // A two-sided range is an `L` row bounded by the `RANGES` section below.
+            None if c.is_range() => 'L',
+            // A free `[-inf, +inf]` row imposes nothing: emit an unconstraining
+            // `N` row (no RHS) rather than an `L` row with a `+inf` bound.
+            None => 'N',
         };
         writeln!(out, " {tag}  {}", c.name)?;
     }
@@ -113,7 +117,9 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         // section then widens it down to the lower bound.
         let rhs = match c.as_single() {
             Some((_, rhs)) => rhs,
-            None => c.upper,
+            None if c.is_range() => c.upper,
+            // Free `N` row: carries no RHS.
+            None => continue,
         };
         let adjusted = rhs - t.constant;
         if adjusted != 0.0 {

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -14,7 +14,7 @@
 
 use std::io::Write;
 
-use oximo_core::{Model, ObjectiveSense, Sense};
+use oximo_core::{Constraint, Model, ObjectiveSense, Sense};
 use oximo_expr::{LinearTerms, VarId, extract_linear};
 use rustc_hash::FxHashMap;
 
@@ -72,10 +72,11 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     writeln!(out, "ROWS")?;
     writeln!(out, " N  OBJ")?;
     for c in constraints.iter() {
-        let tag = match c.sense {
-            Sense::Le => 'L',
-            Sense::Ge => 'G',
-            Sense::Eq => 'E',
+        // A two-sided range is an `L` row bounded by the `RANGES` section below.
+        let tag = match c.as_single() {
+            Some((Sense::Le, _)) | None => 'L',
+            Some((Sense::Ge, _)) => 'G',
+            Some((Sense::Eq, _)) => 'E',
         };
         writeln!(out, " {tag}  {}", c.name)?;
     }
@@ -108,9 +109,24 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         writeln!(out, "    RHS       OBJ       {}", -obj_constant)?;
     }
     for (c, t) in constraints.iter().zip(con_terms.iter()) {
-        let adjusted = c.rhs - t.constant;
+        // A range row's RHS is its upper bound (it is an `L` row), the `RANGES`
+        // section then widens it down to the lower bound.
+        let rhs = match c.as_single() {
+            Some((_, rhs)) => rhs,
+            None => c.upper,
+        };
+        let adjusted = rhs - t.constant;
         if adjusted != 0.0 {
             writeln!(out, "    RHS       {:<10}{}", c.name, adjusted)?;
+        }
+    }
+
+    if constraints.iter().any(Constraint::is_range) {
+        writeln!(out, "RANGES")?;
+        for c in constraints.iter() {
+            if c.is_range() {
+                writeln!(out, "    RNG       {:<10}{}", c.name, c.upper - c.lower)?;
+            }
         }
     }
 

--- a/crates/oximo-io/src/nl/header.rs
+++ b/crates/oximo-io/src/nl/header.rs
@@ -41,7 +41,9 @@ impl Stats {
         _perm: &Permutation,
         opts: &WriteOptions,
     ) -> Self {
-        let n_eqns = constraints.iter().filter(|c| c.sense == Sense::Eq).count();
+        let n_eqns =
+            constraints.iter().filter(|c| matches!(c.as_single(), Some((Sense::Eq, _)))).count();
+        let n_ranges = constraints.iter().filter(|c| c.is_range()).count();
         let nl_con = analysis.cons.iter().filter(|r| r.is_nonlinear()).count();
         let nl_obj = usize::from(analysis.obj.is_nonlinear());
 
@@ -92,7 +94,7 @@ impl Stats {
             n_var: vars.len(),
             n_con: constraints.len(),
             n_obj: 1,
-            n_ranges: 0,
+            n_ranges,
             n_eqns,
             nl_con,
             nl_obj,

--- a/crates/oximo-io/src/nl/segments.rs
+++ b/crates/oximo-io/src/nl/segments.rs
@@ -214,24 +214,37 @@ fn write_r_segment<W: Write>(
         }
         let c = &constraints[orig_idx];
         let lin_const = analysis.cons[orig_idx].linear.constant;
-        let rhs = c.rhs - lin_const;
-        match c.sense {
-            Sense::Le => {
+        // `r`-segment line types (D. M. Gay, Table 17): 0 = `lo <= body <= hi`
+        // (range, two values), 1 = upper, 2 = lower, 3 = free, 4 = equality.
+        match c.as_single() {
+            Some((Sense::Le, rhs)) => {
                 w.int(1)?;
                 w.sep()?;
-                w.dbl(rhs)?;
+                w.dbl(rhs - lin_const)?;
                 w.eor()?;
             }
-            Sense::Ge => {
+            Some((Sense::Ge, rhs)) => {
                 w.int(2)?;
                 w.sep()?;
-                w.dbl(rhs)?;
+                w.dbl(rhs - lin_const)?;
                 w.eor()?;
             }
-            Sense::Eq => {
+            Some((Sense::Eq, rhs)) => {
                 w.int(4)?;
                 w.sep()?;
-                w.dbl(rhs)?;
+                w.dbl(rhs - lin_const)?;
+                w.eor()?;
+            }
+            None if c.is_range() => {
+                w.int(0)?;
+                w.sep()?;
+                w.dbl(c.lower - lin_const)?;
+                w.sep()?;
+                w.dbl(c.upper - lin_const)?;
+                w.eor()?;
+            }
+            None => {
+                w.int(3)?;
                 w.eor()?;
             }
         }

--- a/crates/oximo-io/tests/range.rs
+++ b/crates/oximo-io/tests/range.rs
@@ -1,0 +1,41 @@
+//! Writer coverage for two-sided range constraints (`lo <= e <= hi`).
+//!
+//! A range with constant bounds is one `Constraint`. MPS represents it natively
+//! via a `RANGES` section. CPLEX LP has no portable single-row range so the
+//! writer expands it to two rows. The AMPL `.nl` writer uses bound-type code 0.
+
+#![allow(clippy::float_cmp)]
+
+use oximo_core::prelude::*;
+use oximo_io::{to_lp_string, to_mps_string};
+
+/// max x + y  s.t.  1 <= x + y <= 4.
+fn range_model() -> Model {
+    let m = Model::new("rng");
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    constraint!(m, band, 1.0 <= x + y <= 4.0);
+    objective!(m, Max, x + y);
+    assert_eq!(m.num_constraints(), 1);
+    m
+}
+
+#[test]
+fn mps_emits_ranges_section() {
+    let s = to_mps_string(&range_model()).expect("mps writer");
+    // The range is an `L` row whose RHS is the upper bound
+    assert!(s.contains(" L  band"), "{s}");
+    assert!(s.contains("RHS       band      4"), "{s}");
+    // widened down to the lower bound by RANGES: R = upper - lower = 3.
+    assert!(s.contains("RANGES"), "{s}");
+    assert!(s.contains("RNG       band      3"), "{s}");
+}
+
+#[test]
+fn lp_expands_range_to_two_rows() {
+    let s = to_lp_string(&range_model()).expect("lp writer");
+    assert!(s.contains("band_lo:"), "{s}");
+    assert!(s.contains("band_hi:"), "{s}");
+    assert!(s.contains(">= 1"), "{s}");
+    assert!(s.contains("<= 4"), "{s}");
+}

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -1,8 +1,8 @@
 //! `constraint!(model, [name | name = expr | name[i in dom, ...]], <relation>)`,
 //! where `<relation>` is `lhs <op> rhs` or a two-sided range `lo <= e <= hi`
-//! (`hi >= e >= lo`). A range with constant bounds becomes a single interval
-//! constraint named `{name}`, if a bound is an expression/parameter it instead
-//! lowers to two rows, `{name}_lo` and `{name}_hi`.
+//! (`hi >= e >= lo`). A range with constant bounds and a linear body becomes a
+//! single interval constraint named `{name}`; expression/parameter bounds or a
+//! nonlinear body lower to two rows, `{name}_lo` and `{name}_hi`.
 
 use proc_macro2::{Spacing, Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -1,8 +1,8 @@
 //! `constraint!(model, [name | name = expr | name[i in dom, ...]], <relation>)`,
 //! where `<relation>` is `lhs <op> rhs` or a two-sided range `lo <= e <= hi`
-//! (`hi >= e >= lo`). A range lowers to two rows, `{name}_lo` and `{name}_hi`.
-
-// TODO: Improve so that ranges don't lower to two rows.
+//! (`hi >= e >= lo`). A range with constant bounds becomes a single interval
+//! constraint named `{name}`, if a bound is an expression/parameter it instead
+//! lowers to two rows, `{name}_lo` and `{name}_hi`.
 
 use proc_macro2::{Spacing, Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
@@ -28,24 +28,24 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let root = oximo_root();
 
     match second {
-        None => Ok(register_anonymous(&model, build_relations(first, &root)?, &root)),
+        None => Ok(register_anonymous(&model, build_relations(first, &root)?)),
         Some(rel_tokens) => {
             // Computed name at run-time: `constraint!(m, name = expr, <relation>)`.
             if let Some(name_expr) = computed_name(&first) {
                 let rel = build_relations(rel_tokens, &root)?;
-                return Ok(register_computed(&model, &name_expr, rel, &root));
+                return Ok(register_computed(&model, &name_expr, rel));
             }
 
             let Named { name, binds, cond } = parse_named(first)?;
             let name_str = name.to_string();
             let rel = build_relations(rel_tokens, &root)?;
             match binds {
-                None => Ok(register_named(&model, &name_str, rel, &root)),
+                None => Ok(register_named(&model, &name_str, rel)),
                 Some(binds) => {
                     let param = family_closure_param(&binds);
                     let set = build_set(&binds, &root);
                     let set = filtered_set(set, &binds, cond.as_ref(), &root);
-                    Ok(register_family(&model, &name_str, &set, &param, rel, &root))
+                    Ok(register_family(&model, &name_str, &set, &param, rel))
                 }
             }
         }
@@ -116,65 +116,31 @@ fn build_relations(tokens: TokenStream2, root: &TokenStream2) -> syn::Result<Rel
     }
 }
 
-/// The two relation tokens for a range: `mid >= lo` (the `_lo` row) and
-/// `mid <= hi` (the `_hi` row).
-fn range_rows(lo: &Expr, hi: &Expr, root: &TokenStream2) -> (TokenStream2, TokenStream2) {
-    (
-        quote!( #root::__macro_support::Relate::ge(__mid, #lo) ),
-        quote!( #root::__macro_support::Relate::le(__mid, #hi) ),
-    )
-}
-
-fn register_anonymous(model: &Expr, rel: Relations, root: &TokenStream2) -> TokenStream2 {
+fn register_anonymous(model: &Expr, rel: Relations) -> TokenStream2 {
     match rel {
         Relations::Single(r) => quote!( (#model).__add_constraint_auto(#r) ),
-        Relations::Range { mid, lo, hi } => {
-            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
-            quote! {{
-                let __mid = #mid;
-                (#model).__add_constraint_auto(#lo_rel);
-                (#model).__add_constraint_auto(#hi_rel);
-            }}
-        }
+        Relations::Range { mid, lo, hi } => quote! {
+            (#model).__add_range_auto(#mid, #lo, #hi)
+        },
     }
 }
 
-fn register_named(
-    model: &Expr,
-    name_str: &str,
-    rel: Relations,
-    root: &TokenStream2,
-) -> TokenStream2 {
+fn register_named(model: &Expr, name_str: &str, rel: Relations) -> TokenStream2 {
     match rel {
         Relations::Single(r) => quote!( (#model).__add_constraint(#name_str, #r) ),
-        Relations::Range { mid, lo, hi } => {
-            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
-            quote! {{
-                let __mid = #mid;
-                (#model).__add_constraint(::core::concat!(#name_str, "_lo"), #lo_rel);
-                (#model).__add_constraint(::core::concat!(#name_str, "_hi"), #hi_rel);
-            }}
-        }
+        Relations::Range { mid, lo, hi } => quote! {
+            (#model).__add_range(#name_str, #mid, #lo, #hi)
+        },
     }
 }
 
-fn register_computed(
-    model: &Expr,
-    name_expr: &TokenStream2,
-    rel: Relations,
-    root: &TokenStream2,
-) -> TokenStream2 {
+fn register_computed(model: &Expr, name_expr: &TokenStream2, rel: Relations) -> TokenStream2 {
     match rel {
         Relations::Single(r) => quote!( (#model).__add_constraint(#name_expr, #r) ),
-        Relations::Range { mid, lo, hi } => {
-            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
-            quote! {{
-                let __mid = #mid;
-                let __name = #name_expr;
-                (#model).__add_constraint(::std::format!("{__name}_lo"), #lo_rel);
-                (#model).__add_constraint(::std::format!("{__name}_hi"), #hi_rel);
-            }}
-        }
+        Relations::Range { mid, lo, hi } => quote! {{
+            let __name = #name_expr;
+            (#model).__add_range(&__name, #mid, #lo, #hi)
+        }},
     }
 }
 
@@ -184,20 +150,13 @@ fn register_family(
     set: &TokenStream2,
     param: &TokenStream2,
     rel: Relations,
-    root: &TokenStream2,
 ) -> TokenStream2 {
     match rel {
         Relations::Single(r) => quote! {
             (#model).__add_constraints_over(#name_str, &(#set), |#param| #r);
         },
-        Relations::Range { mid, lo, hi } => {
-            let (lo_rel, hi_rel) = range_rows(&lo, &hi, root);
-            quote! {
-                (#model).__add_range_constraints_over(#name_str, &(#set), |#param| {
-                    let __mid = #mid;
-                    (#lo_rel, #hi_rel)
-                });
-            }
-        }
+        Relations::Range { mid, lo, hi } => quote! {
+            (#model).__add_range_constraints_over(#name_str, &(#set), |#param| (#mid, #lo, #hi));
+        },
     }
 }

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -72,7 +72,7 @@ subtraction, and nonlinear operations (see [Nonlinear Expressions](#nonlinear-ex
 constraint!(m, cap, 2.0 * x + 3.0 * y <= 100.0);
 constraint!(m, demand, x >= 5.0);
 constraint!(m, balance, x - y == 0.0);
-constraint!(m, band, 1.0 <= x + y <= 10.0); // two-sided range -> band_lo + band_hi
+constraint!(m, band, 1.0 <= x + y <= 10.0); // two-sided range -> one constraint
 
 objective!(m, Min, 3.0 * x + 5.0 * y);
 // or

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -37,6 +37,24 @@ fn highs_multi_optima_returns_single_best() {
 }
 
 #[test]
+fn range_constraint_solves_as_single_row() {
+    // max x  s.t.  1 <= x <= 4.
+    let m = Model::new("range");
+    variable!(m, x);
+    constraint!(m, band, 1.0 <= x <= 4.0);
+    objective!(m, Max, x);
+
+    assert_eq!(m.num_constraints(), 1);
+
+    let r = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(r.termination, TerminationStatus::Optimal);
+    assert!((r.objective().unwrap() - 4.0).abs() < 1e-6);
+    assert!((r.value_of(x).unwrap() - 4.0).abs() < 1e-6);
+    let band = m.constraint_id("band").unwrap();
+    assert!(r.dual_of(band).is_some());
+}
+
+#[test]
 fn indexed_param_rebind_changes_solution() {
     // maximize sum_i price[i] * x[i] s.t. sum_i x[i] <= 1, 0 <= x <= 1.
     // With price = [1, 3, 2] the optimum loads x[1] (price 3) -> obj 3.


### PR DESCRIPTION
## Description

This PR adds support for single-row range constraints.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-sided range constraints can now collapse into a single constraint row when bounds are representable, improving exported model structure.

* **Bug Fixes**
  * Dual values and constraint/dual association for ranged constraints are now consistent across backends, including correct folding/accumulation when ranges are split or expanded.
  * Exporters and NL/MPS writers now emit accurate row/range metadata for ranged vs one-sided constraints.

* **Documentation**
  * README docs updated to clarify that two-sided range constraints produce a single constraint in supported cases.

* **Tests**
  * Added/updated end-to-end coverage for range constraint exporting and solving, including dual availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->