### PR TITLE
Split `ModelKind`, add SOC constraints and Clarabel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "amd"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a679e001575697a3bd195813feb57a4718ecc08dc194944015cbc5f6213c2b96"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,7 +41,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -50,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +76,38 @@ dependencies = [
  "bytes",
  "cfg_aliases",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -108,12 +158,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "clarabel"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d950c870fad4feed732bc3f7da489d223ba3911eac0522e6512eed7e659cfafe"
+dependencies = [
+ "amd",
+ "cfg-if",
+ "derive_builder",
+ "enum_dispatch",
+ "faer",
+ "faer-traits",
+ "itertools 0.11.0",
+ "lazy_static",
+ "num-traits",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "thiserror 1.0.69",
+ "web-time",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -140,6 +221,22 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cstr-enum"
@@ -183,10 +280,166 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro 0.2.1",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro 0.4.2",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -202,6 +455,59 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "faer"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe9ac2a073e05ca749eeea503fae16a91440b20d2e92b6fc6f6c6919b9964eb"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "equator 0.4.2",
+ "faer-macros",
+ "faer-traits",
+ "gemm",
+ "generativity",
+ "libm",
+ "nano-gemm",
+ "npyz",
+ "num-complex",
+ "num-traits",
+ "pulp",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "reborrow",
+]
+
+[[package]]
+name = "faer-macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1430e111b20872c7eaa82c7ada071bff1c3e3ac09cc6f4df676065fd2d41eb62"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "faer-macros",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp",
+ "reborrow",
 ]
 
 [[package]]
@@ -227,6 +533,176 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -287,6 +763,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +838,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -359,6 +863,23 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -381,6 +902,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -417,6 +944,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "nano-gemm"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5ba2bea1c00e53de11f6ab5bd0761ba87dc0045d63b0c87ee471d2d3061376"
+dependencies = [
+ "equator 0.2.2",
+ "nano-gemm-c32",
+ "nano-gemm-c64",
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "nano-gemm-f32",
+ "nano-gemm-f64",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40449e57a5713464c3a1208c4c3301c8d29ee1344711822cf022bc91373a91b"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743a6e6211358fba85d1009616751e4107da86f4c95b24e684ce85f25c25b3bf"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963bf7c7110d55430169dc74c67096375491ed580cd2ef84842550ac72e781fa"
+
+[[package]]
+name = "nano-gemm-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3fc4f83ae8861bad79dc3c016bd6b0220da5f9de302e07d3112d16efc24aa6"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3681b7ce35658f79da94b7f62c60a005e29c373c7111ed070e3bf64546a8bb"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1e619ed04d801809e1f63e61b669d380c4119e8b0cdd6ed184c6b111f046d8"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,12 +1039,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "npyz"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0e759e014e630f90af745101b614f761306ddc541681e546649068e25ec1b9"
+dependencies = [
+ "byteorder",
+ "num-bigint",
+ "py_literal",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -466,6 +1086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -479,6 +1100,7 @@ name = "oximo"
 version = "0.3.0"
 dependencies = [
  "oximo-baron",
+ "oximo-clarabel",
  "oximo-core",
  "oximo-expr",
  "oximo-gams",
@@ -499,6 +1121,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "oximo-clarabel"
+version = "0.3.0"
+dependencies = [
+ "clarabel",
+ "oximo-core",
+ "oximo-expr",
+ "oximo-highs",
+ "oximo-solver",
+ "rustc-hash",
+]
+
+[[package]]
 name = "oximo-core"
 version = "0.3.0"
 dependencies = [
@@ -510,7 +1144,7 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "smol_str",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -519,7 +1153,7 @@ version = "0.3.0"
 dependencies = [
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -531,7 +1165,7 @@ dependencies = [
  "oximo-solver",
  "rayon",
  "rustc-hash",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -543,7 +1177,7 @@ dependencies = [
  "oximo-expr",
  "oximo-solver",
  "rustc-hash",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -556,7 +1190,7 @@ dependencies = [
  "oximo-solver",
  "rayon",
  "rustc-hash",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -567,7 +1201,7 @@ dependencies = [
  "oximo-expr",
  "rustc-hash",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -587,8 +1221,63 @@ dependencies = [
  "oximo-core",
  "oximo-expr",
  "rustc-hash",
- "thiserror",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -603,6 +1292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -634,6 +1332,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +1372,55 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "rawpointer"
@@ -673,6 +1447,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "regex"
@@ -723,16 +1503,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -742,6 +1543,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -778,10 +1588,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -798,6 +1625,12 @@ dependencies = [
  "borsh",
  "serde_core",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -822,16 +1655,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -840,7 +1696,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -885,6 +1752,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +1774,28 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -912,6 +1813,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -946,6 +1892,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1064,6 +2029,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/oximo-gurobi",
     "crates/oximo-gams",
     "crates/oximo-baron",
+    "crates/oximo-clarabel",
     "crates/oximo",
 ]
 
@@ -35,6 +36,7 @@ oximo-io     = { path = "crates/oximo-io",     version = "0.3.0" }
 oximo-gurobi = { path = "crates/oximo-gurobi", version = "0.3.0" }
 oximo-gams   = { path = "crates/oximo-gams",   version = "0.3.0" }
 oximo-baron  = { path = "crates/oximo-baron",  version = "0.3.0" }
+oximo-clarabel = { path = "crates/oximo-clarabel", version = "0.3.0" }
 
 rayon            = "1.12"
 syn              = { version = "2", features = ["full"] }
@@ -49,6 +51,7 @@ thiserror        = "2.0"
 num-traits       = "0.2"
 highs            = "2.3"
 grb              = "3.0"    
+clarabel         = "0.11"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -172,15 +172,17 @@ let sparse = Set::from_ints([0, 2, 4, 8]);
 ### Nonlinear expressions
 
 `Pow`, `Sin`, `Cos`, `Exp`, `Log`, `Abs`, and bilinear products are first-class. The
-model's kind (`LP`/`MILP`/`QP`/`MIQP`/`NLP`/`MINLP`) is inferred from the
-expressions.
+model's kind is inferred from the expressions.
 
 ```rust,ignore
 // Rosenbrock NLP
 objective!(m, Min, (1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
 
-// Quadratic constraint
+// Quadratic constraint (model kind: QCP)
 constraint!(m, disk, x.powi(2) + y.powi(2) <= 1.0);
+
+// Second-order cone ||(x, y)|| <= t (model kind: SOCP)
+soc_constraint!(m, cone, [x, y] <= t);
 
 // Transcendental utility (MINLP when any variable is integer/binary)
 objective!(m, Max, sum!(u[i] * (1.0 + w[i] * x[i]).log() for i in items));
@@ -198,13 +200,14 @@ pub trait Solver {
 
 ## Features
 
-| Feature  | What it adds                                                          | Default |
-|----------|-----------------------------------------------------------------------|---------|
-| `highs`  | HiGHS - LP/MILP/QP solver (bundled, no install)                       | yes     |
-| `io`     | MPS and LP file writers                                               | yes     |
-| `gurobi` | Gurobi - LP/MILP/QP/MIQP/NLP/MINLP solver (requires licensed install) | no      |
-| `gams`   | GAMS bridge - LP/MILP/QP/MIQP/NLP/MINLP depending on solver           | no      |
-| `baron`  | BARON  - LP/MILP/QP/MIQP/NLP/MINLP solver (requires licensed install) | no      |
+| Feature    | What it adds                                                 | Default |
+|------------|--------------------------------------------------------------|---------|
+| `highs`    | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
+| `io`       | MPS and LP file writers                                      | yes     |
+| `gurobi`   | Gurobi solver (requires licensed install)                    | no      |
+| `gams`     | GAMS bridge - solve type depends on the selected sub-solver  | no      |
+| `baron`    | BARON - global LP...MINLP solver (requires licensed install) | no      |
+| `clarabel` | Clarabel - LP/QP/SOCP conic solver (pure Rust, no install)   | no      |
 
 ### HiGHS (default)
 
@@ -220,6 +223,12 @@ let result = Highs.solve(&m, &HighsOptions::default()
     .mip_gap(0.01)
     .method(HighsMethod::Ipm))?;
 ```
+
+### Clarabel
+
+Pure-Rust conic interior-point solver, no install or license. Solves continuous
+LP, QP (convex quadratic objectives), and SOCP models. See
+[`crates/oximo-clarabel/README.md`](crates/oximo-clarabel/README.md).
 
 ### Gurobi
 

--- a/crates/oximo-baron/src/lib.rs
+++ b/crates/oximo-baron/src/lib.rs
@@ -42,6 +42,22 @@ impl Baron {
 /// and the `solver_name` stamped on every [`SolverResult`].
 pub(crate) const NAME: &str = "BARON";
 
+pub(crate) const fn supported(kind: ModelKind) -> bool {
+    matches!(
+        kind,
+        ModelKind::LP
+            | ModelKind::MILP
+            | ModelKind::QP
+            | ModelKind::MIQP
+            | ModelKind::QCP
+            | ModelKind::MIQCP
+            | ModelKind::SOCP
+            | ModelKind::MISOCP
+            | ModelKind::NLP
+            | ModelKind::MINLP
+    )
+}
+
 impl Solver for Baron {
     type Options = BaronOptions;
 
@@ -50,16 +66,7 @@ impl Solver for Baron {
     }
 
     fn supports(&self, kind: ModelKind) -> bool {
-        // BARON is a global solver for all of the following model classes.
-        matches!(
-            kind,
-            ModelKind::LP
-                | ModelKind::MILP
-                | ModelKind::QP
-                | ModelKind::MIQP
-                | ModelKind::NLP
-                | ModelKind::MINLP
-        )
+        supported(kind)
     }
 
     fn solve(&mut self, model: &Model, opts: &BaronOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -6,7 +6,7 @@ use std::{fs, io};
 
 use oximo_core::{
     Constraint, ConstraintId, Domain, Model, Objective, ObjectiveSense, Sense, SocConstraint,
-    VarId, Variable,
+    SocConstraintId, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
@@ -43,7 +43,7 @@ pub fn solve(
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
     let sense = model.objective().as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
-    let (bar, var_order, con_order) = build_bar(model, opts)?;
+    let (bar, var_order, con_order, soc_bounds) = build_bar(model, opts)?;
 
     // - Temp directory. Combine a timestamp with a per-process atomic counter so
     //   concurrent invocations never share a directory.
@@ -121,20 +121,22 @@ pub fn solve(
     let tim = fs::read_to_string(&tim_path)
         .map_err(|e| SolverError::Backend(format!("cannot read times file: {e}")))?;
     let res = fs::read_to_string(tmp_dir.join(RES_NAME)).unwrap_or_default();
-    let result = parse_solution(&tim, &res, sense, elapsed, raw_log, &var_order, &con_order);
+    let result =
+        parse_solution(&tim, &res, sense, elapsed, raw_log, &var_order, &con_order, &soc_bounds);
 
     let _ = fs::remove_dir_all(&tmp_dir);
     Ok(result)
 }
 
-/// Build the full `.bar` file text for `model`, returning it alongside the
+/// Everything `solve` needs from the `.bar` writer: the file text, the
 /// variable declaration order (see [`write_var_declarations`]) used to decode
-/// BARON's numeric solution-pool blocks, and the constraint emit-order (see
-/// [`write_equations`]) used to fold range duals back onto their `ConstraintId`.
-fn build_bar(
-    model: &Model,
-    opts: &BaronOptions,
-) -> Result<(String, Vec<VarId>, Vec<ConstraintId>), SolverError> {
+/// BARON's numeric solution-pool blocks, the constraint emit-order (see
+/// [`write_equations`]) used to fold range duals back onto their
+/// `ConstraintId`, and the affine bound side of each explicit SOC constraint
+/// used to rescale its squared-row price to the norm form.
+type BarParts = (String, Vec<VarId>, Vec<ConstraintId>, Vec<LinearTerms>);
+
+fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError> {
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
@@ -148,7 +150,11 @@ fn build_bar(
     let con_order = write_equations(&mut bar, &arena, &constraints, &socs)?;
     write_objective(&mut bar, &arena, objective.as_ref())?;
     write_starting_point(&mut bar, &vars);
-    Ok((bar, var_order, con_order))
+    let soc_bounds = socs
+        .iter()
+        .map(|s| extract_linear(&arena, s.bound).expect("SOC bound is validated affine"))
+        .collect();
+    Ok((bar, var_order, con_order, soc_bounds))
 }
 
 // - .bar writers
@@ -584,6 +590,7 @@ fn fmt(v: f64) -> String {
 /// branch-and-reduce iterations, `[11]` node where the optimum was found
 /// (`-3` => no solution), last = wall time. The termination reason comes from
 /// the `res.lst` banner (see [`map_status`]), not the numeric `[7]` solver status.
+#[allow(clippy::too_many_arguments)]
 fn parse_solution(
     tim: &str,
     res: &str,
@@ -592,6 +599,7 @@ fn parse_solution(
     raw_log: Option<String>,
     var_order: &[VarId],
     con_order: &[ConstraintId],
+    soc_bounds: &[LinearTerms],
 ) -> SolverResult {
     let tokens: Vec<&str> = tim.split_whitespace().collect();
     let int_at = |i: usize| tokens.get(i).and_then(|s| s.parse::<i64>().ok());
@@ -629,11 +637,31 @@ fn parse_solution(
         solutions.push(SolutionPoint { primal: FxHashMap::default(), objective });
     }
 
-    let (dual, reduced_costs) = if has_sol {
+    let (dual, reduced_costs, soc_prices) = if has_sol {
         parse_dual_solution(res, var_order, con_order)
     } else {
-        (FxHashMap::default(), FxHashMap::default())
+        (FxHashMap::default(), FxHashMap::default(), FxHashMap::default())
     };
+
+    // Rescale each SOC squared-row price to the norm-form bound multiplier
+    // using the bound's value at the best primal point.
+    let mut soc_dual: FxHashMap<SocConstraintId, f64> = FxHashMap::default();
+    if let Some(best) = solutions.first() {
+        for (i, bound) in soc_bounds.iter().enumerate() {
+            if let Some(price) = soc_prices.get(&i) {
+                let b_val = bound.constant
+                    + bound
+                        .coeffs
+                        .iter()
+                        .map(|&(v, c)| c * best.primal.get(&v).copied().unwrap_or(0.0))
+                        .sum::<f64>();
+                soc_dual.insert(
+                    SocConstraintId(u32::try_from(i).expect("SOC count overflow")),
+                    2.0 * b_val * price.abs(),
+                );
+            }
+        }
+    }
 
     // A point is only usable if it carries primal values.
     let has_usable_primal = solutions.iter().any(|s| !s.primal.is_empty());
@@ -647,6 +675,7 @@ fn parse_solution(
     SolverResult {
         solutions,
         dual,
+        soc_dual,
         reduced_costs,
         termination,
         primal_status,
@@ -818,28 +847,31 @@ fn parse_solution_pool(res: &str, var_order: &[VarId]) -> Vec<SolutionPoint> {
     out
 }
 
+/// `(dual, reduced_costs, soc_prices)` parsed from BARON's dual section.
+/// `soc_prices` keys the raw price of each appended SOC quadratic row by cone
+/// index (its sign row is skipped).
+type DualParts = (FxHashMap<ConstraintId, f64>, FxHashMap<VarId, f64>, FxHashMap<usize, f64>);
+
 /// Parse the dual solution BARON prints
 ///
 /// Variable marginals are reduced costs, keyed by 1-based position in the
 /// `.bar` declaration order (`var_order`, as in [`parse_solution_pool`]).
 /// Constraint prices are duals, keyed by 1-based position in the `EQUATIONS`
-/// order, which is the `ConstraintId` index plus one. Values are passed
-/// through with BARON's sign convention.
+/// order, which is the `ConstraintId` index plus one; positions past
+/// `con_order` are the appended SOC `(quadratic row, sign row)` pairs in cone
+/// order. Values are passed through with BARON's sign convention.
 ///
 /// Returns empty maps when the section is absent (e.g. `WantDual` off, or
 /// BARON reported "No dual information is available").
-fn parse_dual_solution(
-    res: &str,
-    var_order: &[VarId],
-    con_order: &[ConstraintId],
-) -> (FxHashMap<ConstraintId, f64>, FxHashMap<VarId, f64>) {
+fn parse_dual_solution(res: &str, var_order: &[VarId], con_order: &[ConstraintId]) -> DualParts {
     let mut dual: FxHashMap<ConstraintId, f64> = FxHashMap::default();
     let mut reduced_costs: FxHashMap<VarId, f64> = FxHashMap::default();
+    let mut soc_prices: FxHashMap<usize, f64> = FxHashMap::default();
     // BARON may print the dual vector more than once (e.g. for a solution
     // found during preprocessing and again after `*** Normal completion ***`);
     // the last block is the one for the final best point.
     let Some(pos) = res.rfind("Corresponding dual solution vector") else {
-        return (dual, reduced_costs);
+        return (dual, reduced_costs, soc_prices);
     };
     let strip = |l: &str| l.trim_start().trim_start_matches(">>>").trim().to_string();
 
@@ -871,12 +903,20 @@ fn parse_dual_solution(
         if in_prices {
             if let Some(&id) = con_order.get(k - 1) {
                 *dual.entry(id).or_insert(0.0) += val;
+            } else {
+                // Past the ConstraintId rows: the appended SOC pairs, two
+                // rows per cone. Keep the quadratic row's price, skip the
+                // sign row's.
+                let rel = k - con_order.len() - 1;
+                if rel % 2 == 0 {
+                    soc_prices.insert(rel / 2, val);
+                }
             }
         } else if k <= var_order.len() {
             reduced_costs.insert(var_order[k - 1], val);
         }
     }
-    (dual, reduced_costs)
+    (dual, reduced_costs, soc_prices)
 }
 
 /// Parse the single `"The best solution found is:"` table: rows of
@@ -1203,6 +1243,7 @@ mod tests {
             None,
             &[],
             &[],
+            &[],
         );
         assert_eq!(r.termination, TerminationStatus::Optimal);
         assert_eq!(r.objective(), Some(9.5)); // upper bound for minimize
@@ -1213,6 +1254,7 @@ mod tests {
             ObjectiveSense::Maximize,
             std::time::Duration::ZERO,
             None,
+            &[],
             &[],
             &[],
         );
@@ -1302,7 +1344,7 @@ The best solution found is:
 
 The above solution has an objective value of:    5.0
 ";
-        let (dual, rc) =
+        let (dual, rc, _soc) =
             parse_dual_solution(res, &[VarId(0), VarId(1)], &[ConstraintId(0), ConstraintId(1)]);
         assert_eq!(rc.get(&VarId(0)), Some(&0.0));
         assert_eq!(rc.get(&VarId(1)), Some(&-0.5));
@@ -1344,7 +1386,7 @@ The above solution has an objective value of:    5.0
 
 The best solution found is:
 ";
-        let (dual, rc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
+        let (dual, rc, _soc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
         assert_eq!(rc.get(&VarId(0)), Some(&0.0));
         assert_eq!(dual.get(&ConstraintId(0)), Some(&1.0));
     }
@@ -1359,10 +1401,28 @@ The best solution found is:
  >>>       1             2.0000000000000000000000
  >>>       2            -.50000000000000000000000
 ";
-        let (dual, _rc) =
+        let (dual, _rc, _soc) =
             parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0), ConstraintId(0)]);
         assert_eq!(dual.len(), 1);
         assert_eq!(dual.get(&ConstraintId(0)), Some(&1.5)); // 2.0 + (-0.5)
+    }
+
+    #[test]
+    fn parse_dual_maps_soc_rows_past_constraint_order() {
+        let res = "\
+ >>> Corresponding dual solution vector is:
+ >>> Variable no.              Marginal
+ >>>       1             0.0000000000000000000000
+ >>> Constraint no.             Price
+ >>>       1             2.0000000000000000000000
+ >>>       2            -.75000000000000000000000
+ >>>       3             0.0000000000000000000000
+";
+        let (dual, _rc, soc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
+        assert_eq!(dual.get(&ConstraintId(0)), Some(&2.0));
+        assert_eq!(dual.len(), 1);
+        assert_eq!(soc.get(&0), Some(&-0.75));
+        assert_eq!(soc.len(), 1);
     }
 
     #[test]
@@ -1379,9 +1439,10 @@ No dual information is available.
 
 The best solution found is:
 ";
-        let (dual, rc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
+        let (dual, rc, soc) = parse_dual_solution(res, &[VarId(0)], &[ConstraintId(0)]);
         assert!(dual.is_empty());
         assert!(rc.is_empty());
+        assert!(soc.is_empty());
     }
 
     #[test]
@@ -1425,6 +1486,7 @@ The above solution has an objective value of:  0.0
             None,
             &[VarId(0), VarId(1)],
             &[ConstraintId(0)],
+            &[],
         );
         assert_eq!(r.result_count(), 2);
         assert_eq!(r.reduced_costs.get(&VarId(1)), Some(&1.5));
@@ -1446,6 +1508,7 @@ The above solution has an objective value of:  0.0
             std::time::Duration::ZERO,
             None,
             &[VarId(0)],
+            &[],
             &[],
         );
         assert_eq!(r.result_count(), 1);

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -259,8 +259,6 @@ fn upper_bound_to_emit(v: &Variable) -> Option<f64> {
     }
 }
 
-// TODO: Report SOC duals
-
 /// Write the `EQUATIONS` block, returning the emit-order map.
 /// The `ConstraintId` behind each emitted equation, in BARON's 1-based
 /// "Constraint no." order. BARON has no two-sided equation,

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 use std::{fs, io};
 
 use oximo_core::{
-    Constraint, ConstraintId, Domain, Model, Objective, ObjectiveSense, Sense, VarId, Variable,
+    Constraint, ConstraintId, Domain, Model, Objective, ObjectiveSense, Sense, SocConstraint,
+    VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
@@ -137,13 +138,14 @@ fn build_bar(
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
+    let socs = model.soc_constraints();
     let objective = model.objective();
 
     let mut bar = String::with_capacity(4096);
     write_options(&mut bar, opts, RES_NAME, TIM_NAME);
     let var_order = write_var_declarations(&mut bar, &vars)?;
     write_bounds(&mut bar, &vars);
-    let con_order = write_equations(&mut bar, &arena, &constraints)?;
+    let con_order = write_equations(&mut bar, &arena, &constraints, &socs)?;
     write_objective(&mut bar, &arena, objective.as_ref())?;
     write_starting_point(&mut bar, &vars);
     Ok((bar, var_order, con_order))
@@ -251,6 +253,8 @@ fn upper_bound_to_emit(v: &Variable) -> Option<f64> {
     }
 }
 
+// TODO: Report SOC duals
+
 /// Write the `EQUATIONS` block, returning the emit-order map.
 /// The `ConstraintId` behind each emitted equation, in BARON's 1-based
 /// "Constraint no." order. BARON has no two-sided equation,
@@ -261,13 +265,14 @@ fn write_equations(
     bar: &mut String,
     arena: &ExprArena,
     constraints: &[Constraint],
+    socs: &[SocConstraint],
 ) -> Result<Vec<ConstraintId>, SolverError> {
     let mut emit_map: Vec<ConstraintId> = Vec::with_capacity(constraints.len());
-    if constraints.is_empty() {
+    if constraints.is_empty() && socs.is_empty() {
         return Ok(emit_map);
     }
 
-    let mut names: Vec<String> = Vec::with_capacity(constraints.len());
+    let mut names: Vec<String> = Vec::with_capacity(constraints.len() + 2 * socs.len());
     for (i, c) in constraints.iter().enumerate() {
         let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
         if c.is_range() {
@@ -279,6 +284,10 @@ fn write_equations(
             names.push(format!("c{i}"));
             emit_map.push(id);
         }
+    }
+    for i in 0..socs.len() {
+        names.push(format!("soc{i}"));
+        names.push(format!("soc{i}_sign"));
     }
     writeln!(bar, "EQUATIONS {};", names.join(", ")).unwrap();
 
@@ -308,8 +317,35 @@ fn write_equations(
             write_constraint_body(bar, arena, c.lhs, "<=", c.upper)?;
         }
     }
+    write_soc_rows(bar, arena, socs);
     writeln!(bar).unwrap();
     Ok(emit_map)
+}
+
+/// Emit each explicit SOC constraint `||terms||_2 <= bound` as the polynomial
+/// row `(term_1)^2 + ... - (bound)^2 <= 0` plus the sign row `bound >= 0`
+/// (squaring loses the sign of the bound side).
+fn write_soc_rows(bar: &mut String, arena: &ExprArena, socs: &[SocConstraint]) {
+    for (i, s) in socs.iter().enumerate() {
+        write!(bar, "soc{i}: ").unwrap();
+        for (k, &term) in s.terms.iter().enumerate() {
+            if k > 0 {
+                write!(bar, " + ").unwrap();
+            }
+            let t = extract_linear(arena, term).expect("SOC members are validated affine");
+            write!(bar, "(").unwrap();
+            write_linear(bar, &t, true);
+            write!(bar, ")^2").unwrap();
+        }
+        let b = extract_linear(arena, s.bound).expect("SOC bound is validated affine");
+        write!(bar, " - (").unwrap();
+        write_linear(bar, &b, true);
+        writeln!(bar, ")^2 <= 0;").unwrap();
+
+        write!(bar, "soc{i}_sign: ").unwrap();
+        write_linear(bar, &b, true);
+        writeln!(bar, " >= 0;").unwrap();
+    }
 }
 
 /// Emit one constraint body `<lhs> <op> <rhs>;`. Linear constraints fold the
@@ -958,6 +994,26 @@ mod tests {
         assert!(bar.contains("INTEGER_VARIABLES x1;"), "{bar}");
         assert!(bar.contains("POSITIVE_VARIABLES x2;"), "{bar}");
         assert!(bar.contains("OBJ: maximize"), "{bar}");
+    }
+
+    #[test]
+    fn explicit_soc_emits_squared_rows_and_sign_row() {
+        let m = Model::new("socp");
+        variable!(m, -10.0 <= x <= 10.0);
+        variable!(m, -10.0 <= y <= 10.0);
+        variable!(m, t >= 0.0);
+        m.add_soc_constraint("cone", [x, y], t);
+        constraint!(m, c, x + y >= 1.0);
+        objective!(m, Min, t);
+        assert_eq!(m.kind(), ModelKind::SOCP);
+
+        let bar = render(&m);
+        assert!(bar.contains("EQUATIONS c0, soc0, soc0_sign;"), "declares SOC rows last:\n{bar}");
+        assert!(bar.contains("soc0: "), "emits SOC row:\n{bar}");
+        assert!(bar.contains(")^2"), "squares members:\n{bar}");
+        assert!(bar.contains(")^2 <= 0;"), "row against 0:\n{bar}");
+        assert!(bar.contains("soc0_sign: "), "emits sign row:\n{bar}");
+        assert!(bar.contains(">= 0;"), "sign row nonneg:\n{bar}");
     }
 
     #[test]

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -649,12 +649,11 @@ fn parse_solution(
     if let Some(best) = solutions.first() {
         for (i, bound) in soc_bounds.iter().enumerate() {
             if let Some(price) = soc_prices.get(&i) {
-                let b_val = bound.constant
-                    + bound
-                        .coeffs
-                        .iter()
-                        .map(|&(v, c)| c * best.primal.get(&v).copied().unwrap_or(0.0))
-                        .sum::<f64>();
+                let Some(b_val) = bound.coeffs.iter().try_fold(bound.constant, |acc, &(v, c)| {
+                    best.primal.get(&v).map(|value| acc + c * *value)
+                }) else {
+                    continue;
+                };
                 soc_dual.insert(
                     SocConstraintId(u32::try_from(i).expect("SOC count overflow")),
                     2.0 * b_val * price.abs(),

--- a/crates/oximo-clarabel/Cargo.toml
+++ b/crates/oximo-clarabel/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "Clarabel LP/QP/SOCP conic backend for oximo"
+readme = "README.md"
 
 [features]
 faer = ["clarabel/faer-sparse"]

--- a/crates/oximo-clarabel/Cargo.toml
+++ b/crates/oximo-clarabel/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "oximo-clarabel"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Clarabel LP/QP/SOCP conic backend for oximo"
+
+[features]
+faer = ["clarabel/faer-sparse"]
+
+[dependencies]
+oximo-expr.workspace = true
+oximo-core.workspace = true
+oximo-solver.workspace = true
+clarabel.workspace = true
+rustc-hash.workspace = true
+
+[dev-dependencies]
+oximo-highs.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oximo-clarabel/README.md
+++ b/crates/oximo-clarabel/README.md
@@ -1,0 +1,163 @@
+# oximo-clarabel
+
+[Clarabel](https://clarabel.org) backend for [oximo](https://github.com/oximo-rs/oximo).
+
+Wraps the [`clarabel`](https://crates.io/crates/clarabel) crate: an open-source,
+pure-Rust interior-point solver for convex conic programs. Supports `LP`, convex `QP`
+(quadratic objective, linear constraints), and `SOCP` model kinds. It has no
+integer support, so mixed-integer models are rejected.
+
+## Usage
+
+Enable the `clarabel` feature on the umbrella `oximo` crate:
+
+```toml
+[dependencies]
+oximo = { version = "0.3", features = ["clarabel"] }
+```
+
+To use this crate directly:
+
+```toml
+[dependencies]
+oximo-clarabel = "0.3"
+oximo-core     = "0.3"
+oximo-solver   = "0.3"
+```
+
+The optional `faer` feature adds the [faer](https://crates.io/crates/faer)
+sparse LDL factorization as an alternative KKT backend.
+
+## Quick example
+
+```rust,no_run
+use oximo_core::prelude::*;
+use oximo_clarabel::{Clarabel, ClarabelOptions};
+use oximo_solver::{Solver, TerminationStatus};
+
+let m = Model::new("socp");
+variable!(m, x);
+variable!(m, y);
+variable!(m, t >= 0.0);
+m.fix(t, 1.0);
+soc_constraint!(m, disk, [x, y] <= t); // ||(x, y)||_2 <= t
+objective!(m, Min, x + y);
+
+let result = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap();
+assert_eq!(result.termination, TerminationStatus::Optimal);
+println!("obj = {}", result.objective().unwrap()); // -sqrt(2)
+```
+
+Run the bundled SOCP example:
+
+```sh
+cargo run -p oximo --example gradostat_multiperiod_socp --features clarabel
+```
+
+## Supported model kinds
+
+| Kind                                           | Supported                                                                                                                 |
+|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `LP`                                           | Yes                                                                                                                       |
+| `QP` (quadratic objective, linear constraints) | Yes, the objective Hessian must be positive semidefinite (Clarabel does not check and a non-convex `P` fails numerically) |
+| `SOCP`                                         | Yes                                                                                                                       |
+| `MILP`/`MIQP`/`MISOCP`                         | No, Clarabel has no integer support (returned as `UnsupportedKind`)                                                       |
+| `QCP`/`MIQCP`                                  | No, convex-QCP-to-SOC reformulation is not implemented. Write the constraint in SOC form instead.                         |
+
+A quadratic constraint that is already SOC-shaped (`sum p_i x_i^2 <= n t^2`,
+`t >= 0`) is detected as `SOCP` and solved, a general convex quadratic
+constraint is not.
+
+## Persistent handle (repeated solves)
+
+`Clarabel.solve` builds a fresh solver for each call. When you re-solve one model
+many times (parameter sweeps, sensitivity studies, column generation, rolling
+horizons, etc) build a resident handle with `Clarabel.persistent()` and call
+`solve` on it instead. `ClarabelPersistent` is a plain `Solver`. When the next
+model has the same dimensions, cone layout, and `P`/`A` sparsity pattern, only
+the numeric data (`P`, `q`, `A`, `b`) is overwritten in place via Clarabel's
+`update_data`, reusing the KKT symbolic factorization. Any structural change
+(added/removed rows or columns, a changed sparsity pattern, a new cone, or a
+flipped constraint sense that moves a row between cones) triggers a transparent
+rebuild, so results always match a cold solve.
+
+## Convex quadratic objectives (QP)
+
+A quadratic objective (e.g. `x.powi(2)`, `x * y`) with linear constraints is
+detected as `QP`. oximo derives the Hessian from the objective and Clarabel
+minimizes `c'x + 0.5·x'Px`.
+
+> **Convexity.** Clarabel solves only convex QPs. For minimization `P` must be
+> positive semidefinite; for maximization, negative semidefinite. Clarabel does
+> not check this, so an indefinite or incorrectly signed Hessian may fail
+> numerically or return a non-optimal point.
+
+## Options
+
+`ClarabelOptions` is a typed builder. All methods return `Self` for chaining,
+and every field is `Option`. `None` leaves Clarabel's own default in place.
+
+### Universal options (via `UniversalOptionsExt`)
+
+| Method                  | Clarabel setting                           | Default |
+|-------------------------|--------------------------------------------|---------|
+| `.time_limit(Duration)` | `time_limit`                               | none    |
+| `.threads(usize)`       | `max_threads` (KKT solvers only, see note) | none    |
+| `.verbose(bool)`        | `verbose`                                  | none    |
+
+`.threads` maps to `max_threads`, which only affects multithreaded KKT solvers.
+The default `qdldl` is single-threaded.
+
+### Clarabel options (selected)
+
+| Method                                      | Clarabel setting                | Default |
+|---------------------------------------------|---------------------------------|---------|
+| `.direct_solve_method(ClarabelDirectSolve)` | `direct_solve_method`           | `Auto`  |
+| `.max_iter(u32)`                            | `max_iter`                      | `200`   |
+| `.max_step_fraction(f64)`                   | `max_step_fraction`             | `0.99`  |
+| `.tol_gap_abs(f64)`                         | `tol_gap_abs`                   | `1e-8`  |
+| `.tol_gap_rel(f64)`                         | `tol_gap_rel`                   | `1e-8`  |
+| `.tol_feas(f64)`                            | `tol_feas`                      | `1e-8`  |
+| `.tol_infeas_abs(f64)`                      | `tol_infeas_abs`                | `1e-8`  |
+| `.tol_infeas_rel(f64)`                      | `tol_infeas_rel`                | `1e-8`  |
+| `.tol_ktratio(f64)`                         | `tol_ktratio`                   | `1e-6`  |
+| `.equilibrate_enable(bool)`                 | `equilibrate_enable`            | `true`  |
+| `.static_regularization_enable(bool)`       | `static_regularization_enable`  | `true`  |
+| `.dynamic_regularization_enable(bool)`      | `dynamic_regularization_enable` | `true`  |
+| `.iterative_refinement_enable(bool)`        | `iterative_refinement_enable`   | `true`  |
+| `.presolve_enable(bool)`                    | `presolve_enable`               | `true`  |
+| `.input_sparse_dropzeros(bool)`             | `input_sparse_dropzeros`        | `false` |
+
+There is also a matching set of low-accuracy fallback tolerances
+(`reduced_tol_*`) and further equilibration, line-search, and regularization
+options. The full list is in [src/options.rs](src/options.rs).
+
+```rust,ignore
+use oximo_clarabel::{ClarabelOptions, ClarabelDirectSolve};
+use oximo_solver::UniversalOptionsExt;
+
+let opts = ClarabelOptions::default()
+    .max_iter(100)
+    .tol_gap_rel(1e-9)
+    .direct_solve_method(ClarabelDirectSolve::Qdldl)
+    .verbose(true);
+```
+
+## Result
+
+`SolverResult` fields, populated whenever a usable point is available
+(`primal_status` is `FeasiblePoint` or `OptimalPoint`):
+
+- `solutions` - primal points (`Vec<SolutionPoint>`). This backend returns a single point holding the `primal` values keyed by `VarId` and the `objective` (adjusted for the objective sign and any constant term). Access via `result.objective()` / `result.value_of(var)`
+- `dual` - constraint duals, keyed by `ConstraintId`, access via `result.dual_of(c)`. Reported for equality and single-sided/range linear constraints in the LP convention (`gradient = A' y` of the problem as posed)
+- `soc_dual` - for each explicit `soc_constraint!`, its norm-form bound multiplier (`z0`), keyed by `SocConstraintId`, access via `result.soc_dual_of(soc)`
+- `reduced_costs` - not populated by this backend (always empty)
+- `termination` - why the solve stopped, mapped from Clarabel's `SolverStatus`: `Optimal` (`Solved`), `Infeasible` (`PrimalInfeasible`), `Unbounded` (`DualInfeasible`), `IterationLimit` (`MaxIterations`), `TimeLimit` (`MaxTime`), `Interrupted` (`AlmostSolved`), `NumericError` (`NumericalError` / `InsufficientProgress`), `NotSolved` (`Unsolved`)
+- `primal_status` - whether a usable point came back (`NoSolution` / `FeasiblePoint` / `OptimalPoint`), `result.has_solution()` is the shortcut
+- `best_bound` / `gap` - always `None` (conic solver, no MIP bound)
+- `solve_time` - wall time measured around the Clarabel solve call
+- `iterations` - interior-point iteration count
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/oximo-clarabel/src/lib.rs
+++ b/crates/oximo-clarabel/src/lib.rs
@@ -1,0 +1,59 @@
+#![doc = include_str!("../README.md")]
+
+mod options;
+mod persistent;
+mod translate;
+
+pub use options::{ClarabelDirectSolve, ClarabelOptions};
+pub use persistent::ClarabelPersistent;
+pub use translate::solve;
+
+use oximo_core::{Model, ModelKind};
+use oximo_solver::{PersistentSolver, Solver, SolverError, SolverResult};
+
+/// Clarabel solver handle.
+///
+/// Clarabel is a pure-Rust interior-point solver for convex conic programs:
+/// linear programs, convex quadratic objectives, and second-order cone
+/// constraints.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Clarabel;
+
+/// Display name for this backend; the single source for both [`Solver::name`]
+/// and the `solver_name` stamped on every [`SolverResult`].
+pub(crate) const NAME: &str = "Clarabel";
+
+/// The model kinds Clarabel can solve: continuous LP, quadratic-objective QP,
+/// and SOCP.
+/// QCP is out until convex quadratic constraints are reformulated to SOC.
+pub(crate) const fn supported(kind: ModelKind) -> bool {
+    matches!(kind, ModelKind::LP | ModelKind::QP | ModelKind::SOCP)
+}
+
+impl Solver for Clarabel {
+    type Options = ClarabelOptions;
+
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn supports(&self, kind: ModelKind) -> bool {
+        supported(kind)
+    }
+
+    fn solve(
+        &mut self,
+        model: &Model,
+        opts: &ClarabelOptions,
+    ) -> Result<SolverResult, SolverError> {
+        translate::solve(model, opts)
+    }
+}
+
+impl PersistentSolver for Clarabel {
+    type Handle = ClarabelPersistent;
+
+    fn persistent(&self) -> ClarabelPersistent {
+        ClarabelPersistent::new()
+    }
+}

--- a/crates/oximo-clarabel/src/options.rs
+++ b/crates/oximo-clarabel/src/options.rs
@@ -1,0 +1,152 @@
+use oximo_solver::{HasUniversal, UniversalOptions};
+
+// TODO: Enable Pardiso backends
+
+/// Direct linear (KKT) solver method for Clarabel.
+///
+/// Selects the sparse LDL factorization backend. The built-in `qdldl` and the
+/// `auto` default are always present, while [`Faer`](Self::Faer) requires this
+/// crate's `faer` feature.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ClarabelDirectSolve {
+    /// Let Clarabel choose (`"auto"`). Clarabel default.
+    Auto,
+    /// Built-in QDLDL factorization (`"qdldl"`).
+    Qdldl,
+    /// faer sparse LDL factorization (`"faer"`). Requires the `faer` feature.
+    #[cfg(feature = "faer")]
+    Faer,
+}
+
+/// Declare every scalar [`ClarabelOptions`] option once. Its `Option<T>` field
+/// and its `#[must_use]` builder are generated from the same entry, keeping the
+/// field name identical to the matching `clarabel::solver::CoreSettings` field.
+macro_rules! clarabel_options {
+    ($($(#[$meta:meta])* $name:ident : $ty:ty),* $(,)?) => {
+        /// Clarabel-specific solver options.
+        ///
+        /// A typed mirror of the tunable, non-feature-gated fields of
+        /// `clarabel::solver::CoreSettings`. Every field is `Option`, `None`
+        /// leaves Clarabel's own default in place, so the defaults quoted below
+        /// are informational.
+        ///
+        /// The universal `threads` option maps to Clarabel's `max_threads`,
+        /// which only affects multithreaded KKT solvers. The default `qdldl`
+        /// solver is single-threaded.
+        #[derive(Clone, Debug, Default)]
+        pub struct ClarabelOptions {
+            /// Options shared by every backend.
+            pub universal: UniversalOptions,
+            /// Direct linear (KKT) solver method. Clarabel default `Auto`.
+            pub direct_solve_method: Option<ClarabelDirectSolve>,
+            $(
+                $(#[$meta])*
+                pub $name: Option<$ty>,
+            )*
+        }
+
+        impl ClarabelOptions {
+            /// Select the direct linear (KKT) solver method.
+            #[must_use]
+            pub fn direct_solve_method(mut self, m: ClarabelDirectSolve) -> Self {
+                self.direct_solve_method = Some(m);
+                self
+            }
+
+            $(
+                $(#[$meta])*
+                #[must_use]
+                pub fn $name(mut self, v: $ty) -> Self {
+                    self.$name = Some(v);
+                    self
+                }
+            )*
+        }
+    };
+}
+
+clarabel_options! {
+    /// Interior-point iteration limit. Clarabel default `200`.
+    max_iter: u32,
+    /// Maximum interior-point step length. Clarabel default `0.99`.
+    max_step_fraction: f64,
+    /// Absolute duality-gap tolerance. Clarabel default `1e-8`.
+    tol_gap_abs: f64,
+    /// Relative duality-gap tolerance. Clarabel default `1e-8`.
+    tol_gap_rel: f64,
+    /// Primal/dual feasibility tolerance. Clarabel default `1e-8`.
+    tol_feas: f64,
+    /// Absolute infeasibility tolerance. Clarabel default `1e-8`.
+    tol_infeas_abs: f64,
+    /// Relative infeasibility tolerance. Clarabel default `1e-8`.
+    tol_infeas_rel: f64,
+    /// κ/τ tolerance. Clarabel default `1e-6`.
+    tol_ktratio: f64,
+    /// Reduced (low-accuracy fallback) absolute duality-gap tolerance.
+    /// Clarabel default `5e-5`.
+    reduced_tol_gap_abs: f64,
+    /// Reduced relative duality-gap tolerance. Clarabel default `5e-5`.
+    reduced_tol_gap_rel: f64,
+    /// Reduced feasibility tolerance. Clarabel default `1e-4`.
+    reduced_tol_feas: f64,
+    /// Reduced absolute infeasibility tolerance. Clarabel default `5e-12`.
+    reduced_tol_infeas_abs: f64,
+    /// Reduced relative infeasibility tolerance. Clarabel default `5e-5`.
+    reduced_tol_infeas_rel: f64,
+    /// Reduced κ/τ tolerance. Clarabel default `1e-4`.
+    reduced_tol_ktratio: f64,
+    /// Enable data-equilibration pre-scaling. Clarabel default `true`.
+    equilibrate_enable: bool,
+    /// Maximum equilibration scaling iterations. Clarabel default `10`.
+    equilibrate_max_iter: u32,
+    /// Minimum equilibration scaling allowed. Clarabel default `1e-4`.
+    equilibrate_min_scaling: f64,
+    /// Maximum equilibration scaling allowed. Clarabel default `1e4`.
+    equilibrate_max_scaling: f64,
+    /// Line-search backtracking factor. Clarabel default `0.8`.
+    linesearch_backtrack_step: f64,
+    /// Minimum step for asymmetric cones with PrimalDual scaling.
+    /// Clarabel default `1e-1`.
+    min_switch_step_length: f64,
+    /// Minimum step for symmetric cones / asymmetric cones with Dual scaling.
+    /// Clarabel default `1e-4`.
+    min_terminate_step_length: f64,
+    /// Enable KKT static regularization. Clarabel default `true`.
+    static_regularization_enable: bool,
+    /// KKT static regularization constant. Clarabel default `1e-8`.
+    static_regularization_constant: f64,
+    /// Static regularization proportional to the max abs diagonal term.
+    /// Clarabel default `f64::EPSILON.powi(2)`.
+    static_regularization_proportional: f64,
+    /// Enable KKT dynamic regularization. Clarabel default `true`.
+    dynamic_regularization_enable: bool,
+    /// KKT dynamic regularization threshold. Clarabel default `1e-13`.
+    dynamic_regularization_eps: f64,
+    /// KKT dynamic regularization shift. Clarabel default `2e-7`.
+    dynamic_regularization_delta: f64,
+    /// KKT direct solve with iterative refinement. Clarabel default `true`.
+    iterative_refinement_enable: bool,
+    /// Iterative-refinement relative tolerance. Clarabel default `1e-13`.
+    iterative_refinement_reltol: f64,
+    /// Iterative-refinement absolute tolerance. Clarabel default `1e-12`.
+    iterative_refinement_abstol: f64,
+    /// Iterative-refinement maximum iterations. Clarabel default `10`.
+    iterative_refinement_max_iter: u32,
+    /// Iterative-refinement stalling tolerance. Clarabel default `5.0`.
+    iterative_refinement_stop_ratio: f64,
+    /// Enable presolve constraint reduction. Clarabel default `true`.
+    presolve_enable: bool,
+    /// Drop structural zeros from sparse inputs (disables parametric updating).
+    /// Clarabel default `false`.
+    input_sparse_dropzeros: bool,
+}
+
+impl HasUniversal for ClarabelOptions {
+    fn universal(&self) -> &UniversalOptions {
+        &self.universal
+    }
+
+    fn universal_mut(&mut self) -> &mut UniversalOptions {
+        &mut self.universal
+    }
+}

--- a/crates/oximo-clarabel/src/persistent.rs
+++ b/crates/oximo-clarabel/src/persistent.rs
@@ -1,0 +1,291 @@
+use std::time::Instant;
+
+use clarabel::solver::{DefaultSolver, IPSolver};
+use oximo_core::{Model, ModelKind};
+use oximo_solver::{Solver, SolverError, SolverResult};
+
+use crate::translate::{Problem, build_problem, build_settings, read_result};
+use crate::{ClarabelOptions, NAME};
+
+/// The resident Clarabel solver plus the [`Problem`] it was built from. The
+/// stored problem carries the sparsity pattern / cone layout used to decide
+/// whether the next solve can update in place, and the [`crate::translate::Meta`]
+/// used to read results back.
+struct State {
+    solver: DefaultSolver<f64>,
+    problem: Problem,
+}
+
+/// A stateful Clarabel handle that keeps the built solver resident across
+/// solves.
+///
+/// Created by [`Clarabel::persistent`](crate::Clarabel). When the next model
+/// has the same dimensions, cone layout and `P`/`A` sparsity pattern, only the
+/// numeric data (`P`, `q`, `A`, `b`) is overwritten in place via Clarabel's
+/// [`update_data`](clarabel::solver::DefaultSolver::update_data), reusing the
+/// KKT symbolic factorization instead of rebuilding it. Any structural change
+/// — added/removed rows or columns, a changed sparsity pattern, a new cone, a
+/// flipped constraint sense that moves a row between cones — triggers a
+/// transparent full rebuild, so every result matches a cold
+/// [`Clarabel::solve`](crate::Clarabel).
+///
+/// Clarabel is an interior-point method and does not warm-start from the
+/// previous iterate, so iteration counts are unchanged; the saving is the
+/// skipped setup (equilibration structure, symbolic factorization, allocations).
+///
+/// In-place updates are rejected by Clarabel when presolve or structural-zero
+/// dropping altered the problem, in which case the handle falls back to a
+/// rebuild. Set `presolve_enable(false)` and `input_sparse_dropzeros(false)`
+/// (the defaults leave presolve on) to keep the fast path available.
+///
+/// A failed `solve` leaves the handle without a resident model; the next call
+/// rebuilds from scratch.
+#[derive(Default)]
+pub struct ClarabelPersistent {
+    state: Option<State>,
+}
+
+impl std::fmt::Debug for ClarabelPersistent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClarabelPersistent").field("resident", &self.state.is_some()).finish()
+    }
+}
+
+impl ClarabelPersistent {
+    /// A fresh handle with no model loaded. The first solve builds it.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Drop the resident solver so the next [`solve`](Solver::solve) rebuilds
+    /// from scratch. After this, the next solve behaves exactly like a cold
+    /// [`Clarabel::solve`](crate::Clarabel).
+    pub fn reset(&mut self) {
+        self.state = None;
+    }
+
+    /// Translate the model, update the resident solver in place when the
+    /// structure is unchanged (else rebuild), then solve.
+    fn solve_resident(
+        &mut self,
+        model: &Model,
+        opts: &ClarabelOptions,
+    ) -> Result<SolverResult, SolverError> {
+        let new = build_problem(model)?;
+        let settings = build_settings(opts);
+
+        // Fast path: same structure, and Clarabel accepts both the settings
+        // update (no immutable setting changed) and the data update (structure
+        // not altered by presolve / dropped zeros). Any failure means rebuild.
+        let mut updated = false;
+        if let Some(state) = self.state.as_mut() {
+            if state.problem.same_structure(&new)
+                && state.solver.update_settings(settings.clone()).is_ok()
+                && state.solver.update_data(&new.p_mat, &new.q, &new.a_mat, &new.b).is_ok()
+            {
+                updated = true;
+            }
+        }
+
+        if updated {
+            // Refresh the readback metadata (objective sign/constant, dual map).
+            self.state.as_mut().expect("resident on fast path").problem = new;
+        } else {
+            let solver =
+                DefaultSolver::new(&new.p_mat, &new.q, &new.a_mat, &new.b, &new.cones, settings)
+                    .map_err(|e| SolverError::Backend(format!("Clarabel setup: {e:?}")))?;
+            self.state = Some(State { solver, problem: new });
+        }
+
+        let state = self.state.as_mut().expect("state present before solve");
+        let started = Instant::now();
+        state.solver.solve();
+        let elapsed = started.elapsed();
+        Ok(read_result(&state.solver, &state.problem.meta, elapsed))
+    }
+}
+
+impl Solver for ClarabelPersistent {
+    type Options = ClarabelOptions;
+
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn supports(&self, kind: ModelKind) -> bool {
+        crate::supported(kind)
+    }
+
+    fn solve(
+        &mut self,
+        model: &Model,
+        opts: &ClarabelOptions,
+    ) -> Result<SolverResult, SolverError> {
+        match self.solve_resident(model, opts) {
+            Ok(result) => Ok(result),
+            Err(e) => {
+                self.state = None;
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oximo_core::prelude::*;
+    use oximo_solver::{PersistentSolver, Solver, SolverError, TerminationStatus};
+
+    use crate::{Clarabel, ClarabelOptions};
+
+    /// Relative closeness: two independent interior-point solves stop within
+    /// the solver tolerance, not bit-for-bit, so scale by magnitude.
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() <= 1e-5 * a.abs().max(b.abs()).max(1.0)
+    }
+
+    /// A parameter in an objective coefficient changes `q` only: the sparsity
+    /// pattern is untouched, so the handle updates in place and must match the
+    /// cold solve across the sweep.
+    #[test]
+    fn persistent_matches_cold_on_objective_sweep() {
+        let m = Model::new("pricing");
+        param!(m, p1 = 0.0);
+        variable!(m, x1 >= 0.0);
+        variable!(m, x2 >= 0.0);
+        constraint!(m, labor, 2.0 * x1 + x2 <= 100.0);
+        constraint!(m, material, x1 + 3.0 * x2 <= 90.0);
+        objective!(m, Max, p1 * x1 + 5.0 * x2);
+
+        let mut solver = Clarabel.persistent();
+        for price in [1.0, 1.6, 2.0, 5.0, 11.0] {
+            p1.set_param_value(price);
+            let s = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+            let c = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap();
+            assert_eq!(s.termination, TerminationStatus::Optimal, "price {price}");
+            assert!(close(s.objective().unwrap(), c.objective().unwrap()), "price {price}");
+            assert!(close(s.value_of(x1).unwrap(), c.value_of(x1).unwrap()), "price {price}");
+        }
+    }
+
+    /// A parameter in a right-hand side changes `b` only. Unlike the HiGHS
+    /// handle (which rebuilds on rhs changes), Clarabel can push this through
+    /// the in-place update; results must still match the cold solve.
+    #[test]
+    fn persistent_matches_cold_on_rhs_sweep() {
+        let m = Model::new("capacity");
+        param!(m, cap = 100.0);
+        variable!(m, x1 >= 0.0);
+        variable!(m, x2 >= 0.0);
+        constraint!(m, labor, 2.0 * x1 + x2 <= cap);
+        constraint!(m, material, x1 + 3.0 * x2 <= 90.0);
+        objective!(m, Max, 3.0 * x1 + 5.0 * x2);
+
+        let mut solver = Clarabel.persistent();
+        for c in [100.0, 60.0, 140.0] {
+            cap.set_param_value(c);
+            let s = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+            let cold = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap();
+            assert_eq!(s.termination, TerminationStatus::Optimal, "cap {c}");
+            assert!(close(s.objective().unwrap(), cold.objective().unwrap()), "cap {c}");
+        }
+    }
+
+    /// A parameter in a matrix coefficient changes an `A` value, keeping the
+    /// sparsity pattern: still the in-place path.
+    #[test]
+    fn persistent_matches_cold_on_matrix_coeff_sweep() {
+        let m = Model::new("coeff");
+        param!(m, a = 2.0);
+        variable!(m, x1 >= 0.0);
+        variable!(m, x2 >= 0.0);
+        constraint!(m, labor, a * x1 + x2 <= 100.0);
+        objective!(m, Max, 3.0 * x1 + 5.0 * x2);
+
+        let mut solver = Clarabel.persistent();
+        for av in [2.0, 1.0, 4.0] {
+            a.set_param_value(av);
+            let s = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+            let cold = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap();
+            assert_eq!(s.termination, TerminationStatus::Optimal, "a {av}");
+            assert!(close(s.objective().unwrap(), cold.objective().unwrap()), "a {av}");
+        }
+    }
+
+    /// Fixing a variable moves it from bound rows to a zero-cone row: a
+    /// structural change the handle must absorb via a rebuild, still matching
+    /// the cold solve.
+    #[test]
+    fn persistent_rebuilds_on_structural_change() {
+        let m = Model::new("feas");
+        variable!(m, 0.0 <= x <= 10.0);
+        variable!(m, 0.0 <= y <= 10.0);
+        constraint!(m, c, x + y == 5.0);
+        objective!(m, Min, x + 2.0 * y);
+
+        let mut solver = Clarabel.persistent();
+        let r = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+        assert!(r.has_solution(), "termination = {:?}", r.termination);
+
+        m.fix(x, 2.0);
+        let r2 = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+        let cold = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap();
+        assert!(close(r2.value_of(x).unwrap(), 2.0));
+        assert!(close(r2.value_of(y).unwrap(), 3.0));
+        assert!(close(r2.objective().unwrap(), cold.objective().unwrap()));
+    }
+
+    /// An SOCP with a swept objective coefficient exercises the fast path with
+    /// a second-order cone in the layout.
+    #[test]
+    fn persistent_socp_objective_sweep() {
+        let m = Model::new("socp");
+        param!(m, wt = 1.0);
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, t >= 0.0);
+        m.fix(t, 1.0);
+        m.add_soc_constraint("disk", [x, y], t); // ||(x, y)|| <= 1
+        objective!(m, Min, wt * x + y);
+
+        let mut solver = Clarabel.persistent();
+        for wv in [1.0, 2.0, 0.5] {
+            wt.set_param_value(wv);
+            let warm = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+            let cold = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap();
+            assert_eq!(warm.termination, TerminationStatus::Optimal, "wt {wv}");
+            assert!(close(warm.objective().unwrap(), cold.objective().unwrap()), "wt {wv}");
+        }
+    }
+
+    #[test]
+    fn persistent_reset_then_solve_ok() {
+        let m = Model::new("pricing");
+        param!(m, p1 = 0.0);
+        variable!(m, x1 >= 0.0);
+        variable!(m, x2 >= 0.0);
+        constraint!(m, labor, 2.0 * x1 + x2 <= 100.0);
+        objective!(m, Max, p1 * x1 + 5.0 * x2);
+
+        let mut solver = Clarabel.persistent();
+        p1.set_param_value(2.0);
+        let first = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(first.termination, TerminationStatus::Optimal);
+
+        solver.reset();
+        let after = solver.solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(after.termination, TerminationStatus::Optimal);
+        assert!(close(first.objective().unwrap(), after.objective().unwrap()));
+    }
+
+    #[test]
+    fn persistent_unsupported_kind_errors_and_clears() {
+        let m = Model::new("milp");
+        variable!(m, 0.0 <= x <= 5.0, Int);
+        objective!(m, Min, x);
+        let mut solver = Clarabel.persistent();
+        let err = solver.solve(&m, &ClarabelOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::MILP)));
+    }
+}

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -1,0 +1,868 @@
+//! Translate an oximo [`Model`] into Clarabel's conic form
+//! `min 0.5 x'Px + q'x  s.t.  Ax + s = b, s in K` and read the result back.
+//!
+//! Row layout:
+//! 1. `ZeroCone`: equality constraints, then fixed variables (`lb == ub`).
+//! 2. `NonnegativeCone`: `<=` rows as `(+a, ub)`, `>=` rows as `(-a, -lb)`,
+//!    two-sided ranges as both, then finite variable bounds.
+//! 3. One `SecondOrderCone` block per cone constraint, explicit
+//!    [`SocConstraint`]s first, then SOC-shaped quadratic constraints detected
+//!    by [`detect_soc`] in constraint order. Each block is
+//!    `s0 = bound(x), s_i = term_i(x)` via `A` rows holding the negated
+//!    affine coefficients.
+//!
+//! A `Maximize` objective negates `P`/`q` on the way in and the objective
+//! value and duals on the way out. Duals follow the LP convention
+//! `gradient = A' y` of the problem as posed. SOC blocks and variable-bound
+//! rows carry no [`ConstraintId`] and are skipped. Reduced costs are not
+//! reported.
+
+// TODO: Add convex-QCP-to-SOC reformulation?
+
+use std::time::{Duration, Instant};
+
+use clarabel::algebra::CscMatrix;
+use clarabel::solver::{DefaultSettings, DefaultSolver, IPSolver, SolverStatus, SupportedConeT};
+use oximo_core::{
+    ConstraintId, Model, ObjectiveSense, Sense, SocConstraintId, SocForm, Variable, detect_soc,
+    explicit_soc_form,
+};
+use oximo_expr::{LinearTerms, VarId, extract_linear, extract_quadratic};
+use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
+use rustc_hash::FxHashMap;
+
+use crate::{ClarabelDirectSolve, ClarabelOptions};
+
+/// The linear-or-conic view of one algebraic constraint.
+enum Row {
+    Lin(LinearTerms),
+    Soc(SocForm),
+}
+
+/// `(row, col, value)` sparse-matrix entries.
+type Triplets = Vec<(usize, usize, f64)>;
+
+/// Accumulates the Clarabel `A` rows (as [`Triplets`]), the `b` vector, and the
+/// per-row dual mapping while constraints and bounds are lowered into cone rows.
+#[derive(Default)]
+struct Rows {
+    a_trip: Triplets,
+    b: Vec<f64>,
+    row_duals: Vec<Option<(ConstraintId, f64)>>,
+}
+
+impl Rows {
+    /// Append one `A` row `scale * t.coeffs` with right-hand side `rhs`, carrying
+    /// no dual. The caller attaches one with `set_last_dual` when the row maps
+    /// back to a constraint.
+    fn push(&mut self, t: &LinearTerms, scale: f64, rhs: f64) {
+        let row = self.b.len();
+        for &(var, coef) in &t.coeffs {
+            self.a_trip.push((row, var.index(), scale * coef));
+        }
+        self.b.push(rhs);
+        self.row_duals.push(None);
+    }
+
+    /// Append a single-entry row `scale * x_col = rhs` (a fixed variable or a
+    /// finite bound), carrying no dual.
+    fn push_bound(&mut self, col: usize, scale: f64, rhs: f64) {
+        let row = self.b.len();
+        self.a_trip.push((row, col, scale));
+        self.b.push(rhs);
+        self.row_duals.push(None);
+    }
+
+    /// Attach a dual mapping to the row just pushed.
+    fn set_last_dual(&mut self, id: ConstraintId, scale: f64) {
+        *self.row_duals.last_mut().unwrap() = Some((id, scale));
+    }
+}
+
+/// Readback metadata, turn a solved [`DefaultSolver`] back into a
+/// generic [`SolverResult`].
+pub(crate) struct Meta {
+    /// `-1.0` for a maximize objective (Clarabel always minimizes), else `1.0`.
+    sign: f64,
+    /// Folded objective constant, added back after solving.
+    obj_constant: f64,
+    /// Per `A`-row dual mapping: `Some((constraint, scale))`, or `None` for
+    /// bound/cone rows that carry no [`ConstraintId`].
+    row_duals: Vec<Option<(ConstraintId, f64)>>,
+    /// Row index of each SOC block's `s0` entry.
+    soc_block_starts: Vec<usize>,
+    /// Count of leading SOC blocks that are explicit cones (duals reported).
+    n_explicit: usize,
+}
+
+/// A translated Clarabel problem, conic data plus the [`Meta`] to read its
+/// solution back. The persistent handle keeps the last one to test whether an
+/// in-place [`DefaultSolver::update_data`] is possible.
+pub(crate) struct Problem {
+    pub(crate) p_mat: CscMatrix<f64>,
+    pub(crate) q: Vec<f64>,
+    pub(crate) a_mat: CscMatrix<f64>,
+    pub(crate) b: Vec<f64>,
+    pub(crate) cones: Vec<SupportedConeT<f64>>,
+    pub(crate) meta: Meta,
+}
+
+impl Problem {
+    /// True when `other` shares this problem's dimensions, cone layout, and
+    /// `P`/`A` sparsity patterns.
+    pub(crate) fn same_structure(&self, other: &Problem) -> bool {
+        self.q.len() == other.q.len()
+            && self.b.len() == other.b.len()
+            && self.cones == other.cones
+            && self.p_mat.colptr == other.p_mat.colptr
+            && self.p_mat.rowval == other.p_mat.rowval
+            && self.a_mat.colptr == other.a_mat.colptr
+            && self.a_mat.rowval == other.a_mat.rowval
+    }
+}
+
+/// Translate `model` into a Clarabel problem, solve, and return the generic
+/// [`SolverResult`].
+///
+/// # Errors
+///
+/// Returns [`SolverError::UnsupportedKind`] for anything but continuous
+/// LP/QP/SOCP, [`SolverError::Backend`] for semicontinuous/semi-integer
+/// domains or a Clarabel setup failure, and [`SolverError::Nonlinear`] if an
+/// expression defeats extraction.
+pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, SolverError> {
+    let problem = build_problem(model)?;
+    let settings = build_settings(opts);
+    let mut solver = DefaultSolver::new(
+        &problem.p_mat,
+        &problem.q,
+        &problem.a_mat,
+        &problem.b,
+        &problem.cones,
+        settings,
+    )
+    .map_err(|e| SolverError::Backend(format!("Clarabel setup: {e:?}")))?;
+    let started = Instant::now();
+    solver.solve();
+    let elapsed = started.elapsed();
+    Ok(read_result(&solver, &problem.meta, elapsed))
+}
+
+/// Translate `model` into Clarabel's conic form without solving.
+///
+/// # Errors
+///
+/// Returns [`SolverError::UnsupportedKind`] for anything but continuous
+/// LP/QP/SOCP, [`SolverError::Backend`] for a semicontinuous/semi-integer
+/// domain or an out-of-arena SOC member, and [`SolverError::Nonlinear`] if an
+/// expression defeats extraction.
+///
+/// # Panics
+///
+/// Panics if variable or constraint indices overflow `u32`.
+pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
+    let kind = model.kind();
+    if !crate::supported(kind) {
+        return Err(SolverError::UnsupportedKind(kind));
+    }
+    let vars = model.variables();
+    reject_semi_domains(&vars)?;
+    let n = vars.len();
+
+    let (sign, p_trip, q, obj_constant) = objective_data(model, n)?;
+    let rows = classify_rows(model)?;
+    let (mut acc, m_zero, m_nonneg) = linear_rows(model, &rows);
+    let (soc_sizes, soc_block_starts, n_explicit) = soc_blocks(model, &rows, &mut acc)?;
+
+    let Rows { a_trip, b, row_duals } = acc;
+    let m = b.len();
+    let a_mat = csc_from_triplets(m, n, a_trip);
+    let p_mat = csc_from_triplets(n, n, p_trip);
+    let cones = build_cones(m_zero, m_nonneg, &soc_sizes);
+
+    Ok(Problem {
+        p_mat,
+        q,
+        a_mat,
+        b,
+        cones,
+        meta: Meta { sign, obj_constant, row_duals, soc_block_starts, n_explicit },
+    })
+}
+
+/// The objective in Clarabel form: `sign` (`-1` maximize, else `+1`. It negates
+/// `P`/`q` so a maximize is posed as a minimize.), the upper-triangular `P`
+/// triplets, the `q` vector, and the folded constant.
+///
+/// `extract_quadratic` subsumes the linear case. oximo's Hessian is
+/// lower-triangular with doubled diagonal (the `0.5 x'Qx` convention), matching
+/// Clarabel's `P` up to the triangle side, so entries transpose to
+/// upper-triangular with no scaling.
+fn objective_data(model: &Model, n: usize) -> Result<(f64, Triplets, Vec<f64>, f64), SolverError> {
+    let arena = model.arena();
+    let objective = model.objective();
+    let sign = match objective.as_ref().map(|o| o.sense) {
+        Some(ObjectiveSense::Maximize) => -1.0,
+        _ => 1.0,
+    };
+    let Some(obj) = objective.as_ref() else {
+        return Ok((sign, Triplets::new(), vec![0.0; n], 0.0));
+    };
+    let quad = extract_quadratic(&arena, obj.expr).ok_or(SolverError::Nonlinear)?;
+    let mut q = vec![0.0; n];
+    for &(var, coef) in &quad.linear {
+        q[var.index()] += sign * coef;
+    }
+    let p_trip =
+        quad.hessian.iter().map(|&(row, col, h)| (col.index(), row.index(), sign * h)).collect();
+    Ok((sign, p_trip, q, quad.constant))
+}
+
+/// Classify every algebraic constraint as linear or SOC. The kind gate
+/// guarantees a quadratic constraint detects as SOC, so a miss here is a
+/// genuine nonlinear.
+fn classify_rows(model: &Model) -> Result<Vec<Row>, SolverError> {
+    let arena = model.arena();
+    let vars = model.variables();
+    model
+        .constraints()
+        .iter()
+        .map(|c| match extract_linear(&arena, c.lhs) {
+            Some(t) => Ok(Row::Lin(t)),
+            None => detect_soc(&arena, &vars, c).map(Row::Soc).ok_or(SolverError::Nonlinear),
+        })
+        .collect()
+}
+
+/// Lower the linear constraints and variable bounds into cone rows: the
+/// `ZeroCone` block (equalities, then fixed variables) followed by the
+/// `NonnegativeCone` block (inequalities/ranges, then finite bounds). Returns
+/// the accumulated [`Rows`] and the two block sizes.
+fn linear_rows(model: &Model, rows: &[Row]) -> (Rows, usize, usize) {
+    let vars = model.variables();
+    let constraints = model.constraints();
+    let is_fixed = |v: &Variable| v.lb.is_finite() && v.lb.total_cmp(&v.ub).is_eq();
+    let mut acc = Rows::default();
+
+    // ZeroCone rows: equalities, then fixed variables.
+    for (i, (con, row)) in constraints.iter().zip(rows).enumerate() {
+        if let Row::Lin(lt) = row {
+            if let Some((Sense::Eq, rhs)) = con.as_single() {
+                let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
+                acc.push(lt, 1.0, rhs - lt.constant);
+                acc.set_last_dual(id, -1.0);
+            }
+        }
+    }
+    for var in vars.iter().filter(|&v| is_fixed(v)) {
+        acc.push_bound(var.id.index(), 1.0, var.lb);
+    }
+    let m_zero = acc.b.len();
+
+    // NonnegativeCone rows: inequalities and ranges, then variable bounds.
+    for (i, (con, row)) in constraints.iter().zip(rows).enumerate() {
+        let Row::Lin(lt) = row else { continue };
+        let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
+        match con.as_single() {
+            Some((Sense::Le, rhs)) => {
+                acc.push(lt, 1.0, rhs - lt.constant);
+                acc.set_last_dual(id, -1.0);
+            }
+            Some((Sense::Ge, rhs)) => {
+                acc.push(lt, -1.0, -(rhs - lt.constant));
+                acc.set_last_dual(id, 1.0);
+            }
+            None if con.is_range() => {
+                acc.push(lt, -1.0, -(con.lower - lt.constant));
+                acc.set_last_dual(id, 1.0);
+                acc.push(lt, 1.0, con.upper - lt.constant);
+                acc.set_last_dual(id, -1.0);
+            }
+            Some((Sense::Eq, _)) | None => {}
+        }
+    }
+    for var in vars.iter().filter(|&v| !is_fixed(v)) {
+        if var.ub.is_finite() {
+            acc.push_bound(var.id.index(), 1.0, var.ub);
+        }
+        if var.lb.is_finite() {
+            acc.push_bound(var.id.index(), -1.0, -var.lb);
+        }
+    }
+    let m_nonneg = acc.b.len() - m_zero;
+
+    (acc, m_zero, m_nonneg)
+}
+
+/// Append the second-order-cone blocks (explicit cones first, then detected
+/// ones) to `acc`. Returns each block's size, the row index of each block's
+/// `s0` entry, and how many leading blocks are explicit cones.
+///
+/// Only explicit cones' duals are reported: their bound multiplier `z0` maps
+/// back to the constraint, whereas `SocForm` normalizes away a detected cone's
+/// original quadratic scaling, so its `z0` cannot be mapped back.
+fn soc_blocks(
+    model: &Model,
+    rows: &[Row],
+    acc: &mut Rows,
+) -> Result<(Vec<usize>, Vec<usize>, usize), SolverError> {
+    let arena = model.arena();
+    let socs = model.soc_constraints();
+    let explicit_forms = socs
+        .iter()
+        .map(|s| {
+            explicit_soc_form(&arena, s).ok_or_else(|| {
+                SolverError::Backend(format!(
+                    "SOC constraint '{}' has a member outside this model's arena",
+                    s.name
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let detected_forms = rows.iter().filter_map(|r| match r {
+        Row::Soc(f) => Some(f.clone()),
+        Row::Lin(_) => None,
+    });
+
+    let n_explicit = explicit_forms.len();
+    let mut soc_sizes: Vec<usize> = Vec::new();
+    let mut soc_block_starts: Vec<usize> = Vec::new();
+    for form in explicit_forms.into_iter().chain(detected_forms) {
+        soc_block_starts.push(acc.b.len());
+        acc.push(&form.bound, -1.0, form.bound.constant);
+        for term in &form.terms {
+            acc.push(term, -1.0, term.constant);
+        }
+        soc_sizes.push(1 + form.terms.len());
+    }
+    Ok((soc_sizes, soc_block_starts, n_explicit))
+}
+
+/// Assemble the cone list in row order: zero cone, nonnegative cone, then one
+/// second-order cone per SOC block.
+fn build_cones(m_zero: usize, m_nonneg: usize, soc_sizes: &[usize]) -> Vec<SupportedConeT<f64>> {
+    let mut cones = Vec::new();
+    if m_zero > 0 {
+        cones.push(SupportedConeT::ZeroConeT(m_zero));
+    }
+    if m_nonneg > 0 {
+        cones.push(SupportedConeT::NonnegativeConeT(m_nonneg));
+    }
+    cones.extend(soc_sizes.iter().map(|&k| SupportedConeT::SecondOrderConeT(k)));
+    cones
+}
+
+/// Read a solved [`DefaultSolver`] back into a generic [`SolverResult`],
+/// applying the sign/constant folding and dual mapping recorded in `meta`.
+pub(crate) fn read_result(
+    solver: &DefaultSolver<f64>,
+    meta: &Meta,
+    elapsed: Duration,
+) -> SolverResult {
+    let termination = map_status(solver.solution.status);
+    let has_point = termination.admits_primal();
+
+    let mut solutions = Vec::new();
+    let mut dual: FxHashMap<ConstraintId, f64> = FxHashMap::default();
+    let mut soc_dual: FxHashMap<SocConstraintId, f64> = FxHashMap::default();
+    if has_point {
+        let primal: FxHashMap<VarId, f64> = solver
+            .solution
+            .x
+            .iter()
+            .enumerate()
+            .map(|(i, &val)| (VarId(u32::try_from(i).expect("variable count overflow")), val))
+            .collect();
+        let objective = Some(meta.sign * solver.solution.obj_val + meta.obj_constant);
+        solutions.push(SolutionPoint { primal, objective });
+
+        for (r, &z) in solver.solution.z.iter().enumerate() {
+            if let Some(Some((id, s))) = meta.row_duals.get(r) {
+                *dual.entry(*id).or_insert(0.0) += meta.sign * s * z;
+            }
+        }
+        for (k, &start) in meta.soc_block_starts.iter().take(meta.n_explicit).enumerate() {
+            if let Some(&z0) = solver.solution.z.get(start) {
+                soc_dual.insert(SocConstraintId(u32::try_from(k).expect("SOC count overflow")), z0);
+            }
+        }
+    }
+    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
+
+    SolverResult {
+        termination,
+        primal_status,
+        solutions,
+        dual,
+        soc_dual,
+        reduced_costs: FxHashMap::default(),
+        best_bound: None,
+        gap: None,
+        solve_time: elapsed,
+        iterations: u64::from(solver.info.iterations),
+        raw_log: None,
+        solver_name: Some(crate::NAME.into()),
+    }
+}
+
+/// Assemble an `m x n` [`CscMatrix`] from `(row, col, value)` triplets,
+/// merging duplicates.
+fn csc_from_triplets(m: usize, n: usize, mut trip: Triplets) -> CscMatrix<f64> {
+    trip.sort_unstable_by_key(|&(row, col, _)| (col, row));
+    let mut colptr = vec![0_usize; n + 1];
+    let mut rowval: Vec<usize> = Vec::with_capacity(trip.len());
+    let mut nzval: Vec<f64> = Vec::with_capacity(trip.len());
+    let mut last: Option<(usize, usize)> = None;
+    for (row, col, val) in trip {
+        if last == Some((row, col)) {
+            *nzval.last_mut().unwrap() += val;
+        } else {
+            colptr[col + 1] += 1;
+            rowval.push(row);
+            nzval.push(val);
+            last = Some((row, col));
+        }
+    }
+    for col in 0..n {
+        colptr[col + 1] += colptr[col];
+    }
+    CscMatrix::new(m, n, colptr, rowval, nzval)
+}
+
+pub(crate) fn build_settings(o: &ClarabelOptions) -> DefaultSettings<f64> {
+    let mut s = DefaultSettings {
+        verbose: o.universal.verbose.unwrap_or(false),
+        ..DefaultSettings::default()
+    };
+    if let Some(d) = o.universal.time_limit {
+        s.time_limit = d.as_secs_f64();
+    }
+    // Universal `threads` feeds Clarabel's `max_threads` (only affects
+    // multithreaded KKT solvers, the default qdldl solver is single-threaded).
+    if let Some(n) = o.universal.threads {
+        s.max_threads = n;
+    }
+    if let Some(m) = o.direct_solve_method {
+        s.direct_solve_method = kkt_str(m).to_string();
+    }
+
+    // Every scalar `ClarabelOptions` field shares its name with the matching
+    // `DefaultSettings` field, so apply each verbatim when set.
+    macro_rules! apply_opt {
+        ($($field:ident),* $(,)?) => {
+            $(if let Some(v) = o.$field { s.$field = v; })*
+        };
+    }
+    apply_opt!(
+        max_iter,
+        max_step_fraction,
+        tol_gap_abs,
+        tol_gap_rel,
+        tol_feas,
+        tol_infeas_abs,
+        tol_infeas_rel,
+        tol_ktratio,
+        reduced_tol_gap_abs,
+        reduced_tol_gap_rel,
+        reduced_tol_feas,
+        reduced_tol_infeas_abs,
+        reduced_tol_infeas_rel,
+        reduced_tol_ktratio,
+        equilibrate_enable,
+        equilibrate_max_iter,
+        equilibrate_min_scaling,
+        equilibrate_max_scaling,
+        linesearch_backtrack_step,
+        min_switch_step_length,
+        min_terminate_step_length,
+        static_regularization_enable,
+        static_regularization_constant,
+        static_regularization_proportional,
+        dynamic_regularization_enable,
+        dynamic_regularization_eps,
+        dynamic_regularization_delta,
+        iterative_refinement_enable,
+        iterative_refinement_reltol,
+        iterative_refinement_abstol,
+        iterative_refinement_max_iter,
+        iterative_refinement_stop_ratio,
+        presolve_enable,
+        input_sparse_dropzeros,
+    );
+    s
+}
+
+/// Lower a [`ClarabelDirectSolve`] to the string Clarabel's settings expect.
+fn kkt_str(m: ClarabelDirectSolve) -> &'static str {
+    match m {
+        ClarabelDirectSolve::Auto => "auto",
+        ClarabelDirectSolve::Qdldl => "qdldl",
+        #[cfg(feature = "faer")]
+        ClarabelDirectSolve::Faer => "faer",
+    }
+}
+
+fn reject_semi_domains(vars: &[Variable]) -> Result<(), SolverError> {
+    for v in vars {
+        if v.domain.semi_threshold().is_some() {
+            return Err(SolverError::Backend(format!(
+                "variable {} has a semicontinuous/semi-integer domain, \
+                which Clarabel does not support",
+                v.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn map_status(s: SolverStatus) -> TerminationStatus {
+    match s {
+        SolverStatus::Solved => TerminationStatus::Optimal,
+        SolverStatus::AlmostSolved => TerminationStatus::Interrupted,
+        SolverStatus::PrimalInfeasible | SolverStatus::AlmostPrimalInfeasible => {
+            TerminationStatus::Infeasible
+        }
+        SolverStatus::DualInfeasible | SolverStatus::AlmostDualInfeasible => {
+            TerminationStatus::Unbounded
+        }
+        SolverStatus::MaxIterations => TerminationStatus::IterationLimit,
+        SolverStatus::MaxTime => TerminationStatus::TimeLimit,
+        SolverStatus::NumericalError | SolverStatus::InsufficientProgress => {
+            TerminationStatus::NumericError
+        }
+        SolverStatus::Unsolved => TerminationStatus::NotSolved,
+        other @ SolverStatus::CallbackTerminated => TerminationStatus::Other(format!("{other:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oximo_core::prelude::*;
+    use oximo_solver::UniversalOptionsExt;
+
+    use super::*;
+
+    fn close(a: f64, b: f64, tol: f64) -> bool {
+        (a - b).abs() < tol
+    }
+
+    #[test]
+    fn lp_known_optimum_maximize() {
+        // max 3x + 2y  s.t.  x + y <= 4, 0 <= x, y <= 3.
+        // Optimum x = 3, y = 1, objective 11.
+        let m = Model::new("lp");
+        variable!(m, 0.0 <= x <= 3.0);
+        variable!(m, 0.0 <= y <= 3.0);
+        constraint!(m, cap, x + y <= 4.0);
+        objective!(m, Max, 3.0 * x + 2.0 * y);
+        assert_eq!(m.kind(), ModelKind::LP);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 11.0, 1e-6));
+        assert!(close(res.value_of(x).unwrap(), 3.0, 1e-6));
+        assert!(close(res.value_of(y).unwrap(), 1.0, 1e-6));
+    }
+
+    #[test]
+    fn lp_range_constraint() {
+        // min x + y  s.t.  1 <= x + y <= 3, x, y >= 0. Optimum objective 1.
+        let m = Model::new("range");
+        variable!(m, x >= 0.0);
+        variable!(m, y >= 0.0);
+        constraint!(m, band, 1.0 <= x + y <= 3.0);
+        objective!(m, Min, x + y);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 1.0, 1e-6));
+    }
+
+    #[test]
+    fn qp_cvxopt_quickstart() {
+        // min 2 x0^2 + x0 x1 + x1^2 + x0 + x1  s.t.  x0 + x1 = 1, x >= 0.
+        // x = [0.25, 0.75], objective = 1.875.
+        let m = Model::new("cvxopt");
+        variable!(m, x0 >= 0.0);
+        variable!(m, x1 >= 0.0);
+        constraint!(m, eq, x0 + x1 == 1.0);
+        objective!(m, Min, 2.0 * x0.powi(2) + x0 * x1 + x1.powi(2) + x0 + x1);
+        assert_eq!(m.kind(), ModelKind::QP);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.value_of(x0).unwrap(), 0.25, 1e-5));
+        assert!(close(res.value_of(x1).unwrap(), 0.75, 1e-5));
+        assert!(close(res.objective().unwrap(), 1.875, 1e-5));
+    }
+
+    #[test]
+    fn qp_objective_constant_is_added_back() {
+        // min (x - 1)^2  ->  x = 1, objective 0 (folded constant 1).
+        let m = Model::new("shift");
+        variable!(m, -5.0 <= x <= 5.0);
+        objective!(m, Min, (x - 1.0).powi(2));
+        assert_eq!(m.kind(), ModelKind::QP);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.value_of(x).unwrap(), 1.0, 1e-5));
+        assert!(res.objective().unwrap().abs() < 1e-5);
+    }
+
+    #[test]
+    fn explicit_socp_min_linear_over_disk() {
+        // min x + y  s.t.  ||(x, y)||_2 <= 1. Optimum objective -sqrt(2).
+        // KKT: (1, 1) + z0 * (x, y)/||(x, y)|| = 0  =>  z0 = sqrt(2).
+        let m = Model::new("socp");
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, t >= 0.0);
+        m.fix(t, 1.0);
+        let disk = m.add_soc_constraint("disk", [x, y], t);
+        objective!(m, Min, x + y);
+        assert_eq!(m.kind(), ModelKind::SOCP);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), -std::f64::consts::SQRT_2, 1e-6));
+
+        let z0 = res.soc_dual_of(disk).expect("SOC dual missing");
+        assert!(close(z0, std::f64::consts::SQRT_2, 1e-6), "z0 = {z0}");
+    }
+
+    #[test]
+    fn detected_socp_hypotenuse() {
+        // min t  s.t.  x^2 + y^2 <= t^2, t >= 0, x = 3, y = 4. Optimum t = 5.
+        let m = Model::new("socp_detected");
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, t >= 0.0);
+        m.fix(x, 3.0);
+        m.fix(y, 4.0);
+        constraint!(m, cone, x.powi(2) + y.powi(2) <= t.powi(2));
+        objective!(m, Min, t);
+        assert_eq!(m.kind(), ModelKind::SOCP);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 5.0, 1e-5));
+    }
+
+    #[test]
+    fn socp_with_quadratic_objective() {
+        // min x^2 + y  s.t.  ||(x, y)|| <= 2, y >= -2: unconstrained in x at
+        // x = 0, then y = -2 on the cone boundary. Objective -2.
+        let m = Model::new("socp_qobj");
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, t >= 0.0);
+        m.fix(t, 2.0);
+        m.add_soc_constraint("disk", [x, y], t);
+        objective!(m, Min, x.powi(2) + y);
+        assert_eq!(m.kind(), ModelKind::SOCP);
+
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), -2.0, 1e-5));
+    }
+
+    #[test]
+    fn milp_is_unsupported() {
+        let m = Model::new("milp");
+        variable!(m, 0.0 <= x <= 5.0, Int);
+        objective!(m, Min, x);
+        let err = solve(&m, &ClarabelOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::MILP)));
+    }
+
+    #[test]
+    fn qcp_is_unsupported() {
+        // Bilinear constraint is not SOC-shaped, so this stays QCP and is
+        // rejected.
+        let m = Model::new("qcp");
+        variable!(m, x >= 0.0);
+        variable!(m, y >= 0.0);
+        constraint!(m, c, x * y <= 4.0);
+        objective!(m, Min, x + y);
+        let err = solve(&m, &ClarabelOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::QCP)));
+    }
+
+    #[test]
+    fn nlp_is_unsupported() {
+        let m = Model::new("nlp");
+        variable!(m, x >= 0.1);
+        objective!(m, Min, x.sin());
+        let err = solve(&m, &ClarabelOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::NLP)));
+    }
+
+    #[test]
+    fn semi_domain_is_rejected() {
+        let m = Model::new("semi");
+        variable!(m, s <= 10.0, SemiCont(2.0));
+        objective!(m, Min, s);
+        let err = solve(&m, &ClarabelOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::Backend(_)));
+    }
+
+    #[test]
+    fn infeasible_lp_is_reported() {
+        let m = Model::new("infeas");
+        variable!(m, 0.0 <= x <= 1.0);
+        constraint!(m, c, x >= 2.0);
+        objective!(m, Min, x);
+        let res = solve(&m, &ClarabelOptions::default()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Infeasible);
+        assert!(!res.has_solution());
+    }
+
+    #[test]
+    fn lp_dual_signs_match_highs() {
+        // min 2x + 3y  s.t.  x + y >= 2, x - y <= 1, x, y >= 0.
+        fn build() -> Model {
+            let m = Model::new("duals");
+            variable!(m, x >= 0.0);
+            variable!(m, y >= 0.0);
+            constraint!(m, demand, x + y >= 2.0);
+            constraint!(m, link, x - y <= 1.0);
+            objective!(m, Min, 2.0 * x + 3.0 * y);
+            m
+        }
+
+        let m = build();
+        let ours = solve(&m, &ClarabelOptions::default()).unwrap();
+        let reference = oximo_highs::solve(&m, &oximo_highs::HighsOptions::default()).unwrap();
+        assert_eq!(ours.termination, TerminationStatus::Optimal);
+        for (id, want) in &reference.dual {
+            let got = ours.dual.get(id).copied().unwrap_or(0.0);
+            assert!(close(got, *want, 1e-5), "dual {id:?}: clarabel {got} vs highs {want}");
+        }
+    }
+
+    /// Every option set to a valid, near-default value.
+    fn all_options_set() -> ClarabelOptions {
+        ClarabelOptions::default()
+            .threads(1)
+            .direct_solve_method(ClarabelDirectSolve::Auto)
+            .max_iter(500)
+            .max_step_fraction(0.99)
+            .tol_gap_abs(1e-8)
+            .tol_gap_rel(1e-8)
+            .tol_feas(1e-8)
+            .tol_infeas_abs(1e-8)
+            .tol_infeas_rel(1e-8)
+            .tol_ktratio(1e-6)
+            .reduced_tol_gap_abs(5e-5)
+            .reduced_tol_gap_rel(5e-5)
+            .reduced_tol_feas(1e-4)
+            .reduced_tol_infeas_abs(5e-12)
+            .reduced_tol_infeas_rel(5e-5)
+            .reduced_tol_ktratio(1e-4)
+            .equilibrate_enable(true)
+            .equilibrate_max_iter(10)
+            .equilibrate_min_scaling(1e-4)
+            .equilibrate_max_scaling(1e4)
+            .linesearch_backtrack_step(0.8)
+            .min_switch_step_length(1e-1)
+            .min_terminate_step_length(1e-4)
+            .static_regularization_enable(true)
+            .static_regularization_constant(1e-8)
+            .static_regularization_proportional(1e-30)
+            .dynamic_regularization_enable(true)
+            .dynamic_regularization_eps(1e-13)
+            .dynamic_regularization_delta(2e-7)
+            .iterative_refinement_enable(true)
+            .iterative_refinement_reltol(1e-13)
+            .iterative_refinement_abstol(1e-12)
+            .iterative_refinement_max_iter(10)
+            .iterative_refinement_stop_ratio(5.0)
+            .presolve_enable(true)
+            .input_sparse_dropzeros(false)
+    }
+
+    #[test]
+    fn builder_sets_all_fields() {
+        let o = all_options_set();
+        // universal + enum + a representative scalar of each type.
+        assert_eq!(o.universal.threads, Some(1));
+        assert_eq!(o.direct_solve_method, Some(ClarabelDirectSolve::Auto));
+        assert_eq!(o.max_iter, Some(500)); // u32
+        assert_eq!(o.tol_gap_abs, Some(1e-8)); // f64
+        assert_eq!(o.reduced_tol_infeas_abs, Some(5e-12));
+        assert_eq!(o.equilibrate_max_iter, Some(10));
+        assert_eq!(o.presolve_enable, Some(true)); // bool
+        assert_eq!(o.input_sparse_dropzeros, Some(false));
+        assert_eq!(o.iterative_refinement_stop_ratio, Some(5.0));
+    }
+
+    #[test]
+    fn apply_all_options_solves() {
+        // Setting every option must still produce settings `DefaultSolver::new`
+        // accepts and an LP that solves to the known optimum.
+        let m = Model::new("lp");
+        variable!(m, 0.0 <= x <= 3.0);
+        variable!(m, 0.0 <= y <= 3.0);
+        constraint!(m, cap, x + y <= 4.0);
+        objective!(m, Max, 3.0 * x + 2.0 * y);
+
+        let res = solve(&m, &all_options_set()).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 11.0, 1e-6));
+    }
+
+    #[test]
+    fn direct_solve_method_qdldl_solves() {
+        let m = Model::new("lp");
+        variable!(m, 0.0 <= x <= 3.0);
+        variable!(m, 0.0 <= y <= 3.0);
+        constraint!(m, cap, x + y <= 4.0);
+        objective!(m, Max, 3.0 * x + 2.0 * y);
+
+        let opts = ClarabelOptions::default().direct_solve_method(ClarabelDirectSolve::Qdldl);
+        let res = solve(&m, &opts).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 11.0, 1e-6));
+    }
+
+    #[cfg(feature = "faer")]
+    #[test]
+    fn direct_solve_method_faer_solves() {
+        let m = Model::new("lp");
+        variable!(m, 0.0 <= x <= 3.0);
+        variable!(m, 0.0 <= y <= 3.0);
+        constraint!(m, cap, x + y <= 4.0);
+        objective!(m, Max, 3.0 * x + 2.0 * y);
+
+        let opts = ClarabelOptions::default().direct_solve_method(ClarabelDirectSolve::Faer);
+        let res = solve(&m, &opts).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 11.0, 1e-6));
+    }
+
+    #[test]
+    fn low_max_iter_caps_iterations() {
+        let m = Model::new("cvxopt");
+        variable!(m, x0 >= 0.0);
+        variable!(m, x1 >= 0.0);
+        constraint!(m, eq, x0 + x1 == 1.0);
+        objective!(m, Min, 2.0 * x0.powi(2) + x0 * x1 + x1.powi(2) + x0 + x1);
+
+        let res = solve(&m, &ClarabelOptions::default().max_iter(1)).unwrap();
+        assert!(res.iterations <= 1, "iterations = {}", res.iterations);
+    }
+
+    #[test]
+    fn threads_maps_to_max_threads() {
+        let m = Model::new("lp");
+        variable!(m, 0.0 <= x <= 3.0);
+        variable!(m, 0.0 <= y <= 3.0);
+        constraint!(m, cap, x + y <= 4.0);
+        objective!(m, Max, 3.0 * x + 2.0 * y);
+
+        let res = solve(&m, &ClarabelOptions::default().threads(2)).unwrap();
+        assert_eq!(res.termination, TerminationStatus::Optimal);
+        assert!(close(res.objective().unwrap(), 11.0, 1e-6));
+    }
+}

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -173,6 +173,20 @@ constraint!(m, flow[i in 0..n, j in 0..m], x[i, j] >= 0.0);
 constraint!(m, diag[(i, j) in rc if i == j], x[i, j] <= 1.0);
 ```
 
+### Second-order cone constraints
+
+`soc_constraint!` registers `||terms||_2 <= bound`. Every term and the bound
+must be affine. The model classifies as `SOCP`/`MISOCP`.
+
+```rust,ignore
+soc_constraint!(m, cone, [x, y] <= t);                       // named -> SocConstraintId
+soc_constraint!(m, [x - y, 2.0 * y] <= t + 1.0);             // anonymous (auto-named _soc0, ...)
+soc_constraint!(m, name = format!("c_{k}"), [x] <= t);       // computed run-time name
+soc_constraint!(m, risk[i in assets], [s[i] * w[i]] <= cap); // family: risk[key] per key
+```
+
+The method form `m.add_soc_constraint("cone", [x, y], t)` is equivalent.
+
 ### Summation
 
 `sum!(body for k in domain)` reads as `sum_{k in domain} body`. Nest with extra
@@ -218,16 +232,17 @@ m.param_value_idx(&cost, 1);    // -> Some(9.0)
 
 ## Model kind
 
-Inferred automatically from variables and expressions, cached and invalidated on change:
+Inferred automatically from variables and expressions, cached and invalidated
+on change. The decision ladder runs top-down. Any integer/binary variable
+picks the `MI*` variant of the row that matches:
 
-| Kind    | Conditions                                          |
-|---------|-----------------------------------------------------|
-| `LP`    | All continuous, all linear                          |
-| `MILP`  | Any integer/binary, all linear                      |
-| `QP`    | All continuous, `Mul` with >=2 non-const children   |
-| `MIQP`  | Any integer/binary + quadratic                      |
-| `NLP`   | All continuous, `Pow`/`Sin`/`Cos`/`Exp`/`Log`/`Abs` |
-| `MINLP` | Any integer/binary + nonlinear                      |
+| Kind (continuous/integer) | Conditions                                                       |
+|---------------------------|------------------------------------------------------------------|
+| `NLP`/`MINLP`             | Any nonlinear expression (degree > 2, transcendentals, division) |
+| `QCP`/`MIQCP`             | Any quadratic constraint not recognized as a second-order cone   |
+| `SOCP`/`MISOCP`           | Second-order cones present (explicit or detected)                |
+| `QP`/`MIQP`               | Quadratic objective, linear constraints                          |
+| `LP`/`MILP`               | Everything linear                                                |
 
 ## License
 

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod objective;
 pub mod param;
 pub mod prelude;
 pub mod set;
+pub mod soc;
 pub mod sum;
 pub mod var;
 
@@ -26,6 +27,7 @@ pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
 pub use set::{Axis, FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};
+pub use soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
 pub use sum::SumDomain;
 pub use var::{VarBuilder, Variable};
 

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -35,4 +35,4 @@ pub use var::{VarBuilder, Variable};
 // `oximo-expr` import.
 pub use oximo_expr::{Expr, ExprArena, ExprId, ExprNode, ParamId, VarId, dot};
 
-pub use oximo_macros::{constraint, objective, param, set, sum, variable};
+pub use oximo_macros::{constraint, objective, param, set, soc_constraint, sum, variable};

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -12,18 +12,35 @@ use crate::indexed::{IndexedFamily, IndexedParam, IndexedVar, build_storage};
 use crate::objective::{Objective, ObjectiveSense};
 use crate::param::Parameter;
 use crate::set::{Axis, FromIndexKey, IndexKey, Set};
+use crate::soc::{SocConstraint, SocConstraintId, detect_soc};
 use crate::var::{VarBuilder, Variable};
 
 /// The kind of mathematical program a `Model` represents.
 ///
 /// This is inferred from the variables and expressions in the model, not set
-/// explicitly by the user. See [`Model::kind`] for details.
+/// explicitly by the user. See [`Model::kind`] for the exact decision ladder.
+///
+/// The `MI*` variant of each class is picked when any variable has an integer
+/// domain. The continuous classes are, from most to least general:
+///
+/// - `NLP`: some expression is nonlinear (degree > 2, transcendental, division)
+/// - `QCP`: some constraint is quadratic and not recognized as a second-order
+///   cone
+/// - `SOCP`: second-order cone constraints are present (explicit
+///   [`crate::SocConstraint`]s or SOC-shaped quadratic constraints recognized
+///   by [`crate::detect_soc`]); the objective may be linear or quadratic
+/// - `QP`: quadratic objective, linear constraints
+/// - `LP`: everything linear
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ModelKind {
     LP,
     MILP,
     QP,
     MIQP,
+    QCP,
+    MIQCP,
+    SOCP,
+    MISOCP,
     NLP,
     MINLP,
 }
@@ -45,6 +62,8 @@ pub struct Model {
     pub(crate) param_names: RefCell<FxHashMap<SmolStr, ParamId>>,
     pub(crate) constraints: RefCell<Vec<Constraint>>,
     pub(crate) constraint_names: RefCell<FxHashMap<SmolStr, ConstraintId>>,
+    pub(crate) soc_constraints: RefCell<Vec<SocConstraint>>,
+    pub(crate) soc_names: RefCell<FxHashMap<SmolStr, SocConstraintId>>,
     pub(crate) objective: RefCell<Option<Objective>>,
     cached_kind: Cell<Option<ModelKind>>,
     /// Monotonic counter for auto-naming anonymous constraints registered via
@@ -59,6 +78,7 @@ impl std::fmt::Debug for Model {
             .field("vars", &self.variables.borrow().len())
             .field("params", &self.parameters.borrow().len())
             .field("constraints", &self.constraints.borrow().len())
+            .field("soc_constraints", &self.soc_constraints.borrow().len())
             .field("has_objective", &self.objective.borrow().is_some())
             .finish()
     }
@@ -75,6 +95,8 @@ impl Model {
             param_names: RefCell::new(FxHashMap::default()),
             constraints: RefCell::new(Vec::new()),
             constraint_names: RefCell::new(FxHashMap::default()),
+            soc_constraints: RefCell::new(Vec::new()),
+            soc_names: RefCell::new(FxHashMap::default()),
             objective: RefCell::new(None),
             cached_kind: Cell::new(None),
             auto_seq: Cell::new(0),
@@ -175,6 +197,8 @@ impl Model {
         let v = &mut vars[id.index()];
         v.lb = value;
         v.ub = value;
+        drop(vars);
+        self.cached_kind.set(None);
     }
 
     /// Set the initial (warm-start) value of a single-variable expression.
@@ -196,6 +220,8 @@ impl Model {
         let v = &mut vars[id.index()];
         v.lb = lb;
         v.ub = ub;
+        drop(vars);
+        self.cached_kind.set(None);
     }
 
     // Parameters
@@ -531,6 +557,72 @@ impl Model {
         self.constraint_names.borrow().get(name).copied()
     }
 
+    // Second-order cone constraints
+
+    /// Register the explicit second-order cone constraint
+    /// `||terms||_2 <= bound`.
+    ///
+    /// Every member of `terms` and the `bound` must be affine; the bound is
+    /// additionally constrained to be nonnegative by the cone itself, so
+    /// backends emit a `bound >= 0` side condition where needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a SOC constraint with the same name is already registered, if
+    /// `terms` is empty, if any term or the bound is not affine, or if the
+    /// count exceeds `u32::MAX`.
+    pub fn add_soc_constraint<'a>(
+        &'a self,
+        name: impl Into<SmolStr>,
+        terms: impl IntoIterator<Item = Expr<'a>>,
+        bound: Expr<'a>,
+    ) -> SocConstraintId {
+        let name = name.into();
+        let arena = self.arena.borrow();
+        let terms: Vec<ExprId> = terms
+            .into_iter()
+            .map(|e| {
+                assert!(
+                    classify(&arena, e.id) == ExprClass::Linear,
+                    "SOC constraint {name:?} has a non-affine term"
+                );
+                e.id
+            })
+            .collect();
+        assert!(!terms.is_empty(), "SOC constraint {name:?} has no terms");
+        assert!(
+            classify(&arena, bound.id) == ExprClass::Linear,
+            "SOC constraint {name:?} has a non-affine bound"
+        );
+        drop(arena);
+
+        let mut by_name = self.soc_names.borrow_mut();
+        assert!(!by_name.contains_key(&name), "SOC constraint name {name:?} already registered");
+        let mut all = self.soc_constraints.borrow_mut();
+        let id = SocConstraintId(u32::try_from(all.len()).expect("SOC constraint count overflow"));
+        all.push(SocConstraint { name: name.clone(), terms, bound: bound.id, active: true });
+        by_name.insert(name, id);
+        self.cached_kind.set(None);
+        id
+    }
+
+    pub fn soc_constraints(&self) -> Ref<'_, Vec<SocConstraint>> {
+        self.soc_constraints.borrow()
+    }
+
+    pub fn num_soc_constraints(&self) -> usize {
+        self.soc_constraints.borrow().len()
+    }
+
+    pub fn soc_constraint_id(&self, name: &str) -> Option<SocConstraintId> {
+        self.soc_names.borrow().get(name).copied()
+    }
+
+    /// Whether the model carries any explicit second-order cone constraints.
+    pub fn has_cones(&self) -> bool {
+        !self.soc_constraints.borrow().is_empty()
+    }
+
     // Objective
 
     /// Macro-facing entry point backing `objective!(m, Min, ..)`. Not part of the
@@ -570,33 +662,64 @@ impl Model {
     /// Infer the [`ModelKind`] from current variables and expressions.
     /// Result is cached and invalidated whenever variables, constraints, or the
     /// objective change.
+    ///
+    /// The decision ladder, top-down (any integer variable picks the `MI*`
+    /// column):
+    ///
+    /// 1. any nonlinear expression (objective or constraint) -> `NLP`
+    /// 2. any quadratic constraint not recognized as SOC (see
+    ///    [`crate::detect_soc`]) -> `QCP`
+    /// 3. cones present (explicit or detected) -> `SOCP`
+    /// 4. quadratic objective -> `QP`
+    /// 5. otherwise -> `LP`
     pub fn kind(&self) -> ModelKind {
         if let Some(k) = self.cached_kind.get() {
             return k;
         }
         let arena = self.arena.borrow();
-        let has_int = self.variables.borrow().iter().any(|v| v.domain.is_integer());
+        let vars = self.variables.borrow();
+        let has_int = vars.iter().any(|v| v.domain.is_integer());
+        let obj_class = self
+            .objective
+            .borrow()
+            .as_ref()
+            .map_or(ExprClass::Linear, |o| classify(&arena, o.expr));
 
-        // Highest expression class across the objective and every constraint
-        // determines the model class
-        let mut class = ExprClass::Linear;
-        if let Some(o) = self.objective.borrow().as_ref() {
-            class = class.max(classify(&arena, o.expr));
-        }
-        for c in self.constraints.borrow().iter() {
-            if class == ExprClass::Nonlinear {
-                break;
+        let mut any_nonlinear = obj_class == ExprClass::Nonlinear;
+        // A quadratic constraint that is not SOC-shaped.
+        let mut plain_quad_con = false;
+        let mut detected_soc = false;
+        if !any_nonlinear {
+            for c in self.constraints.borrow().iter() {
+                match classify(&arena, c.lhs) {
+                    ExprClass::Linear => {}
+                    ExprClass::Quadratic => {
+                        if detect_soc(&arena, &vars, c).is_some() {
+                            detected_soc = true;
+                        } else {
+                            plain_quad_con = true;
+                        }
+                    }
+                    ExprClass::Nonlinear => {
+                        any_nonlinear = true;
+                        break;
+                    }
+                }
             }
-            class = class.max(classify(&arena, c.lhs));
         }
+        let has_soc = detected_soc || !self.soc_constraints.borrow().is_empty();
 
-        let k = match (has_int, class) {
-            (false, ExprClass::Linear) => ModelKind::LP,
-            (true, ExprClass::Linear) => ModelKind::MILP,
-            (false, ExprClass::Quadratic) => ModelKind::QP,
-            (true, ExprClass::Quadratic) => ModelKind::MIQP,
-            (false, ExprClass::Nonlinear) => ModelKind::NLP,
-            (true, ExprClass::Nonlinear) => ModelKind::MINLP,
+        let pick = |cont, int| if has_int { int } else { cont };
+        let k = if any_nonlinear {
+            pick(ModelKind::NLP, ModelKind::MINLP)
+        } else if plain_quad_con {
+            pick(ModelKind::QCP, ModelKind::MIQCP)
+        } else if has_soc {
+            pick(ModelKind::SOCP, ModelKind::MISOCP)
+        } else if obj_class == ExprClass::Quadratic {
+            pick(ModelKind::QP, ModelKind::MIQP)
+        } else {
+            pick(ModelKind::LP, ModelKind::MILP)
         };
         self.cached_kind.set(Some(k));
         k

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -606,6 +606,55 @@ impl Model {
         id
     }
 
+    /// A fresh unique auto-name `_soc{n}` in the SOC namespace, skipping any a
+    /// user already took. Shares `auto_seq` with [`Self::next_auto_name`]; the
+    /// prefixes differ, so the two namespaces never collide.
+    fn next_auto_soc_name(&self) -> SmolStr {
+        loop {
+            let n = self.auto_seq.get();
+            self.auto_seq.set(n + 1);
+            let candidate: SmolStr = format!("_soc{n}").into();
+            if !self.soc_names.borrow().contains_key(&candidate) {
+                break candidate;
+            }
+        }
+    }
+
+    /// Register an anonymous SOC constraint, deriving a unique name `_soc{n}`
+    /// from an internal counter. Backs the name-less form of the
+    /// `soc_constraint!` macro. Not part of the stable public API.
+    #[doc(hidden)]
+    pub fn __add_soc_constraint_auto<'a>(
+        &'a self,
+        terms: impl IntoIterator<Item = Expr<'a>>,
+        bound: Expr<'a>,
+    ) -> SocConstraintId {
+        self.add_soc_constraint(self.next_auto_soc_name(), terms, bound)
+    }
+
+    /// Macro-facing entry point backing the indexed-family form of the
+    /// `soc_constraint!` macro: one cone per key, named `{prefix}[{key}]`. The
+    /// closure returns the cone's `(terms, bound)` pair for each typed key.
+    /// Not part of the stable public API.
+    #[doc(hidden)]
+    pub fn __add_soc_constraints_over<'a, K, T, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        mut rule: F,
+    ) where
+        K: FromIndexKey,
+        T: IntoIterator<Item = Expr<'a>>,
+        F: FnMut(K) -> (T, Expr<'a>),
+    {
+        for key in set {
+            let typed = K::from_index_key(&key);
+            let (terms, bound) = rule(typed);
+            let name: SmolStr = format_index_name(name_prefix, &key).into();
+            self.add_soc_constraint(name, terms, bound);
+        }
+    }
+
     pub fn soc_constraints(&self) -> Ref<'_, Vec<SocConstraint>> {
         self.soc_constraints.borrow()
     }

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -11,4 +11,4 @@ pub use crate::sum::SumDomain;
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};
 
-pub use oximo_macros::{constraint, objective, param, set, sum, variable};
+pub use oximo_macros::{constraint, objective, param, set, soc_constraint, sum, variable};

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -6,6 +6,7 @@ pub use crate::model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
+pub use crate::soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
 pub use crate::sum::SumDomain;
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};

--- a/crates/oximo-core/src/soc.rs
+++ b/crates/oximo-core/src/soc.rs
@@ -1,0 +1,104 @@
+use oximo_expr::{ExprArena, ExprId, LinearTerms, VarId, extract_linear, extract_quadratic};
+use smol_str::SmolStr;
+
+use crate::constraint::{Constraint, Sense};
+use crate::var::Variable;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SocConstraintId(pub u32);
+
+impl SocConstraintId {
+    #[inline]
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+// TODO: Support rotated cones
+
+/// An explicit second-order cone constraint `||terms||_2 <= bound`.
+///
+/// Every member of `terms` and the `bound` must be affine. This is validated
+/// when the constraint is registered via [`crate::Model::add_soc_constraint`].
+/// Rotated cones (`2uv >= ||w||^2`) are not supported yet.
+#[derive(Clone, Debug)]
+pub struct SocConstraint {
+    pub name: SmolStr,
+    pub terms: Vec<ExprId>,
+    pub bound: ExprId,
+    pub active: bool,
+}
+
+/// Normalized second-order cone data: `|| A x + a ||_2 <= b'x + beta`, one
+/// [`LinearTerms`] per row of `A x + a` plus one for the bound side. Produced
+/// by [`detect_soc`] (algebraic quadratic constraints) and
+/// [`explicit_soc_form`] ([`SocConstraint`]s), so backends translate both
+/// through a single shape.
+#[derive(Clone, Debug)]
+pub struct SocForm {
+    pub terms: Vec<LinearTerms>,
+    pub bound: LinearTerms,
+}
+
+// TODO: Here we are deliberately conservative and purely structural
+
+/// Recognize an algebraic quadratic constraint as second-order-cone shaped.
+///
+/// A constraint is recognized iff:
+///
+/// - it is single-sided `lhs <= rhs` (no ranges, `>=`, or equalities),
+/// - `lhs - rhs` is a pure quadratic form: no linear terms, no constant,
+/// - the Hessian is diagonal with exactly one negative entry `-n` (on the
+///   bound variable `t`) and at least one positive entry `p_i`,
+/// - `t` has lower bound `>= 0`.
+///
+/// That is `sum_i p_i x_i^2 <= n t^2` with `t >= 0`, equivalent to
+/// `|| sqrt(p_i/n) x_i ||_2 <= t`. Cross-term (Cholesky-factorized) quadratic
+/// forms are not detected, they classify as QCP instead.
+pub fn detect_soc(arena: &ExprArena, vars: &[Variable], c: &Constraint) -> Option<SocForm> {
+    let (sense, rhs) = c.as_single()?;
+    if sense != Sense::Le {
+        return None;
+    }
+    let q = extract_quadratic(arena, c.lhs)?;
+    if !q.linear.is_empty() || q.constant - rhs != 0.0 {
+        return None;
+    }
+
+    let mut positives: Vec<(VarId, f64)> = Vec::new();
+    let mut negative: Option<(VarId, f64)> = None;
+    for &(row, col, h) in &q.hessian {
+        if row != col {
+            return None;
+        }
+        let coef = h / 2.0;
+        if coef > 0.0 {
+            positives.push((row, coef));
+        } else if coef < 0.0 {
+            if negative.is_some() {
+                return None;
+            }
+            negative = Some((row, -coef));
+        }
+    }
+    let (t, n) = negative?;
+    if positives.is_empty() || vars[t.index()].lb < 0.0 {
+        return None;
+    }
+
+    let terms = positives
+        .into_iter()
+        .map(|(x, p)| LinearTerms { coeffs: vec![(x, (p / n).sqrt())], constant: 0.0 })
+        .collect();
+    let bound = LinearTerms { coeffs: vec![(t, 1.0)], constant: 0.0 };
+    Some(SocForm { terms, bound })
+}
+
+/// The normalized [`SocForm`] view of an explicit [`SocConstraint`]. Members
+/// are validated affine at registration, so this only returns `None` on a
+/// corrupted model (e.g. an `ExprId` from a different arena).
+pub fn explicit_soc_form(arena: &ExprArena, s: &SocConstraint) -> Option<SocForm> {
+    let terms = s.terms.iter().map(|&e| extract_linear(arena, e)).collect::<Option<Vec<_>>>()?;
+    let bound = extract_linear(arena, s.bound)?;
+    Some(SocForm { terms, bound })
+}

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -593,3 +593,87 @@ fn set_macro_comprehension_multi_bind_builds_product() {
     assert_eq!(m.num_variables(), 3);
     assert_eq!(m.num_constraints(), 3);
 }
+
+// - soc_constraint! -----------------------------------------------------------
+
+#[test]
+fn soc_named_scalar() {
+    let m = Model::new("soc_named");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    let id = soc_constraint!(m, cone, [x, y] <= t);
+    assert_eq!(m.soc_constraint_id("cone"), Some(id));
+    assert_eq!(m.num_soc_constraints(), 1);
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+}
+
+#[test]
+fn soc_anonymous_auto_names() {
+    let m = Model::new("soc_anon");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    soc_constraint!(m, [x] <= t);
+    soc_constraint!(m, [x, t] <= t + 1.0);
+    assert!(m.soc_constraint_id("_soc0").is_some());
+    assert!(m.soc_constraint_id("_soc1").is_some());
+    assert_eq!(m.num_soc_constraints(), 2);
+}
+
+#[test]
+fn soc_computed_name() {
+    let m = Model::new("soc_computed");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    let k = 7;
+    soc_constraint!(m, name = format!("cone_{k}"), [x] <= t);
+    assert!(m.soc_constraint_id("cone_7").is_some());
+}
+
+#[test]
+fn soc_affine_terms_and_bound() {
+    let m = Model::new("soc_affine");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    soc_constraint!(m, cone, [x - y, 2.0 * y + 1.0] <= t + 2.0);
+    let socs = m.soc_constraints();
+    assert_eq!(socs[0].terms.len(), 2);
+}
+
+#[test]
+fn soc_family_over_range() {
+    let m = Model::new("soc_family");
+    let assets = Set::range(0..3);
+    variable!(m, u[i in assets]);
+    variable!(m, v[i in assets]);
+    variable!(m, cap >= 0.0);
+    soc_constraint!(m, risk[i in assets], [u[i], v[i]] <= cap);
+    assert_eq!(m.num_soc_constraints(), 3);
+    assert!(m.soc_constraint_id("risk[0]").is_some());
+    assert!(m.soc_constraint_id("risk[2]").is_some());
+    objective!(m, Min, cap);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+}
+
+#[test]
+fn soc_filtered_family() {
+    let m = Model::new("soc_filtered");
+    variable!(m, w[i in 0..4]);
+    variable!(m, t >= 0.0);
+    soc_constraint!(m, even[i in 0..4 if i % 2 == 0], [w[i]] <= t);
+    assert_eq!(m.num_soc_constraints(), 2);
+    assert!(m.soc_constraint_id("even[0]").is_some());
+    assert!(m.soc_constraint_id("even[2]").is_some());
+    assert!(m.soc_constraint_id("even[1]").is_none());
+}
+
+#[test]
+#[should_panic(expected = "non-affine term")]
+fn soc_macro_rejects_quadratic_term() {
+    let m = Model::new("soc_bad");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    soc_constraint!(m, cone, [x * x] <= t);
+}

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -39,13 +39,158 @@ fn classifies_miqp() {
 }
 
 #[test]
-fn quadratic_constraint_classifies_qp() {
-    let m = Model::new("qp_con");
+fn quadratic_constraint_classifies_qcp() {
+    let m = Model::new("qcp");
     variable!(m, x >= 0.0);
-    // Linear objective but a quadratic constraint still makes the model a QP.
+    // A quadratic constraint (not the objective) makes the model a QCP,
+    // not a QP.
     constraint!(m, c, x.powi(2) <= 4.0);
     objective!(m, Min, x);
-    assert_eq!(m.kind(), ModelKind::QP);
+    assert_eq!(m.kind(), ModelKind::QCP);
+}
+
+#[test]
+fn quadratic_objective_and_constraint_classifies_qcp() {
+    let m = Model::new("qcp_both");
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    constraint!(m, c, x * y <= 4.0);
+    objective!(m, Min, x.powi(2));
+    assert_eq!(m.kind(), ModelKind::QCP);
+}
+
+#[test]
+fn integer_var_promotes_qcp_to_miqcp() {
+    let m = Model::new("miqcp");
+    variable!(m, x >= 0.0);
+    variable!(m, 0.0 <= y <= 1.0, Int);
+    constraint!(m, c, x.powi(2) + y <= 4.0);
+    objective!(m, Min, x);
+    assert_eq!(m.kind(), ModelKind::MIQCP);
+}
+
+#[test]
+fn soc_shaped_quadratic_constraint_classifies_socp() {
+    let m = Model::new("socp_detected");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    constraint!(m, c, x.powi(2) + y.powi(2) <= t.powi(2));
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+}
+
+#[test]
+fn soc_detection_requires_nonnegative_bound_var() {
+    let m = Model::new("qcp_signed");
+    variable!(m, x);
+    variable!(m, t);
+    constraint!(m, c, x.powi(2) <= t.powi(2));
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::QCP);
+}
+
+#[test]
+fn detected_socp_with_integer_var_is_misocp() {
+    let m = Model::new("misocp");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    variable!(m, 0.0 <= z <= 1.0, Int);
+    constraint!(m, c, x.powi(2) <= t.powi(2));
+    constraint!(m, link, x + z >= 1.0);
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::MISOCP);
+}
+
+#[test]
+fn explicit_soc_constraint_classifies_socp() {
+    let m = Model::new("socp_explicit");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x, y], t);
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+    assert!(m.has_cones());
+    assert!(m.soc_constraint_id("cone").is_some());
+}
+
+#[test]
+fn explicit_soc_with_quadratic_objective_stays_socp() {
+    let m = Model::new("socp_qobj");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x], t);
+    objective!(m, Min, x.powi(2));
+    assert_eq!(m.kind(), ModelKind::SOCP);
+}
+
+#[test]
+fn explicit_soc_with_plain_quadratic_constraint_is_qcp() {
+    let m = Model::new("qcp_over_socp");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x], t);
+    constraint!(m, c, x * y <= 1.0);
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::QCP);
+}
+
+#[test]
+fn explicit_soc_with_nonlinear_constraint_is_nlp() {
+    let m = Model::new("nlp_over_socp");
+    variable!(m, x >= 0.1);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x], t);
+    constraint!(m, c, x.sin() <= 0.5);
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::NLP);
+}
+
+#[test]
+#[should_panic(expected = "non-affine term")]
+fn add_soc_constraint_rejects_quadratic_term() {
+    let m = Model::new("bad_soc");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x * x], t);
+}
+
+#[test]
+fn bound_change_invalidates_kind_cache() {
+    // Kind depends on bounds: `x^2 <= t^2` is SOC only while `t >= 0`, so a
+    // bound mutation after `kind()` was cached must recompute.
+    let m = Model::new("soc_bounds");
+    variable!(m, x);
+    variable!(m, t);
+    constraint!(m, c, x.powi(2) <= t.powi(2));
+    objective!(m, Min, t);
+    // t is free, so the squared form is not a cone.
+    assert_eq!(m.kind(), ModelKind::QCP);
+
+    // Fixing t to a nonnegative value makes the row a cone.
+    m.fix(t, 1.0);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    // Unfixing back to a free variable demotes it again.
+    m.unfix_var(t.var_id().unwrap(), f64::NEG_INFINITY, f64::INFINITY);
+    assert_eq!(m.kind(), ModelKind::QCP);
+
+    // A nonnegative lower bound restores the cone.
+    m.unfix_var(t.var_id().unwrap(), 0.0, f64::INFINITY);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+}
+
+#[test]
+fn adding_soc_constraint_invalidates_kind_cache() {
+    let m = Model::new("soc_cache");
+    variable!(m, x >= 0.0);
+    variable!(m, t >= 0.0);
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::LP);
+    m.add_soc_constraint("cone", [x], t);
+    assert_eq!(m.kind(), ModelKind::SOCP);
 }
 
 #[test]

--- a/crates/oximo-core/tests/soc.rs
+++ b/crates/oximo-core/tests/soc.rs
@@ -1,0 +1,115 @@
+//! Tests for SOC pattern detection (`detect_soc`) and the normalized
+//! `SocForm` views backends translate from.
+
+#![allow(clippy::float_cmp, clippy::many_single_char_names)]
+
+use oximo_core::prelude::*;
+
+fn detect_first(m: &Model) -> Option<SocForm> {
+    let arena = m.arena();
+    let vars = m.variables();
+    let constraints = m.constraints();
+    detect_soc(&arena, &vars, &constraints[0])
+}
+
+#[test]
+fn accepts_scaled_sum_of_squares() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    constraint!(m, c, 2.0 * x * x + 3.0 * y * y <= 5.0 * t * t);
+
+    let form = detect_first(&m).expect("should detect SOC");
+    assert_eq!(form.terms.len(), 2);
+    let coef_of = |name: &str| {
+        let id = m.variable_id(name).unwrap();
+        form.terms.iter().find(|lt| lt.coeffs[0].0 == id).map(|lt| lt.coeffs[0].1).unwrap()
+    };
+    assert!((coef_of("x") - (2.0f64 / 5.0).sqrt()).abs() < 1e-12);
+    assert!((coef_of("y") - (3.0f64 / 5.0).sqrt()).abs() < 1e-12);
+    assert_eq!(form.bound.coeffs, vec![(m.variable_id("t").unwrap(), 1.0)]);
+    assert_eq!(form.bound.constant, 0.0);
+}
+
+#[test]
+fn rejects_cross_terms() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    constraint!(m, c, x * x + x * y + y * y <= t * t);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn rejects_linear_part() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    constraint!(m, c, x * x + x <= t * t);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn rejects_nonzero_constant() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    constraint!(m, c, x * x + 1.0 <= t * t);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn rejects_ge_sense() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    constraint!(m, c, x * x >= t * t);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn rejects_two_negative_squares() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    variable!(m, u >= 0.0);
+    constraint!(m, c, x * x - u * u <= t * t);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn rejects_all_positive_squares() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, y);
+    constraint!(m, c, x * x + y * y <= 4.0);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn rejects_unsigned_bound_variable() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, t);
+    constraint!(m, c, x * x <= t * t);
+    assert!(detect_first(&m).is_none());
+}
+
+#[test]
+fn explicit_form_recovers_affine_rows() {
+    let m = Model::new("soc");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x - y, 2.0 * y + 1.0], t);
+
+    let arena = m.arena();
+    let socs = m.soc_constraints();
+    let form = explicit_soc_form(&arena, &socs[0]).expect("affine members");
+    assert_eq!(form.terms.len(), 2);
+    assert_eq!(form.terms[0].coeffs.len(), 2);
+    assert_eq!(form.terms[1].constant, 1.0);
+    assert_eq!(form.bound.coeffs, vec![(m.variable_id("t").unwrap(), 1.0)]);
+}

--- a/crates/oximo-gams/src/lib.rs
+++ b/crates/oximo-gams/src/lib.rs
@@ -46,6 +46,26 @@ impl Gams {
 /// and the `solver_name` stamped on every [`SolverResult`].
 pub(crate) const NAME: &str = "GAMS";
 
+/// GAMS handles every kind oximo classifies: quadratic constraints route
+/// through the QCP/MIQCP solve types and explicit SOC constraints are emitted
+/// as quadratic `sqr(..)` rows. Whether the selected sub-solver copes is
+/// checked separately (see `validate_solver`).
+pub(crate) const fn supported(kind: ModelKind) -> bool {
+    matches!(
+        kind,
+        ModelKind::LP
+            | ModelKind::MILP
+            | ModelKind::QP
+            | ModelKind::MIQP
+            | ModelKind::QCP
+            | ModelKind::MIQCP
+            | ModelKind::SOCP
+            | ModelKind::MISOCP
+            | ModelKind::NLP
+            | ModelKind::MINLP
+    )
+}
+
 impl Solver for Gams {
     type Options = GamsOptions;
 
@@ -54,15 +74,7 @@ impl Solver for Gams {
     }
 
     fn supports(&self, kind: ModelKind) -> bool {
-        matches!(
-            kind,
-            ModelKind::LP
-                | ModelKind::MILP
-                | ModelKind::QP
-                | ModelKind::MIQP
-                | ModelKind::NLP
-                | ModelKind::MINLP
-        )
+        supported(kind)
     }
 
     fn solve(&mut self, model: &Model, opts: &GamsOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -9,8 +9,8 @@ use std::{fs, io};
 static SOLVE_ID: AtomicU64 = AtomicU64::new(0);
 
 use oximo_core::{
-    Constraint, ConstraintId, Domain, Model, ModelKind, Objective, ObjectiveSense, Sense, VarId,
-    Variable,
+    Constraint, ConstraintId, Domain, Model, ModelKind, Objective, ObjectiveSense, Sense,
+    SocConstraint, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
@@ -44,6 +44,7 @@ pub fn solve(
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
+    let socs = model.soc_constraints();
     let objective = model.try_objective().map_err(SolverError::Core)?;
     let sense = objective.sense;
 
@@ -59,6 +60,7 @@ pub fn solve(
         &arena,
         &vars,
         &constraints,
+        &socs,
         &objective,
         sense_kw,
         opts,
@@ -105,6 +107,7 @@ pub fn solve(
     drop(arena);
     drop(vars);
     drop(constraints);
+    drop(socs);
 
     // - Write .gms file
     let gms_path = tmp_dir.join("model.gms");
@@ -509,6 +512,7 @@ fn build_model_section(
     arena: &ExprArena,
     vars: &[Variable],
     constraints: &[Constraint],
+    socs: &[SocConstraint],
     objective: &Objective,
     sense_kw: &str,
     opts: &GamsOptions,
@@ -519,7 +523,7 @@ fn build_model_section(
     write_preamble(gms);
     write_var_declarations(gms, vars);
     write_bounds_and_initials(gms, vars);
-    write_equations(gms, arena, constraints, objective);
+    write_equations(gms, arena, constraints, socs, objective);
     write_options(gms, opts, solve_type);
     write_model_and_solve(gms, solve_type, sense_kw, solver_opt.is_some());
 
@@ -530,8 +534,8 @@ pub(crate) fn gams_solve_type(kind: ModelKind) -> &'static str {
     match kind {
         ModelKind::LP => "LP",
         ModelKind::MILP => "MIP",
-        ModelKind::QP => "QCP",
-        ModelKind::MIQP => "MIQCP",
+        ModelKind::QP | ModelKind::QCP | ModelKind::SOCP => "QCP",
+        ModelKind::MIQP | ModelKind::MIQCP | ModelKind::MISOCP => "MIQCP",
         ModelKind::NLP => "NLP",
         ModelKind::MINLP => "MINLP",
     }
@@ -665,6 +669,7 @@ fn write_equations(
     gms: &mut String,
     arena: &ExprArena,
     constraints: &[Constraint],
+    socs: &[SocConstraint],
     objective: &Objective,
 ) {
     write!(gms, "Equations\n    eq_obj").unwrap();
@@ -674,6 +679,9 @@ fn write_equations(
         } else {
             write!(gms, ", eq_c{i}_lo, eq_c{i}_hi").unwrap();
         }
+    }
+    for i in 0..socs.len() {
+        write!(gms, ", eq_soc{i}, eq_soc{i}_sign").unwrap();
     }
     writeln!(gms, ";").unwrap();
     writeln!(gms).unwrap();
@@ -725,7 +733,36 @@ fn write_equations(
             }
         }
     }
+    write_soc_equations(gms, arena, socs);
     writeln!(gms).unwrap();
+}
+
+// TODO: Report SOC duals
+
+/// Emit each explicit SOC constraint `||terms||_2 <= bound` as the quadratic
+/// row `sqr(term_1) + ... =l= sqr(bound)` plus the sign row `bound =g= 0`
+/// (squaring loses the sign of the bound side).
+fn write_soc_equations(gms: &mut String, arena: &ExprArena, socs: &[SocConstraint]) {
+    for (i, s) in socs.iter().enumerate() {
+        write!(gms, "eq_soc{i}.. ").unwrap();
+        for (k, &term) in s.terms.iter().enumerate() {
+            if k > 0 {
+                write!(gms, " +").unwrap();
+            }
+            let t = extract_linear(arena, term).expect("SOC members are validated affine");
+            write!(gms, " sqr(").unwrap();
+            write_linear(gms, &t, true);
+            write!(gms, " )").unwrap();
+        }
+        let b = extract_linear(arena, s.bound).expect("SOC bound is validated affine");
+        write!(gms, " =l= sqr(").unwrap();
+        write_linear(gms, &b, true);
+        writeln!(gms, " );").unwrap();
+
+        write!(gms, "eq_soc{i}_sign..").unwrap();
+        write_linear(gms, &b, true);
+        writeln!(gms, " =g= 0;").unwrap();
+    }
 }
 
 fn write_model_and_solve(gms: &mut String, solve_type: &str, sense_kw: &str, has_opt: bool) {
@@ -939,6 +976,7 @@ mod tests {
         let arena = model.arena();
         let vars = model.variables();
         let constraints = model.constraints();
+        let socs = model.soc_constraints();
         let objective = model.try_objective().expect("objective set");
         let sense_kw = match objective.sense {
             ObjectiveSense::Minimize => "minimizing",
@@ -951,6 +989,7 @@ mod tests {
             &arena,
             &vars,
             &constraints,
+            &socs,
             &objective,
             sense_kw,
             opts,
@@ -1044,6 +1083,53 @@ mod tests {
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using MINLP maximizing v_obj;"), "got:\n{gms}");
         assert!(gms.contains("log("), "expected log(...) in objective:\n{gms}");
+    }
+
+    #[test]
+    fn solve_type_map_is_total_over_all_kinds() {
+        assert_eq!(gams_solve_type(ModelKind::LP), "LP");
+        assert_eq!(gams_solve_type(ModelKind::MILP), "MIP");
+        assert_eq!(gams_solve_type(ModelKind::QP), "QCP");
+        assert_eq!(gams_solve_type(ModelKind::MIQP), "MIQCP");
+        assert_eq!(gams_solve_type(ModelKind::QCP), "QCP");
+        assert_eq!(gams_solve_type(ModelKind::MIQCP), "MIQCP");
+        assert_eq!(gams_solve_type(ModelKind::SOCP), "QCP");
+        assert_eq!(gams_solve_type(ModelKind::MISOCP), "MIQCP");
+        assert_eq!(gams_solve_type(ModelKind::NLP), "NLP");
+        assert_eq!(gams_solve_type(ModelKind::MINLP), "MINLP");
+    }
+
+    #[test]
+    fn explicit_soc_emits_sqr_rows_and_sign_row() {
+        let m = Model::new("socp");
+        variable!(m, -10.0 <= x <= 10.0);
+        variable!(m, -10.0 <= y <= 10.0);
+        variable!(m, t >= 0.0);
+        m.add_soc_constraint("cone", [x, y], t);
+        objective!(m, Min, x + y);
+        assert_eq!(m.kind(), ModelKind::SOCP);
+
+        let gms = render(&m, &GamsOptions::default());
+        assert!(gms.contains("eq_soc0, eq_soc0_sign"), "declares SOC equations:\n{gms}");
+        assert!(gms.contains("eq_soc0.. "), "emits SOC row:\n{gms}");
+        assert!(gms.contains("sqr("), "uses sqr():\n{gms}");
+        assert!(gms.contains("=l= sqr("), "bound side squared:\n{gms}");
+        assert!(gms.contains("eq_soc0_sign.."), "emits sign row:\n{gms}");
+        assert!(gms.contains("=g= 0;"), "sign row nonneg:\n{gms}");
+        assert!(gms.contains("Solve oximo_m using QCP minimizing v_obj;"), "got:\n{gms}");
+    }
+
+    #[test]
+    fn subsolver_capabilities_cover_new_kinds() {
+        use crate::GamsSolver;
+        use crate::solver_options::GamsSolverConfig;
+        let cplex = GamsSolverConfig::from(GamsSolver::Cplex);
+        assert!(cplex.supports(ModelKind::QCP));
+        assert!(cplex.supports(ModelKind::SOCP), "SOCP routes through QCP");
+        assert!(cplex.supports(ModelKind::MISOCP));
+        let highs = GamsSolverConfig::from(GamsSolver::Highs);
+        assert!(!highs.supports(ModelKind::QCP), "HiGHS under GAMS is LP/MIP only");
+        assert!(!highs.supports(ModelKind::SOCP));
     }
 
     #[test]

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -786,8 +786,6 @@ fn write_equations(
     writeln!(gms).unwrap();
 }
 
-// TODO: Report SOC duals
-
 /// Emit each explicit SOC constraint `||terms||_2 <= bound` as the quadratic
 /// row `sqr(term_1) + ... =l= sqr(bound)` plus the sign row `bound =g= 0`
 /// (squaring loses the sign of the bound side).

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -10,7 +10,7 @@ static SOLVE_ID: AtomicU64 = AtomicU64::new(0);
 
 use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, Objective, ObjectiveSense, Sense,
-    SocConstraint, VarId, Variable,
+    SocConstraint, SocConstraintId, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
@@ -102,7 +102,16 @@ pub fn solve(
             writeln!(gms, "Put 'D{i}=' eq_c{i}.m:0:15 /;").unwrap();
         }
     }
+    write_soc_marginal_puts(&mut gms, socs.len());
     writeln!(gms, "Putclose oximo_sol;").unwrap();
+
+    // The affine bound side of each explicit SOC constraint, kept to rescale
+    // the squared-form `eq_soc{i}` marginal back to the norm form after the
+    // solve (see `parseoximo_solution`).
+    let soc_bounds: Vec<LinearTerms> = socs
+        .iter()
+        .map(|s| extract_linear(&arena, s.bound).expect("SOC bound is validated affine"))
+        .collect();
 
     drop(arena);
     drop(vars);
@@ -175,7 +184,7 @@ pub fn solve(
     let mut result = if sol_path.exists() {
         let content = fs::read_to_string(&sol_path)
             .map_err(|e| SolverError::Backend(format!("cannot read solution file: {e}")))?;
-        let mut result = parseoximo_solution(&content, elapsed, raw_log);
+        let mut result = parseoximo_solution(&content, &soc_bounds, elapsed, raw_log);
         // If a sub-solver wrote a solution pool (e.g. CPLEX `solnpool`), surface
         // every pooled point. The model itself emits no GDX, so any pool GDX in
         // the run directory came from the user's option file.
@@ -257,9 +266,21 @@ fn summarize_listing(listing: &str) -> String {
     out.join("\n")
 }
 
+/// Emit `Z{i}=` PUT lines reading each lowered SOC row's marginal, mirroring
+/// the `D{i}` constraint-dual lines.
+fn write_soc_marginal_puts(gms: &mut String, n: usize) {
+    for i in 0..n {
+        writeln!(gms, "Put 'Z{i}=' eq_soc{i}.m:0:15 /;").unwrap();
+    }
+}
+
 /// Parse the PUT-generated solution file.
+///
+/// `soc_bounds` holds the affine bound side of each explicit SOC constraint
+/// (in `SocConstraintId` order), the squared-row marginal parsed is rescaled.
 fn parseoximo_solution(
     content: &str,
+    soc_bounds: &[LinearTerms],
     elapsed: std::time::Duration,
     raw_log: Option<String>,
 ) -> SolverResult {
@@ -269,6 +290,7 @@ fn parseoximo_solution(
     let mut iterations: u64 = 0;
     let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
     let mut dual: FxHashMap<ConstraintId, f64> = FxHashMap::default();
+    let mut soc_marginals: FxHashMap<u32, f64> = FxHashMap::default();
     let mut reduced_costs: FxHashMap<VarId, f64> = FxHashMap::default();
 
     for line in content.lines() {
@@ -299,6 +321,14 @@ fn parseoximo_solution(
                     }
                 }
             }
+        } else if let Some(rest) = line.strip_prefix('Z') {
+            if let Some(eq) = rest.find('=') {
+                if let Ok(idx) = rest[..eq].parse::<u32>() {
+                    if let Some(val) = parse_gams_float(rest[eq + 1..].trim()) {
+                        soc_marginals.insert(idx, val);
+                    }
+                }
+            }
         } else if let Some(eq) = line.find('=') {
             let key = line[..eq].trim();
             if let Ok(idx) = key.parse::<u32>() {
@@ -313,6 +343,24 @@ fn parseoximo_solution(
     let termination = map_status(modelstat, solvestat.unwrap_or(0));
     let has_sol = modelstat_has_solution(modelstat);
 
+    // Rescale each lowered SOC row's marginal to the norm-form bound
+    // multiplier using the bound's value at the primal point.
+    let mut soc_dual: FxHashMap<SocConstraintId, f64> = FxHashMap::default();
+    if has_sol {
+        for (i, bound) in soc_bounds.iter().enumerate() {
+            let idx = u32::try_from(i).expect("SOC count overflow");
+            if let Some(m) = soc_marginals.get(&idx) {
+                let b_val = bound.constant
+                    + bound
+                        .coeffs
+                        .iter()
+                        .map(|&(v, c)| c * primal.get(&v).copied().unwrap_or(0.0))
+                        .sum::<f64>();
+                soc_dual.insert(SocConstraintId(idx), 2.0 * b_val * m.abs());
+            }
+        }
+    }
+
     // The PUT solution file holds only the incumbent. `solve` augments this with
     // a sub-solver solution pool (if one was written) read from the run dir's GDX.
     let solutions =
@@ -321,6 +369,7 @@ fn parseoximo_solution(
     SolverResult {
         solutions,
         dual: if has_sol { dual } else { FxHashMap::default() },
+        soc_dual,
         reduced_costs: if has_sol { reduced_costs } else { FxHashMap::default() },
         termination,
         primal_status,
@@ -1001,9 +1050,26 @@ mod tests {
     fn parses_iterations_from_put_file() {
         // The PUT solution file emits `ITER=` from `oximo_m.iterusd`.
         let content = "STATUS=1\nSOLVESTAT=1\nITER=42\nOBJVAL=10.0\n0=2.5\n";
-        let r = parseoximo_solution(content, std::time::Duration::ZERO, None);
+        let r = parseoximo_solution(content, &[], std::time::Duration::ZERO, None);
         assert_eq!(r.termination, TerminationStatus::Optimal);
         assert_eq!(r.iterations, 42);
+    }
+
+    #[test]
+    fn soc_marginal_is_rescaled_to_norm_form() {
+        let content = "STATUS=1\nSOLVESTAT=1\nOBJVAL=-1.0\n0=-1.0\n1=1.5\nZ0=-0.75\n";
+        let bounds = vec![LinearTerms { coeffs: vec![(VarId(1), 1.0)], constant: 0.5 }];
+        let r = parseoximo_solution(content, &bounds, std::time::Duration::ZERO, None);
+        let z0 = r.soc_dual_of(SocConstraintId(0)).expect("SOC dual missing");
+        assert!((z0 - 3.0).abs() < 1e-9, "z0 = {z0}");
+    }
+
+    #[test]
+    fn put_section_reads_soc_marginals() {
+        let mut gms = String::new();
+        write_soc_marginal_puts(&mut gms, 2);
+        assert!(gms.contains("Put 'Z0=' eq_soc0.m:0:15 /;"), "{gms}");
+        assert!(gms.contains("Put 'Z1=' eq_soc1.m:0:15 /;"), "{gms}");
     }
 
     #[test]

--- a/crates/oximo-gurobi/src/lib.rs
+++ b/crates/oximo-gurobi/src/lib.rs
@@ -25,6 +25,25 @@ pub struct Gurobi;
 /// and the `solver_name` stamped on every [`SolverResult`].
 pub(crate) const NAME: &str = "Gurobi";
 
+/// Gurobi handles every kind oximo classifies: linear, quadratic objectives
+/// and constraints, second-order cones (lowered to quadratic rows), and
+/// general nonlinear expressions.
+pub(crate) const fn supported(kind: ModelKind) -> bool {
+    matches!(
+        kind,
+        ModelKind::LP
+            | ModelKind::MILP
+            | ModelKind::QP
+            | ModelKind::MIQP
+            | ModelKind::QCP
+            | ModelKind::MIQCP
+            | ModelKind::SOCP
+            | ModelKind::MISOCP
+            | ModelKind::NLP
+            | ModelKind::MINLP
+    )
+}
+
 impl Solver for Gurobi {
     type Options = GurobiOptions;
 
@@ -33,15 +52,7 @@ impl Solver for Gurobi {
     }
 
     fn supports(&self, kind: ModelKind) -> bool {
-        matches!(
-            kind,
-            ModelKind::LP
-                | ModelKind::MILP
-                | ModelKind::QP
-                | ModelKind::MIQP
-                | ModelKind::NLP
-                | ModelKind::MINLP
-        )
+        supported(kind)
     }
 
     fn solve(&mut self, model: &Model, opts: &GurobiOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-gurobi/src/persistent.rs
+++ b/crates/oximo-gurobi/src/persistent.rs
@@ -110,15 +110,7 @@ impl Solver for GurobiPersistent {
     }
 
     fn supports(&self, kind: ModelKind) -> bool {
-        matches!(
-            kind,
-            ModelKind::LP
-                | ModelKind::MILP
-                | ModelKind::QP
-                | ModelKind::MIQP
-                | ModelKind::NLP
-                | ModelKind::MINLP
-        )
+        crate::supported(kind)
     }
 
     fn solve(&mut self, model: &Model, opts: &GurobiOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -4,7 +4,7 @@ use grb::expr::{LinExpr, QuadExpr};
 use grb::prelude::*;
 use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, SocConstraint,
-    VarId, Variable,
+    SocConstraintId, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, LinearTerms, extract_linear};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
@@ -48,6 +48,7 @@ pub(crate) struct Built {
     pub model: grb::Model,
     pub vars: Vec<grb::Var>,
     pub constrs: Vec<GrbRow>,
+    pub soc_rows: Vec<(grb::QConstr, LinearTerms)>,
     pub obj_constant: f64,
     pub has_semi: bool,
 }
@@ -86,7 +87,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     let mut aux_counter = 0_u32;
     let gurobi_constrs =
         add_constraints(&arena, &constraints, &mut grb_model, &gurobi_vars, &mut aux_counter)?;
-    add_soc_rows(&arena, &socs, &mut grb_model, &gurobi_vars)?;
+    let soc_rows = add_soc_rows(&arena, &socs, &mut grb_model, &gurobi_vars)?;
 
     let obj_constant = match objective.as_ref() {
         Some(o) => {
@@ -109,6 +110,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
         model: grb_model,
         vars: gurobi_vars,
         constrs: gurobi_constrs,
+        soc_rows,
         obj_constant,
         has_semi,
     })
@@ -131,8 +133,14 @@ pub(crate) fn run_and_collect(
     let termination = map_status(&built.model)?;
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let iterations = built.model.get_attr(attr::IterCount).unwrap_or(0.0) as u64;
-    let (solutions, reduced_costs, dual) =
-        collect_solution(kind, &mut built.model, &built.vars, &built.constrs, built.obj_constant);
+    let (solutions, reduced_costs, dual, soc_dual) = collect_solution(
+        kind,
+        &mut built.model,
+        &built.vars,
+        &built.constrs,
+        &built.soc_rows,
+        built.obj_constant,
+    );
 
     let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
     let best_bound = built.model.get_attr(attr::ObjBound).ok().filter(|b| b.is_finite());
@@ -143,6 +151,7 @@ pub(crate) fn run_and_collect(
         primal_status,
         solutions,
         dual,
+        soc_dual,
         reduced_costs,
         best_bound,
         gap,
@@ -256,17 +265,20 @@ fn add_constraints(
     Ok(gurobi_constrs)
 }
 
-// TODO: Report SOC duals
-
 /// Lower each explicit SOC constraint `||terms||_2 <= bound` to the quadratic
 /// row `sum(term_i^2) - bound^2 <= 0` plus the linear side condition
 /// `bound >= 0`.
+///
+/// Returns each cone's quadratic-row handle plus its affine bound side, in
+/// `SocConstraintId` order, so `collect_solution` can rescale the squared-form
+/// `QCPi` multiplier back to the norm form.
 fn add_soc_rows(
     arena: &ExprArena,
     socs: &[SocConstraint],
     grb_model: &mut grb::Model,
     gurobi_vars: &[grb::Var],
-) -> Result<(), SolverError> {
+) -> Result<Vec<(grb::QConstr, LinearTerms)>, SolverError> {
+    let mut rows = Vec::with_capacity(socs.len());
     for (i, s) in socs.iter().enumerate() {
         let mut q = QuadExpr::new();
         for &term in &s.terms {
@@ -275,15 +287,16 @@ fn add_soc_rows(
         }
         let b = extract_linear(arena, s.bound).ok_or(SolverError::Nonlinear)?;
         add_squared_affine(&mut q, &b, -1.0, gurobi_vars);
-        grb_model.add_qconstr(&format!("soc{i}"), c!(q <= 0.0)).map_err(map_grb_err)?;
+        let qrow = grb_model.add_qconstr(&format!("soc{i}"), c!(q <= 0.0)).map_err(map_grb_err)?;
 
         let mut e = LinExpr::new();
         for &(v, co) in &b.coeffs {
             e.add_term(co, gurobi_vars[v.index()]);
         }
         grb_model.add_constr(&format!("soc{i}_sign"), c!(e >= -b.constant)).map_err(map_grb_err)?;
+        rows.push((qrow, b));
     }
-    Ok(())
+    Ok(rows)
 }
 
 /// Expand `sign * (a'x + c)^2` into `q`.
@@ -376,27 +389,38 @@ fn set_objective(
     Ok(0.0)
 }
 
-/// Build `(solutions, reduced_costs, dual)` from a solved Gurobi model.
+/// Build `(solutions, reduced_costs, dual, soc_dual)` from a solved Gurobi
+/// model.
 ///
 /// `solutions` holds every point in Gurobi's solution pool, best first (index 0
 /// is the incumbent). The pool is populated automatically during a MIP solve,
 /// set `PoolSearchMode`/`PoolSolutions` (via [`crate::GurobiOptions`]) to force
 /// Gurobi to enumerate alternative optima. Duals and reduced costs are returned
 /// for continuous models (`LP` and `QP`). For quadratically constrained models
-/// Gurobi computes duals only with `QCPDual=1`.
+/// (`QCP`/`SOCP`, including the lowered SOC rows) Gurobi computes duals only
+/// with `QCPDual=1`.
+/// `(solutions, reduced_costs, dual, soc_dual)` bundle read from a solved model.
+type Collected = (
+    Vec<SolutionPoint>,
+    FxHashMap<VarId, f64>,
+    FxHashMap<ConstraintId, f64>,
+    FxHashMap<SocConstraintId, f64>,
+);
+
 fn collect_solution(
     kind: ModelKind,
     model: &mut grb::Model,
     vars: &[grb::Var],
     constrs: &[GrbRow],
+    soc_rows: &[(grb::QConstr, LinearTerms)],
     obj_constant: f64,
-) -> (Vec<SolutionPoint>, FxHashMap<VarId, f64>, FxHashMap<ConstraintId, f64>) {
+) -> Collected {
     // A primal point exists only when Gurobi actually stored one. `SolCount` is
     // the number of available solutions and it stays `> 0` for an incumbent
     // kept at a time/iteration/node limit.
     let sol_count = model.get_attr(attr::SolCount).unwrap_or(0);
     if sol_count <= 0 {
-        return (Vec::new(), FxHashMap::default(), FxHashMap::default());
+        return (Vec::new(), FxHashMap::default(), FxHashMap::default(), FxHashMap::default());
     }
 
     let solutions = collect_pool(model, vars, obj_constant, sol_count);
@@ -406,7 +430,7 @@ fn collect_solution(
     // LP/QP always have duals, QCP/SOCP rows only when the user opted into
     // `QCPDual=1`.
     if !matches!(kind, ModelKind::LP | ModelKind::QP | ModelKind::QCP | ModelKind::SOCP) {
-        return (solutions, FxHashMap::default(), FxHashMap::default());
+        return (solutions, FxHashMap::default(), FxHashMap::default(), FxHashMap::default());
     }
 
     let reduced_costs = model
@@ -425,7 +449,24 @@ fn collect_solution(
         }
     }
 
-    (solutions, reduced_costs, dual)
+    // Convert the squared-form multiplier back to the norm-form
+    // bound multiplier `z0 = 2 * bound_value * |QCPi|`.
+    // Available only under `QCPDual=1`.
+    let mut soc_dual = FxHashMap::default();
+    let primal = &solutions[0].primal;
+    for (i, (qrow, bound)) in soc_rows.iter().enumerate() {
+        if let Ok(pi) = model.get_obj_attr(attr::QCPi, qrow) {
+            let b_val = bound.constant
+                + bound
+                    .coeffs
+                    .iter()
+                    .map(|&(v, c)| c * primal.get(&v).copied().unwrap_or(0.0))
+                    .sum::<f64>();
+            soc_dual.insert(SocConstraintId(u32::try_from(i).unwrap()), 2.0 * b_val * pi.abs());
+        }
+    }
+
+    (solutions, reduced_costs, dual, soc_dual)
 }
 
 /// Collect the `n` pooled primal points, best first.

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -1,11 +1,12 @@
 use std::time::Instant;
 
-use grb::expr::LinExpr;
+use grb::expr::{LinExpr, QuadExpr};
 use grb::prelude::*;
 use oximo_core::{
-    Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, VarId, Variable,
+    Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, SocConstraint,
+    VarId, Variable,
 };
-use oximo_expr::{ExprArena, ExprId, extract_linear};
+use oximo_expr::{ExprArena, ExprId, LinearTerms, extract_linear};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
 use rustc_hash::FxHashMap;
 
@@ -59,12 +60,20 @@ pub(crate) struct Built {
 /// cannot represent or Gurobi reports an error during setup.
 pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Built, SolverError> {
     let kind = model.kind();
-    let nonlinear_kind =
-        matches!(kind, ModelKind::QP | ModelKind::MIQP | ModelKind::NLP | ModelKind::MINLP);
+    let nonlinear_kind = matches!(
+        kind,
+        ModelKind::QP
+            | ModelKind::MIQP
+            | ModelKind::QCP
+            | ModelKind::MIQCP
+            | ModelKind::NLP
+            | ModelKind::MINLP
+    );
 
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
+    let socs = model.soc_constraints();
     let objective = model.objective();
     let has_semi = vars.iter().any(|v| v.domain.semi_threshold().is_some());
 
@@ -77,6 +86,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     let mut aux_counter = 0_u32;
     let gurobi_constrs =
         add_constraints(&arena, &constraints, &mut grb_model, &gurobi_vars, &mut aux_counter)?;
+    add_soc_rows(&arena, &socs, &mut grb_model, &gurobi_vars)?;
 
     let obj_constant = match objective.as_ref() {
         Some(o) => {
@@ -246,6 +256,52 @@ fn add_constraints(
     Ok(gurobi_constrs)
 }
 
+// TODO: Report SOC duals
+
+/// Lower each explicit SOC constraint `||terms||_2 <= bound` to the quadratic
+/// row `sum(term_i^2) - bound^2 <= 0` plus the linear side condition
+/// `bound >= 0`.
+fn add_soc_rows(
+    arena: &ExprArena,
+    socs: &[SocConstraint],
+    grb_model: &mut grb::Model,
+    gurobi_vars: &[grb::Var],
+) -> Result<(), SolverError> {
+    for (i, s) in socs.iter().enumerate() {
+        let mut q = QuadExpr::new();
+        for &term in &s.terms {
+            let t = extract_linear(arena, term).ok_or(SolverError::Nonlinear)?;
+            add_squared_affine(&mut q, &t, 1.0, gurobi_vars);
+        }
+        let b = extract_linear(arena, s.bound).ok_or(SolverError::Nonlinear)?;
+        add_squared_affine(&mut q, &b, -1.0, gurobi_vars);
+        grb_model.add_qconstr(&format!("soc{i}"), c!(q <= 0.0)).map_err(map_grb_err)?;
+
+        let mut e = LinExpr::new();
+        for &(v, co) in &b.coeffs {
+            e.add_term(co, gurobi_vars[v.index()]);
+        }
+        grb_model.add_constr(&format!("soc{i}_sign"), c!(e >= -b.constant)).map_err(map_grb_err)?;
+    }
+    Ok(())
+}
+
+/// Expand `sign * (a'x + c)^2` into `q`.
+fn add_squared_affine(q: &mut QuadExpr, t: &LinearTerms, sign: f64, gurobi_vars: &[grb::Var]) {
+    for (i, &(vi, ci)) in t.coeffs.iter().enumerate() {
+        q.add_qterm(sign * ci * ci, gurobi_vars[vi.index()], gurobi_vars[vi.index()]);
+        for &(vj, cj) in &t.coeffs[i + 1..] {
+            q.add_qterm(sign * 2.0 * ci * cj, gurobi_vars[vi.index()], gurobi_vars[vj.index()]);
+        }
+        if t.constant != 0.0 {
+            q.add_term(sign * 2.0 * ci * t.constant, gurobi_vars[vi.index()]);
+        }
+    }
+    if t.constant != 0.0 {
+        q.add_constant(sign * t.constant * t.constant);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn add_nonlinear_constraint(
     arena: &ExprArena,
@@ -345,9 +401,11 @@ fn collect_solution(
 
     let solutions = collect_pool(model, vars, obj_constant, sol_count);
 
-    // Skip retrieval of duals and reduced costs for any model
-    // class where Gurobi will either return zeros or refuse the attribute.
-    if !matches!(kind, ModelKind::LP | ModelKind::QP) {
+    // Skip retrieval of duals and reduced costs for integer model classes,
+    // where Gurobi refuses the attributes.
+    // LP/QP always have duals, QCP/SOCP rows only when the user opted into
+    // `QCPDual=1`.
+    if !matches!(kind, ModelKind::LP | ModelKind::QP | ModelKind::QCP | ModelKind::SOCP) {
         return (solutions, FxHashMap::default(), FxHashMap::default());
     }
 

--- a/crates/oximo-gurobi/tests/soc.rs
+++ b/crates/oximo-gurobi/tests/soc.rs
@@ -1,0 +1,82 @@
+//! Live Gurobi tests for second-order cone models (explicit and detected).
+
+#![allow(clippy::many_single_char_names)]
+
+use oximo_core::prelude::*;
+use oximo_gurobi::{Gurobi, GurobiOptions};
+use oximo_solver::Solver;
+
+fn close(a: f64, b: f64, tol: f64) -> bool {
+    (a - b).abs() < tol
+}
+
+#[test]
+fn explicit_socp_min_linear_over_disk() {
+    let m = Model::new("socp");
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    variable!(m, t >= 0.0);
+    m.fix(t, 1.0);
+    m.add_soc_constraint("disk", [x, y], t);
+    objective!(m, Min, x + y);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
+    assert!(r.has_solution());
+    let obj = r.objective().expect("obj");
+    assert!(close(obj, -std::f64::consts::SQRT_2, 1e-4), "obj = {obj}");
+}
+
+#[test]
+fn detected_socp_hypotenuse() {
+    let m = Model::new("socp_detected");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    m.fix(x, 3.0);
+    m.fix(y, 4.0);
+    constraint!(m, cone, x.powi(2) + y.powi(2) <= t.powi(2));
+    objective!(m, Min, t);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
+    assert!(r.has_solution());
+    let obj = r.objective().expect("obj");
+    assert!(close(obj, 5.0, 1e-4), "obj = {obj}");
+}
+
+#[test]
+fn misocp_with_binary_var() {
+    let m = Model::new("misocp");
+    variable!(m, x);
+    variable!(m, y >= 1.0);
+    variable!(m, t >= 0.0);
+    variable!(m, z, Bin);
+    m.add_soc_constraint("cone", [x, y], t);
+    constraint!(m, cx, x >= 1.0 + z);
+    objective!(m, Min, t + 10.0 * z);
+    assert_eq!(m.kind(), ModelKind::MISOCP);
+
+    let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
+    assert!(r.has_solution());
+    let obj = r.objective().expect("obj");
+    assert!(close(obj, std::f64::consts::SQRT_2, 1e-4), "obj = {obj}");
+}
+
+#[test]
+fn soc_with_affine_members() {
+    let m = Model::new("socp_affine");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, u >= -1.0);
+    m.fix(x, 1.0);
+    m.fix(y, 1.0);
+    m.add_soc_constraint("cone", [x - y, y + 1.0], u + 2.0);
+    objective!(m, Min, u);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
+    assert!(r.has_solution());
+    let obj = r.objective().expect("obj");
+    assert!(close(obj, 0.0, 1e-4), "obj = {obj}");
+}

--- a/crates/oximo-gurobi/tests/soc.rs
+++ b/crates/oximo-gurobi/tests/soc.rs
@@ -28,6 +28,28 @@ fn explicit_socp_min_linear_over_disk() {
 }
 
 #[test]
+fn explicit_soc_dual_matches_norm_form_multiplier() {
+    // KKT gives z0 = ||grad obj|| = sqrt(2)
+    let m = Model::new("socp_dual");
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    variable!(m, t >= 0.0);
+    m.fix(t, 1.0);
+    let disk = m.add_soc_constraint("disk", [x, y], t);
+    objective!(m, Min, x + y);
+
+    let opts = GurobiOptions::default().qcp_dual(1);
+    let r = Gurobi.solve(&m, &opts).expect("solve");
+    assert!(r.has_solution());
+    let z0 = r.soc_dual_of(disk).expect("SOC dual missing");
+    assert!(close(z0, std::f64::consts::SQRT_2, 1e-4), "z0 = {z0}");
+
+    // Without QCPDual=1 Gurobi computes no QCP duals; the map stays empty.
+    let r = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve");
+    assert!(r.soc_dual.is_empty());
+}
+
+#[test]
 fn detected_socp_hypotenuse() {
     let m = Model::new("socp_detected");
     variable!(m, x);

--- a/crates/oximo-highs/src/lib.rs
+++ b/crates/oximo-highs/src/lib.rs
@@ -25,6 +25,11 @@ pub struct Highs;
 /// and the `solver_name` stamped on every [`SolverResult`].
 pub(crate) const NAME: &str = "HiGHS";
 
+/// The model kinds HiGHS can solve: linear models and quadratic-objective QP.
+pub(crate) const fn supported(kind: ModelKind) -> bool {
+    matches!(kind, ModelKind::LP | ModelKind::MILP | ModelKind::QP)
+}
+
 impl Solver for Highs {
     type Options = HighsOptions;
 
@@ -33,7 +38,7 @@ impl Solver for Highs {
     }
 
     fn supports(&self, kind: ModelKind) -> bool {
-        matches!(kind, ModelKind::LP | ModelKind::MILP | ModelKind::QP)
+        supported(kind)
     }
 
     fn solve(&mut self, model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-highs/src/persistent.rs
+++ b/crates/oximo-highs/src/persistent.rs
@@ -136,7 +136,7 @@ impl Solver for HighsPersistent {
     }
 
     fn supports(&self, kind: ModelKind) -> bool {
-        matches!(kind, ModelKind::LP | ModelKind::MILP | ModelKind::QP)
+        crate::supported(kind)
     }
 
     fn solve(&mut self, model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -207,6 +207,7 @@ pub(crate) fn extract_result(
         primal_status,
         solutions,
         dual,
+        soc_dual: FxHashMap::default(),
         reduced_costs,
         best_bound,
         gap,

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -83,7 +83,7 @@ pub(crate) struct Meta {
 /// represented, or an expression is not linear/quadratic as required.
 pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> {
     let kind = model.kind();
-    if !matches!(kind, ModelKind::LP | ModelKind::MILP | ModelKind::QP) {
+    if !crate::supported(kind) {
         return Err(SolverError::UnsupportedKind(kind));
     }
 
@@ -441,5 +441,30 @@ mod tests {
 
         let err = solve(&m, &HighsOptions::default()).unwrap_err();
         assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::MIQP)));
+    }
+
+    #[test]
+    fn qcp_is_unsupported() {
+        let m = Model::new("qcp");
+        variable!(m, x >= 0.0);
+        constraint!(m, c, x.powi(2) <= 4.0);
+        objective!(m, Min, x);
+        assert_eq!(m.kind(), ModelKind::QCP);
+
+        let err = solve(&m, &HighsOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::QCP)));
+    }
+
+    #[test]
+    fn socp_is_unsupported() {
+        let m = Model::new("socp");
+        variable!(m, x);
+        variable!(m, t >= 0.0);
+        m.add_soc_constraint("cone", [x], t);
+        objective!(m, Min, t);
+        assert_eq!(m.kind(), ModelKind::SOCP);
+
+        let err = solve(&m, &HighsOptions::default()).unwrap_err();
+        assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::SOCP)));
     }
 }

--- a/crates/oximo-io/src/error.rs
+++ b/crates/oximo-io/src/error.rs
@@ -6,6 +6,8 @@ pub enum IoError {
     NoObjective,
     #[error("nonlinear nodes are not representable in this format")]
     Nonlinear,
+    #[error("second-order cone constraints cannot be represented in this format")]
+    Conic,
     #[error("unsupported expression node in NL writer: {0}")]
     UnsupportedNode(&'static str),
     #[error("variable domain {0} is not representable in NL")]

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -14,7 +14,7 @@
 
 use std::io::Write;
 
-use oximo_core::{Domain, Model, ObjectiveSense, Sense};
+use oximo_core::{Domain, Model, ModelKind, ObjectiveSense, Sense};
 use oximo_expr::{LinearTerms, extract_linear};
 use rustc_hash::FxHashSet;
 
@@ -40,7 +40,9 @@ use crate::error::IoError;
 /// constructs.
 #[allow(clippy::too_many_lines)]
 pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
-    if model.num_soc_constraints() > 0 {
+    if model.num_soc_constraints() > 0
+        || matches!(model.kind(), ModelKind::SOCP | ModelKind::MISOCP)
+    {
         return Err(IoError::Conic);
     }
     let arena = model.arena();

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -31,13 +31,18 @@ use crate::error::IoError;
 /// - `Binaries` (binary vars)
 /// - `End`
 ///
-/// LP only represents linear LP/MILP. Nonlinear nodes raise [`IoError::Nonlinear`].
+/// LP only represents linear LP/MILP. Nonlinear nodes raise
+/// [`IoError::Nonlinear`], second-order cone constraints [`IoError::Conic`].
 ///
 /// # Errors
 ///
-/// Returns [`IoError`] on I/O failure, missing objective, or nonlinear constructs.
+/// Returns [`IoError`] on I/O failure, missing objective, or nonlinear/conic
+/// constructs.
 #[allow(clippy::too_many_lines)]
 pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
+    if model.num_soc_constraints() > 0 {
+        return Err(IoError::Conic);
+    }
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -23,8 +23,9 @@ use crate::error::IoError;
 /// Write `model` to `out` in fixed-format MPS.
 ///
 /// MPS only represents linear LP / MILP. Nonlinear expressions in the
-/// objective or constraints raise [`IoError::Nonlinear`]. The objective row
-/// is named `OBJ`. Constraint rows take their oximo names.
+/// objective or constraints raise [`IoError::Nonlinear`], second-order cone
+/// constraints [`IoError::Conic`]. The objective row is named `OBJ`.
+/// Constraint rows take their oximo names.
 ///
 /// # Errors
 ///
@@ -32,6 +33,9 @@ use crate::error::IoError;
 ///
 #[allow(clippy::too_many_lines)]
 pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
+    if model.num_soc_constraints() > 0 {
+        return Err(IoError::Conic);
+    }
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -14,7 +14,7 @@
 
 use std::io::Write;
 
-use oximo_core::{Constraint, Model, ObjectiveSense, Sense};
+use oximo_core::{Constraint, Model, ModelKind, ObjectiveSense, Sense};
 use oximo_expr::{LinearTerms, VarId, extract_linear};
 use rustc_hash::FxHashMap;
 
@@ -33,7 +33,9 @@ use crate::error::IoError;
 ///
 #[allow(clippy::too_many_lines)]
 pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
-    if model.num_soc_constraints() > 0 {
+    if model.num_soc_constraints() > 0
+        || matches!(model.kind(), ModelKind::SOCP | ModelKind::MISOCP)
+    {
         return Err(IoError::Conic);
     }
     let arena = model.arena();

--- a/crates/oximo-io/src/nl/mod.rs
+++ b/crates/oximo-io/src/nl/mod.rs
@@ -72,12 +72,17 @@ pub fn to_nl_string(model: &Model) -> Result<String, IoError> {
 ///
 /// # Errors
 ///
-/// Returns [`IoError`] on missing objective, unsupported nodes, or I/O failure.
+/// Returns [`IoError`] on missing objective, unsupported nodes, second-order
+/// cone constraints ([`IoError::Conic`]; the NL format has no conic segment),
+/// or I/O failure.
 pub fn write_nl_with<W: Write>(
     model: &Model,
     out: &mut W,
     opts: &WriteOptions,
 ) -> Result<(), IoError> {
+    if model.num_soc_constraints() > 0 {
+        return Err(IoError::Conic);
+    }
     let vars = model.variables();
     let constraints = model.constraints();
     let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;

--- a/crates/oximo-io/tests/conic.rs
+++ b/crates/oximo-io/tests/conic.rs
@@ -1,0 +1,31 @@
+//! Every text format rejects models with explicit second-order cone
+//! constraints: LP/MPS/NL have no conic representation.
+
+use oximo_core::prelude::*;
+use oximo_io::{IoError, to_lp_string, to_mps_string, to_nl_string};
+
+fn soc_model() -> Model {
+    let m = Model::new("socp");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    m.add_soc_constraint("cone", [x, y], t);
+    constraint!(m, c0, x + y >= 1.0);
+    objective!(m, Min, t);
+    m
+}
+
+#[test]
+fn lp_writer_rejects_soc_constraints() {
+    assert!(matches!(to_lp_string(&soc_model()), Err(IoError::Conic)));
+}
+
+#[test]
+fn mps_writer_rejects_soc_constraints() {
+    assert!(matches!(to_mps_string(&soc_model()), Err(IoError::Conic)));
+}
+
+#[test]
+fn nl_writer_rejects_soc_constraints() {
+    assert!(matches!(to_nl_string(&soc_model()), Err(IoError::Conic)));
+}

--- a/crates/oximo-macros/README.md
+++ b/crates/oximo-macros/README.md
@@ -1,7 +1,8 @@
 # oximo-macros
 
 Internal procedural macros backing oximo's modeling surface:
-`variable!`, `constraint!`, `objective!`, `sum!`, `set!`, and `param!`.
+`variable!`, `constraint!`, `soc_constraint!`, `objective!`, `sum!`, `set!`,
+and `param!`.
 
 This crate is an implementation detail, do not depend on it directly.
 The macros are re-exported through `oximo-core` and `oximo::prelude`, which is the

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -54,7 +54,8 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
 
 /// Detect the computed-name form `name = EXPR` in the name slot, returning the
 /// `EXPR` tokens. The literal marker `name` keeps a bare ident a literal name.
-fn computed_name(first: &TokenStream2) -> Option<TokenStream2> {
+/// Shared with `soc_constraint!`.
+pub(crate) fn computed_name(first: &TokenStream2) -> Option<TokenStream2> {
     let mut it = first.clone().into_iter();
     match it.next()? {
         TokenTree::Ident(id) if id == "name" => {}

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -13,6 +13,7 @@ mod index;
 mod objective;
 mod param;
 mod set;
+mod soc;
 mod sum;
 mod variable;
 
@@ -52,6 +53,15 @@ pub fn variable(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn constraint(input: TokenStream) -> TokenStream {
     constraint::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `soc_constraint!(model, [name|name = expr|name[idx]], [terms] <= bound)`,
+/// register the second-order cone constraint `||terms||_2 <= bound` (every
+/// term and the bound must be affine), an auto-named anonymous cone, or an
+/// indexed family of cones.
+#[proc_macro]
+pub fn soc_constraint(input: TokenStream) -> TokenStream {
+    soc::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 /// `objective!(model, Min|Max, expr)`, set the model objective and sense.

--- a/crates/oximo-macros/src/soc.rs
+++ b/crates/oximo-macros/src/soc.rs
@@ -1,0 +1,106 @@
+//! `soc_constraint!(model, [name | name = expr | name[i in dom, ...]], [terms] <= bound)`,
+//! register the second-order cone constraint `||terms||_2 <= bound`. Every
+//! term and the bound must be affine (validated at registration). The
+//! relation must be a bracketed term list on the left of a single `<=`.
+
+use proc_macro2::{Delimiter, Span, TokenStream as TokenStream2, TokenTree};
+use quote::quote;
+use syn::Expr;
+
+use crate::bind::{family_closure_param, filtered_set};
+use crate::constraint::computed_name;
+use crate::{Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas};
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let parts = split_top_commas(input);
+    let mut parts = parts.into_iter();
+    let model = parts.next().expect("split always yields at least one segment");
+    let model: Expr = syn::parse2(model)?;
+
+    let first = parts.next().ok_or_else(|| {
+        syn::Error::new(Span::call_site(), "soc_constraint! needs `[terms] <= bound`")
+    })?;
+    let second = parts.next();
+    if let Some(extra) = parts.next() {
+        return Err(syn::Error::new_spanned(
+            extra,
+            "unexpected trailing tokens in soc_constraint!",
+        ));
+    }
+
+    let root = oximo_root();
+
+    match second {
+        None => {
+            let (terms, bound) = parse_relation(first)?;
+            Ok(quote!( (#model).__add_soc_constraint_auto([#(#terms),*], #bound) ))
+        }
+        Some(rel_tokens) => {
+            // Computed name at run-time: `soc_constraint!(m, name = expr, ..)`.
+            if let Some(name_expr) = computed_name(&first) {
+                let (terms, bound) = parse_relation(rel_tokens)?;
+                return Ok(quote!(
+                    (#model).add_soc_constraint(#name_expr, [#(#terms),*], #bound)
+                ));
+            }
+
+            let Named { name, binds, cond } = parse_named(first)?;
+            let name_str = name.to_string();
+            let (terms, bound) = parse_relation(rel_tokens)?;
+            match binds {
+                None => Ok(quote!(
+                    (#model).add_soc_constraint(#name_str, [#(#terms),*], #bound)
+                )),
+                Some(binds) => {
+                    let param = family_closure_param(&binds);
+                    let set = build_set(&binds, &root);
+                    let set = filtered_set(set, &binds, cond.as_ref(), &root);
+                    Ok(quote! {
+                        (#model).__add_soc_constraints_over(
+                            #name_str,
+                            &(#set),
+                            |#param| ([#(#terms),*], #bound),
+                        );
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Parse the relation `[term, term, ...] <= bound` into the term expressions
+/// and the bound expression.
+fn parse_relation(tokens: TokenStream2) -> syn::Result<(Vec<Expr>, Expr)> {
+    const SHAPE: &str = "a SOC constraint must be written `[term, term, ...] <= bound`";
+    let (segs, ops) = split_relops(tokens);
+    let (lhs, rhs) = match (segs.len(), ops.as_slice()) {
+        (2, [RelOp::Le]) => {
+            let mut segs = segs.into_iter();
+            (segs.next().unwrap(), segs.next().unwrap())
+        }
+        _ => return Err(syn::Error::new(Span::call_site(), SHAPE)),
+    };
+
+    let mut lhs_tts = lhs.into_iter();
+    let group = match (lhs_tts.next(), lhs_tts.next()) {
+        (Some(TokenTree::Group(g)), None) if g.delimiter() == Delimiter::Bracket => g,
+        (Some(other), _) => return Err(syn::Error::new(other.span(), SHAPE)),
+        (None, _) => return Err(syn::Error::new(Span::call_site(), SHAPE)),
+    };
+
+    let terms = split_top_commas(group.stream())
+        .into_iter()
+        .filter(|seg| !seg.is_empty())
+        .map(parse_seg)
+        .collect::<syn::Result<Vec<Expr>>>()?;
+    if terms.is_empty() {
+        return Err(syn::Error::new(group.span(), "a SOC constraint needs at least one term"));
+    }
+
+    let bound = parse_seg(rhs)?;
+    Ok((terms, bound))
+}
+
+fn parse_seg(ts: TokenStream2) -> syn::Result<Expr> {
+    syn::parse2(crate::index::rewrite_index_subscripts(ts))
+}

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -1,6 +1,6 @@
 use std::hash::Hasher;
 
-use oximo_core::{Model, ObjectiveSense, Variable};
+use oximo_core::{Model, ModelKind, ObjectiveSense, Variable};
 use oximo_expr::{ExprArena, VarId, extract_linear};
 use rustc_hash::FxHasher;
 
@@ -42,11 +42,13 @@ pub struct Snapshot {
 /// # Errors
 ///
 /// Returns [`SolverError::Nonlinear`] if the objective or any constraint is not
-/// linear, or [`SolverError::UnsupportedKind`] if the model carries
-/// second-order cone constraints.
+/// linear, or [`SolverError::UnsupportedKind`] if the model is a second-order
+/// cone program (explicit [`oximo_core::SocConstraint`]s or SOC-shaped
+/// quadratic constraints detected by [`Model::kind`]).
 pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
-    if model.num_soc_constraints() > 0 {
-        return Err(SolverError::UnsupportedKind(model.kind()));
+    let kind = model.kind();
+    if model.num_soc_constraints() > 0 || matches!(kind, ModelKind::SOCP | ModelKind::MISOCP) {
+        return Err(SolverError::UnsupportedKind(kind));
     }
     let arena = model.arena();
     let vars = model.variables();

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -42,8 +42,12 @@ pub struct Snapshot {
 /// # Errors
 ///
 /// Returns [`SolverError::Nonlinear`] if the objective or any constraint is not
-/// linear.
+/// linear, or [`SolverError::UnsupportedKind`] if the model carries
+/// second-order cone constraints.
 pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
+    if model.num_soc_constraints() > 0 {
+        return Err(SolverError::UnsupportedKind(model.kind()));
+    }
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
@@ -180,6 +184,19 @@ mod tests {
         variable!(m, x >= 0.0);
         objective!(m, Min, x.powi(2));
         assert!(snapshot(&m).is_err());
+    }
+
+    #[test]
+    fn soc_constraint_is_rejected() {
+        let m = Model::new("t");
+        variable!(m, x >= 0.0);
+        variable!(m, t >= 0.0);
+        m.add_soc_constraint("cone", [x], t);
+        objective!(m, Min, t);
+        assert!(matches!(
+            snapshot(&m),
+            Err(crate::status::SolverError::UnsupportedKind(ModelKind::SOCP))
+        ));
     }
 
     #[test]

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use oximo_core::{
-    ConstraintId, Expr, ExprNode, IndexKey, IndexedVar, Model, ObjectiveSense, VarId,
+    ConstraintId, Expr, ExprNode, IndexKey, IndexedVar, Model, ObjectiveSense, SocConstraintId,
+    VarId,
 };
 use rustc_hash::FxHashMap;
 
@@ -76,6 +77,7 @@ pub struct SolverResult {
     pub primal_status: PrimalStatus,
     pub solutions: Vec<SolutionPoint>,
     pub dual: FxHashMap<ConstraintId, f64>,
+    pub soc_dual: FxHashMap<SocConstraintId, f64>,
     pub reduced_costs: FxHashMap<VarId, f64>,
     pub best_bound: Option<f64>,
     pub gap: Option<f64>,
@@ -92,6 +94,7 @@ impl Default for SolverResult {
             primal_status: PrimalStatus::NoSolution,
             solutions: Vec::new(),
             dual: FxHashMap::default(),
+            soc_dual: FxHashMap::default(),
             reduced_costs: FxHashMap::default(),
             best_bound: None,
             gap: None,
@@ -151,6 +154,12 @@ impl SolverResult {
 
     pub fn dual_of(&self, c: ConstraintId) -> Option<f64> {
         self.dual.get(&c).copied()
+    }
+
+    /// The norm-form bound multiplier of an explicit SOC constraint,
+    /// or `None` when the backend did not compute it.
+    pub fn soc_dual_of(&self, c: SocConstraintId) -> Option<f64> {
+        self.soc_dual.get(&c).copied()
     }
 
     /// Look up the best solution's primal value for a specific index of an
@@ -260,6 +269,18 @@ impl std::fmt::Display for ModelReport<'_> {
                 let id = ConstraintId(u32::try_from(i).expect("constraint index fits u32"));
                 let d = r.dual_of(id).map_or_else(|| "n/a".to_owned(), num);
                 writeln!(f, "  {:<width$}  dual = {d}", c.name)?;
+            }
+        }
+
+        // SOC bound multipliers, only when the solver returned any
+        if !r.soc_dual.is_empty() {
+            let socs = m.soc_constraints();
+            writeln!(f, "\nsoc constraints ({})", socs.len())?;
+            let width = socs.iter().map(|s| s.name.len()).max().unwrap_or(0);
+            for (i, s) in socs.iter().enumerate() {
+                let id = SocConstraintId(u32::try_from(i).expect("soc index fits u32"));
+                let d = r.soc_dual_of(id).map_or_else(|| "n/a".to_owned(), num);
+                writeln!(f, "  {:<width$}  dual = {d}", s.name)?;
             }
         }
 

--- a/crates/oximo/Cargo.toml
+++ b/crates/oximo/Cargo.toml
@@ -18,6 +18,8 @@ io = ["dep:oximo-io"]
 gurobi = ["dep:oximo-gurobi"]
 gams = ["dep:oximo-gams"]
 baron = ["dep:oximo-baron"]
+clarabel = ["dep:oximo-clarabel"]
+clarabel-faer = ["clarabel", "oximo-clarabel/faer"]
 
 [dependencies]
 oximo-expr.workspace = true
@@ -27,6 +29,7 @@ oximo-highs = { workspace = true, optional = true }
 oximo-gurobi = { workspace = true, optional = true }
 oximo-gams = { workspace = true, optional = true }
 oximo-baron = { workspace = true, optional = true }
+oximo-clarabel = { workspace = true, optional = true }
 oximo-io = { workspace = true, optional = true }
 
 [lints]

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -198,13 +198,14 @@ pub trait Solver {
 
 ## Features
 
-| Feature  | What it adds                                                          | Default |
-|----------|-----------------------------------------------------------------------|---------|
-| `highs`  | HiGHS - LP/MILP/QP solver (bundled, no install)                       | yes     |
-| `io`     | MPS and LP file writers                                               | yes     |
-| `gurobi` | Gurobi - LP/MILP/QP/MIQP/NLP/MINLP solver (requires licensed install) | no      |
-| `gams`   | GAMS bridge - LP/MILP/QP/MIQP/NLP/MINLP depending on solver           | no      |
-| `baron`  | BARON  - LP/MILP/QP/MIQP/NLP/MINLP solver (requires licensed install) | no      |
+| Feature    | What it adds                                                 | Default |
+|------------|--------------------------------------------------------------|---------|
+| `highs`    | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
+| `io`       | MPS and LP file writers                                      | yes     |
+| `gurobi`   | Gurobi solver (requires licensed install)                    | no      |
+| `gams`     | GAMS bridge - solve type depends on the selected sub-solver  | no      |
+| `baron`    | BARON - global LP...MINLP solver (requires licensed install) | no      |
+| `clarabel` | Clarabel - LP/QP/SOCP conic solver (pure Rust, no install)   | no      |
 
 ### HiGHS (default)
 
@@ -220,6 +221,12 @@ let result = Highs.solve(&m, &HighsOptions::default()
     .mip_gap(0.01)
     .method(HighsMethod::Ipm))?;
 ```
+
+### Clarabel
+
+Pure-Rust conic interior-point solver, no install or license. Solves continuous
+LP, QP (convex quadratic objectives), and SOCP models. See
+[`crates/oximo-clarabel/README.md`](crates/oximo-clarabel/README.md).
 
 ### Gurobi
 

--- a/crates/oximo/examples/gradostat_multiperiod_socp.rs
+++ b/crates/oximo/examples/gradostat_multiperiod_socp.rs
@@ -1,0 +1,155 @@
+//! Multi-period second-order cone optimization of the gradostat (model `P_RC`).
+//!
+//! Replication of Section 7.2 of Taylor & Rapaport (2021).
+//! A four-tank gradostat with constant flows and diffusions is
+//! optimized over `TAU = 1000` time periods to maximize cumulative
+//! biogas production.
+//!
+//! # Model
+//!
+//! Growth parameters `mu_max = K = y = 1`, unit tank volumes `V = I`, Euler's
+//! explicit method with time step `Delta = 1`, and a periodic horizon
+//! (`S(1) = S(TAU+1)`, `X(1) = X(TAU+1)`).
+//!
+//! ```text
+//! max   sum_{i,t}  T_i(t)                                             (eq. 24)
+//! s.t.  S_i(t+1) - S_i(t) = -T_i(t) + [(M+L) S(t)]_i + Qin_i Sin_i(t) (25a)
+//!       X_i(t+1) - X_i(t) =  T_i(t) + [(M+L) X(t)]_i + Qin_i Xin_i(t) (25b)
+//!       || [S_i(t), T_i(t), X_i(t)] || <= X_i(t) + S_i(t) - T_i(t)    (eq. 9a)
+//!       S_i(t) - T_i(t) >= 0                                          (eq. 9b)
+//!       sum_i Qin_i Xin_i(t) <= 3                                     (biomass-inflow budget)
+//!       S, X, T >= 0,   Xin >= 0
+//! ```
+//!
+//! The substrate inflow `Sin(t)` is a fixed data profile, the biomass inflow
+//! `Xin(t)` is the decision variable.
+//!
+//! # Reproduction vs. the authors' code
+//!
+//! This model matches the authors' reference implementation and
+//! returns the same values.
+//!
+//! ## Details matched to the MATLAB code:
+//!
+//! 1. Diffusion `d = 0.3` on each existing pipe (`d = 0.3*(Q>0)`).
+//! 2. Budget on the inflow `Xin(t)`: `Qin' Xin(t) <= 3`, not on the tank
+//!    concentration `X(t)`.
+//! 3. Time base: The paper indexes `t in {1..TAU}`, here periods are
+//!    `p in {0..TAU-1}` with `t = p + 1` used in the `Sin` profiles.
+//!
+//! Run:
+//!   cargo run -p oximo --example gradostat_multiperiod_socp --features clarabel
+//!
+//! References:
+//! - Taylor, J. A., & Rapaport, A. (2021).
+//!   Second-order cone optimization of the gradostat.
+//!   Computers & Chemical Engineering, 151, 107347.
+//!   <https://doi.org/10.1016/j.compchemeng.2021.107347>
+
+#[cfg(feature = "clarabel")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use oximo::ClarabelOptions;
+    use oximo::prelude::*;
+    use oximo::solvers::Clarabel;
+
+    // Problem data
+    const N: usize = 4; // tanks
+    const TAU: usize = 1000; // time periods
+
+    // Forced-flow + diffusion matrix M + L.
+    const ML: [[f64; N]; N] = [
+        [-2.3, 0.3, 0.0, 0.0],
+        [1.3, -3.9, 0.3, 1.3],
+        [0.0, 2.3, -3.6, 0.3],
+        [0.0, 0.3, 1.3, -2.6],
+    ];
+
+    // C = diag(Qin), the external water inflow at each tank.
+    const QIN: [f64; N] = [2.0, 1.0, 1.0, 1.0];
+
+    // Total biomass mass allowed in the tanks per period: 1' Qin X(t) <= BUDGET.
+    const BUDGET: f64 = 3.0;
+
+    // Substrate inflow profiles Sin_i(t), indexed sin[i][p] with paper time t=p+1.
+    #[allow(clippy::needless_range_loop, clippy::cast_precision_loss)]
+    let sin: Vec<Vec<f64>> = {
+        let pi = std::f64::consts::PI;
+        let tau = TAU as f64;
+        let mut sin = vec![vec![0.0f64; TAU]; N];
+        for p in 0..TAU {
+            let t = (p + 1) as f64;
+            let ti = p + 1;
+            sin[0][p] = 1.0 + (4.0 * pi * t / tau).sin();
+            sin[1][p] = 0.0;
+            sin[2][p] = if ti > TAU / 4 && ti <= 3 * TAU / 4 { 0.5 } else { 0.0 };
+            sin[3][p] = 1.0 + (4.0 * pi * t / tau).cos();
+        }
+        sin
+    };
+
+    let m = Model::new("gradostat_multiperiod");
+    let tanks = Set::range(0..N);
+    let periods = Set::range(0..TAU);
+
+    variable!(m, s[i in tanks, p in periods] >= 0.0); // substrate  S
+    variable!(m, x[i in tanks, p in periods] >= 0.0); // biomass    X
+    variable!(m, kin[i in tanks, p in periods] >= 0.0); // kinetics T
+    variable!(m, xin[i in tanks, p in periods] >= 0.0); // biomass inflow Xin (decision)
+
+    // Dynamic substrate and biomass balances (25a, 25b), Euler-explicit, V=y=1.
+    constraint!(m, s_bal[i in tanks, p in periods],
+        s[i, (p + 1) % TAU] - s[i, p]
+            == -kin[i, p] + sum!(ML[i][j] * s[j, p] for j in tanks) + QIN[i] * sin[i][p]);
+    constraint!(m, x_bal[i in tanks, p in periods],
+        x[i, (p + 1) % TAU] - x[i, p]
+            == kin[i, p] + sum!(ML[i][j] * x[j, p] for j in tanks) + QIN[i] * xin[i, p]);
+
+    // Contois growth as a second-order cone (eq. 9, mu_max = K = 1).
+    soc_constraint!(m, growth[i in tanks, p in periods],
+        [s[i, p], kin[i, p], x[i, p]] <= x[i, p] + s[i, p] - kin[i, p]);
+    constraint!(m, st_diff[i in tanks, p in periods], s[i, p] - kin[i, p] >= 0.0);
+
+    // Per-period biomass-inflow budget, 1' Qin Xin(t) <= BUDGET.
+    constraint!(m, bio_budget[p in periods], sum!(QIN[i] * xin[i, p] for i in tanks) <= BUDGET);
+
+    // Maximize cumulative biogas, sum_{i,t} V_ii T_i with V = I (eq. 24, undiscounted).
+    objective!(m, Max, sum!(kin[i, p] for i in tanks, p in periods));
+
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let res = Clarabel.solve(&m, &ClarabelOptions::default())?;
+    assert_eq!(res.termination, TerminationStatus::Optimal);
+
+    // Exactness metric E = max_{i,t} |r(S,X)-T|/r(S,X), with the Contois
+    // kinetics r(S,X) = mu_max S X/(K X + S) evaluated at the solution.
+    let mut e_max = 0.0f64;
+    for i in 0..N {
+        for p in 0..TAU {
+            let sv = res.value_of(s[(i, p)]).unwrap();
+            let xv = res.value_of(x[(i, p)]).unwrap();
+            let tv = res.value_of(kin[(i, p)]).unwrap();
+            let denom = sv + xv;
+            if denom > 1e-9 {
+                let r = sv * xv / denom;
+                if r > 1e-9 {
+                    e_max = e_max.max((r - tv).abs() / r);
+                }
+            }
+        }
+    }
+
+    println!("Results:");
+    println!("Termination: {:?}", res.termination);
+    println!("Objective: {:.4}", res.objective().unwrap());
+    println!("Exactness E: {e_max:.3e}");
+    println!("Iterations: {}", res.iterations);
+    println!("Solve time: {:.3} s", res.solve_time.as_secs_f64());
+
+    Ok(())
+}
+
+#[cfg(not(feature = "clarabel"))]
+fn main() {
+    eprintln!("This example needs the clarabel feature:");
+    eprintln!("  cargo run -p oximo --example gradostat_multiperiod_socp --features clarabel");
+}

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -28,6 +28,9 @@ pub use oximo_gams::{GamsOptions, GamsSolver};
 #[cfg(feature = "baron")]
 pub use oximo_baron::BaronOptions;
 
+#[cfg(feature = "clarabel")]
+pub use oximo_clarabel::{ClarabelDirectSolve, ClarabelOptions};
+
 /// GAMS backend types: sub-solver selection and per-solver option structs.
 #[cfg(feature = "gams")]
 pub mod gams {
@@ -59,6 +62,9 @@ pub mod prelude {
 
     #[cfg(feature = "baron")]
     pub use oximo_baron::BaronOptions;
+
+    #[cfg(feature = "clarabel")]
+    pub use oximo_clarabel::{ClarabelDirectSolve, ClarabelOptions, ClarabelPersistent};
 }
 
 pub mod solvers {
@@ -75,4 +81,7 @@ pub mod solvers {
 
     #[cfg(feature = "baron")]
     pub use oximo_baron::Baron;
+
+    #[cfg(feature = "clarabel")]
+    pub use oximo_clarabel::Clarabel;
 }

--- a/crates/oximo/tests/solve_baron.rs
+++ b/crates/oximo/tests/solve_baron.rs
@@ -80,3 +80,26 @@ fn baron_milp_duals_at_best_point() {
     assert!(result.dual_of(cap).is_some(), "dual missing for cap");
     assert!(!result.reduced_costs.is_empty(), "reduced costs missing");
 }
+
+#[test]
+#[allow(clippy::many_single_char_names)]
+fn baron_soc_dual_matches_norm_form_multiplier() {
+    // min x + y  s.t.  ||(x, y)||_2 <= 1 (explicit SOC, lowered to squared
+    // rows). KKT: z0 = ||grad obj|| = sqrt(2), the soc0 row's price is
+    // rescaled by 2 * bound_value.
+    let m = Model::new("socp_dual");
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    variable!(m, t >= 0.0);
+    m.fix(t, 1.0);
+    let disk = m.add_soc_constraint("disk", [x, y], t);
+    objective!(m, Min, x + y);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let opts = BaronOptions::default().want_dual(true).time_limit(Duration::from_secs(30));
+    let r = Baron::new().solve(&m, &opts).unwrap();
+    assert!(r.has_solution());
+    assert!((r.objective().unwrap() + std::f64::consts::SQRT_2).abs() < 1e-4);
+    let z0 = r.soc_dual_of(disk).expect("SOC dual missing");
+    assert!((z0 - std::f64::consts::SQRT_2).abs() < 1e-3, "z0 = {z0}");
+}

--- a/crates/oximo/tests/solve_clarabel.rs
+++ b/crates/oximo/tests/solve_clarabel.rs
@@ -1,0 +1,49 @@
+//! Integration tests for the Clarabel backend through the umbrella crate.
+//! Clarabel is pure Rust, so these run without any installed solver.
+//! Compiled only with `--features clarabel`.
+
+#![cfg(feature = "clarabel")]
+
+use oximo::ClarabelOptions;
+use oximo::prelude::*;
+use oximo::solvers::Clarabel;
+
+#[test]
+fn lp_round_trip() {
+    // max 3x + 2y  s.t.  x + y <= 4, 0 <= x, y <= 3. Optimum 11 at (3, 1).
+    let m = Model::new("lp");
+    variable!(m, 0.0 <= x <= 3.0);
+    variable!(m, 0.0 <= y <= 3.0);
+    constraint!(m, cap, x + y <= 4.0);
+    objective!(m, Max, 3.0 * x + 2.0 * y);
+
+    let res = Clarabel.solve(&m, &ClarabelOptions::default()).expect("solve");
+    assert_eq!(res.termination, TerminationStatus::Optimal);
+    assert!((res.objective().unwrap() - 11.0).abs() < 1e-6);
+}
+
+#[test]
+fn socp_round_trip() {
+    // min x + y  s.t.  ||(x, y)||_2 <= 1. Optimum -sqrt(2).
+    let m = Model::new("socp");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, t >= 0.0);
+    m.fix(t, 1.0);
+    soc_constraint!(m, disk, [x, y] <= t);
+    objective!(m, Min, x + y);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let res = Clarabel.solve(&m, &ClarabelOptions::default()).expect("solve");
+    assert_eq!(res.termination, TerminationStatus::Optimal);
+    assert!((res.objective().unwrap() + std::f64::consts::SQRT_2).abs() < 1e-6);
+}
+
+#[test]
+fn milp_is_rejected_with_kind() {
+    let m = Model::new("milp");
+    variable!(m, 0.0 <= x <= 5.0, Int);
+    objective!(m, Min, x);
+    let err = Clarabel.solve(&m, &ClarabelOptions::default()).unwrap_err();
+    assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::MILP)));
+}

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -253,3 +253,25 @@ fn gams_reads_cplex_solution_pool() {
         prev = obj;
     }
 }
+
+#[test]
+#[allow(clippy::many_single_char_names)]
+fn gams_soc_dual_matches_norm_form_multiplier() {
+    // min x + y  s.t.  ||(x, y)||_2 <= 1 (explicit SOC, lowered to sqr rows).
+    // KKT: z0 = ||grad obj|| = sqrt(2); the eq_soc0 marginal is rescaled by
+    // 2 * bound_value.
+    let m = Model::new("socp_dual");
+    variable!(m, -10.0 <= x <= 10.0);
+    variable!(m, -10.0 <= y <= 10.0);
+    variable!(m, t >= 0.0);
+    m.fix(t, 1.0);
+    let disk = m.add_soc_constraint("disk", [x, y], t);
+    objective!(m, Min, x + y);
+    assert_eq!(m.kind(), ModelKind::SOCP);
+
+    let r = Gams::new().solve(&m, &GamsOptions::default()).unwrap();
+    assert!(r.has_solution());
+    assert!((r.objective().unwrap() + std::f64::consts::SQRT_2).abs() < 1e-4);
+    let z0 = r.soc_dual_of(disk).expect("SOC dual missing");
+    assert!((z0 - std::f64::consts::SQRT_2).abs() < 1e-4, "z0 = {z0}");
+}


### PR DESCRIPTION
## Description

This PR adds first-class second-order cone constraints to oximo. Modifies existing backend to emit/parse them, and introduces `oximo-clarabel`, a pure-Rust conic backend (LP/QP/SOCP).
We add a `soc_constraint!` macro, a `ModelKind` that distinguishes conic problems, backend lowering, and dual/marginal readback. `oximo-solver` now has a `soc_dual` result field and incremental snapshot rejects SOC models.


| Backend             | Handling                                                                       |
|-------------------|-----------------------------------------------------------|
| Gurobi               | SOC lowered to native QCP, SOC duals parsed            |
| GAMS                | SOC emitted as `sqr()` rows, SOC marginals parsed     |
| BARON              | SOC lowered to squared text rows, SOC duals parsed |
| HiGHS                | Rejects QCP/SOCP with `UnsupportedKind`                 |
| IO (LP/MPS/NL) | Errors on cone constraints                                            |

TODOs:
- Add support for semidefinite programs (SDPs) (Left out for now because we don't have matrices in the model layer)
- Add automatic convex-QCP-to-SOC reformulation (Gated behind a .reformulate method?)
- Enable Pardiso backends for Clarabel (I didn't do it now because of tests, maybe there is a way to test using CI? I need to check Clarabel's CI)

I would like to thank Joshua Taylor for sharing the original MATLAB implementation of the model from the "Second-order cone optimization of the gradostat" paper, as there were some discrepancies with my initial implementation.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/18