### PR TITLE
Add feasibility declaration

### DIFF
--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -137,6 +137,7 @@ pub fn solve(
 type BarParts = (String, Vec<VarId>, Vec<ConstraintId>, Vec<LinearTerms>);
 
 fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
@@ -1113,6 +1114,7 @@ mod tests {
         let m = Model::new("feas");
         variable!(m, 0.0 <= x <= 1.0);
         constraint!(m, c, x <= 1.0);
+        objective!(m, Feasibility);
         let bar = render(&m);
         assert!(bar.contains("OBJ: minimize 0;"), "{bar}");
     }

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -161,6 +161,7 @@ pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, Solv
 ///
 /// Panics if variable or constraint indices overflow `u32`.
 pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if !crate::supported(kind) {
         return Err(SolverError::UnsupportedKind(kind));

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -34,7 +34,7 @@ constraint!(m, c1, x + 2.0 * y <= 14.0);
 constraint!(m, c2, 3.0 * x - y >= 0.0);
 constraint!(m, band, 1.0 <= x + y <= 12.0);
 
-// Objective
+// Objective (or `objective!(m, Feasibility)` for a pure feasibility problem)
 objective!(m, Max, 3.0 * x + 4.0 * y);
 
 println!("kind = {:?}", m.kind()); // LP

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -65,6 +65,7 @@ pub struct Model {
     pub(crate) soc_constraints: RefCell<Vec<SocConstraint>>,
     pub(crate) soc_names: RefCell<FxHashMap<SmolStr, SocConstraintId>>,
     pub(crate) objective: RefCell<Option<Objective>>,
+    objective_declared: Cell<bool>,
     cached_kind: Cell<Option<ModelKind>>,
     /// Monotonic counter for auto-naming anonymous constraints registered via
     /// the `constraint!` macro.
@@ -80,6 +81,7 @@ impl std::fmt::Debug for Model {
             .field("constraints", &self.constraints.borrow().len())
             .field("soc_constraints", &self.soc_constraints.borrow().len())
             .field("has_objective", &self.objective.borrow().is_some())
+            .field("feasibility", &self.is_feasibility())
             .finish()
     }
 }
@@ -98,6 +100,7 @@ impl Model {
             soc_constraints: RefCell::new(Vec::new()),
             soc_names: RefCell::new(FxHashMap::default()),
             objective: RefCell::new(None),
+            objective_declared: Cell::new(false),
             cached_kind: Cell::new(None),
             auto_seq: Cell::new(0),
         }
@@ -688,9 +691,37 @@ impl Model {
         self.set_objective(expr, ObjectiveSense::Maximize);
     }
 
+    /// Macro-facing entry point backing `objective!(m, Feasibility)`. Declares
+    /// the model a feasibility problem (no objective to optimize), clearing any
+    /// previously set objective. Not part of the stable public API.
+    #[doc(hidden)]
+    pub fn __feasibility(&self) {
+        *self.objective.borrow_mut() = None;
+        self.objective_declared.set(true);
+        self.cached_kind.set(None);
+    }
+
     fn set_objective(&self, expr: Expr<'_>, sense: ObjectiveSense) {
         *self.objective.borrow_mut() = Some(Objective { expr: expr.id, sense });
+        self.objective_declared.set(true);
         self.cached_kind.set(None);
+    }
+
+    /// Whether feasibility was declared explicitly via `objective!(m, Feasibility)`,
+    /// as opposed to a model that simply has no objective set.
+    pub fn is_feasibility(&self) -> bool {
+        self.objective_declared.get() && self.objective.borrow().is_none()
+    }
+
+    /// Ensure the model has a solve direction declared: either an objective
+    /// (`Min`/`Max`) or an explicit feasibility problem.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoObjective`] if neither an objective nor
+    /// `objective!(m, Feasibility)` was declared.
+    pub fn ensure_objective_declared(&self) -> Result<()> {
+        if self.objective_declared.get() { Ok(()) } else { Err(Error::NoObjective) }
     }
 
     pub fn objective(&self) -> Ref<'_, Option<Objective>> {

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -340,20 +340,31 @@ fn objective_sense_aliases_map_correctly() {
 
 #[test]
 fn feasibility_declares_a_problem_without_objective() {
-    for spelling in ["Feasibility", "feasibility", "feas"] {
-        let m = Model::new("feas");
-        variable!(m, 0.0 <= x <= 1.0);
-        constraint!(m, c, x >= 0.5);
-        match spelling {
-            "Feasibility" => objective!(m, Feasibility),
-            "feasibility" => objective!(m, feasibility),
-            _ => objective!(m, feas),
-        }
+    fn check(m: &Model, spelling: &str) {
         assert!(m.is_feasibility(), "{spelling}: expected feasibility");
         assert!(m.objective().is_none(), "{spelling}: no objective expr");
         assert!(m.ensure_objective_declared().is_ok(), "{spelling}");
         assert_eq!(m.kind(), ModelKind::LP, "{spelling}");
     }
+
+    // All three spellings lower to `__feasibility()`.
+    let m = Model::new("feas");
+    variable!(m, 0.0 <= x <= 1.0);
+    constraint!(m, c, x >= 0.5);
+    objective!(m, Feasibility);
+    check(&m, "Feasibility");
+
+    let m = Model::new("feas");
+    variable!(m, 0.0 <= x <= 1.0);
+    constraint!(m, c, x >= 0.5);
+    objective!(m, feasibility);
+    check(&m, "feasibility");
+
+    let m = Model::new("feas");
+    variable!(m, 0.0 <= x <= 1.0);
+    constraint!(m, c, x >= 0.5);
+    objective!(m, feas);
+    check(&m, "feas");
 }
 
 #[test]

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -339,6 +339,45 @@ fn objective_sense_aliases_map_correctly() {
 }
 
 #[test]
+fn feasibility_declares_a_problem_without_objective() {
+    for spelling in ["Feasibility", "feasibility", "feas"] {
+        let m = Model::new("feas");
+        variable!(m, 0.0 <= x <= 1.0);
+        constraint!(m, c, x >= 0.5);
+        match spelling {
+            "Feasibility" => objective!(m, Feasibility),
+            "feasibility" => objective!(m, feasibility),
+            _ => objective!(m, feas),
+        }
+        assert!(m.is_feasibility(), "{spelling}: expected feasibility");
+        assert!(m.objective().is_none(), "{spelling}: no objective expr");
+        assert!(m.ensure_objective_declared().is_ok(), "{spelling}");
+        assert_eq!(m.kind(), ModelKind::LP, "{spelling}");
+    }
+}
+
+#[test]
+fn unset_objective_is_not_declared() {
+    let m = Model::new("unset");
+    variable!(m, x >= 0.0);
+    constraint!(m, c, x <= 1.0);
+    assert!(!m.is_feasibility());
+    assert!(m.ensure_objective_declared().is_err());
+}
+
+#[test]
+fn optimize_after_feasibility_clears_feasibility() {
+    let m = Model::new("switch");
+    variable!(m, x >= 0.0);
+    objective!(m, Feasibility);
+    assert!(m.is_feasibility());
+    objective!(m, Min, x);
+    assert!(!m.is_feasibility());
+    assert!(m.objective().is_some());
+    assert!(m.ensure_objective_declared().is_ok());
+}
+
+#[test]
 fn param_handle_keeps_model_linear() {
     let m = Model::new("param");
     param!(m, rate = 0.05);

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -39,14 +39,15 @@ pub fn solve(
     opts: &GamsOptions,
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     validate_solver(opts, kind)?;
     let arena = model.arena();
     let vars = model.variables();
     let constraints = model.constraints();
     let socs = model.soc_constraints();
-    let objective = model.try_objective().map_err(SolverError::Core)?;
-    let sense = objective.sense;
+    let objective = model.objective();
+    let sense = objective.as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
 
     let sense_kw = match sense {
         ObjectiveSense::Minimize => "minimizing",
@@ -61,7 +62,7 @@ pub fn solve(
         &vars,
         &constraints,
         &socs,
-        &objective,
+        objective.as_ref(),
         sense_kw,
         opts,
     );
@@ -562,7 +563,7 @@ fn build_model_section(
     vars: &[Variable],
     constraints: &[Constraint],
     socs: &[SocConstraint],
-    objective: &Objective,
+    objective: Option<&Objective>,
     sense_kw: &str,
     opts: &GamsOptions,
 ) -> Option<(String, String)> {
@@ -719,7 +720,7 @@ fn write_equations(
     arena: &ExprArena,
     constraints: &[Constraint],
     socs: &[SocConstraint],
-    objective: &Objective,
+    objective: Option<&Objective>,
 ) {
     write!(gms, "Equations\n    eq_obj").unwrap();
     for (i, c) in constraints.iter().enumerate() {
@@ -735,10 +736,15 @@ fn write_equations(
     writeln!(gms, ";").unwrap();
     writeln!(gms).unwrap();
 
-    let obj_form = ExprForm::from(arena, objective.expr);
-    write!(gms, "eq_obj..  v_obj =e=").unwrap();
-    write_form(gms, arena, &obj_form, true);
-    writeln!(gms, ";").unwrap();
+    match objective {
+        None => writeln!(gms, "eq_obj..  v_obj =e= 0;").unwrap(),
+        Some(obj) => {
+            let obj_form = ExprForm::from(arena, obj.expr);
+            write!(gms, "eq_obj..  v_obj =e=").unwrap();
+            write_form(gms, arena, &obj_form, true);
+            writeln!(gms, ";").unwrap();
+        }
+    }
 
     for (ci, c) in constraints.iter().enumerate() {
         if let Some((sense, rhs)) = c.as_single() {
@@ -1024,8 +1030,8 @@ mod tests {
         let vars = model.variables();
         let constraints = model.constraints();
         let socs = model.soc_constraints();
-        let objective = model.try_objective().expect("objective set");
-        let sense_kw = match objective.sense {
+        let objective = model.objective();
+        let sense_kw = match objective.as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense) {
             ObjectiveSense::Minimize => "minimizing",
             ObjectiveSense::Maximize => "maximizing",
         };
@@ -1037,7 +1043,7 @@ mod tests {
             &vars,
             &constraints,
             &socs,
-            &objective,
+            objective.as_ref(),
             sense_kw,
             opts,
         );
@@ -1113,6 +1119,18 @@ mod tests {
         constraint!(m, c, x + y <= 5.0);
         objective!(m, Min, x + 2.0 * y);
         let gms = render(&m, &GamsOptions::default());
+        assert!(gms.contains("Solve oximo_m using LP minimizing v_obj;"), "got:\n{gms}");
+    }
+
+    #[test]
+    fn feasibility_minimizes_zero_with_lp_solve_type() {
+        let m = Model::new("feas");
+        variable!(m, 0.0 <= x <= 10.0);
+        variable!(m, 0.0 <= y <= 10.0);
+        constraint!(m, c, x + y == 5.0);
+        objective!(m, Feasibility);
+        let gms = render(&m, &GamsOptions::default());
+        assert!(gms.contains("eq_obj..  v_obj =e= 0;"), "got:\n{gms}");
         assert!(gms.contains("Solve oximo_m using LP minimizing v_obj;"), "got:\n{gms}");
     }
 

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -60,6 +60,7 @@ pub(crate) struct Built {
 /// Returns a [`SolverError`] if the model contains nonlinear expressions Gurobi
 /// cannot represent or Gurobi reports an error during setup.
 pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Built, SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     let nonlinear_kind = matches!(
         kind,

--- a/crates/oximo-gurobi/tests/persistent.rs
+++ b/crates/oximo-gurobi/tests/persistent.rs
@@ -70,6 +70,7 @@ fn persistent_feasibility_no_objective() {
     variable!(m, 0.0 <= x <= 10.0);
     variable!(m, 0.0 <= y <= 10.0);
     constraint!(m, c, x + y == 5.0);
+    objective!(m, Feasibility);
 
     let mut solver = Gurobi.persistent();
     let r = solver.solve(&m, &GurobiOptions::default()).expect("feasibility solve");

--- a/crates/oximo-highs/src/persistent.rs
+++ b/crates/oximo-highs/src/persistent.rs
@@ -213,6 +213,7 @@ mod tests {
         variable!(m, 0.0 <= x <= 10.0);
         variable!(m, 0.0 <= y <= 10.0);
         constraint!(m, c, x + y == 5.0);
+        objective!(m, Feasibility);
 
         let mut solver = Highs.persistent();
         let r = solver.solve(&m, &HighsOptions::default()).unwrap();

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -82,6 +82,7 @@ pub(crate) struct Meta {
 /// Returns a [`SolverError`] if the model kind is unsupported, a domain cannot be
 /// represented, or an expression is not linear/quadratic as required.
 pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if !crate::supported(kind) {
         return Err(SolverError::UnsupportedKind(kind));

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -65,6 +65,8 @@ pub fn soc_constraint(input: TokenStream) -> TokenStream {
 }
 
 /// `objective!(model, Min|Max, expr)`, set the model objective and sense.
+/// `objective!(model, Feasibility)` (also `feasibility`/`feas`) declares a
+/// feasibility problem with no objective to optimize.
 #[proc_macro]
 pub fn objective(input: TokenStream) -> TokenStream {
     objective::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()

--- a/crates/oximo-macros/src/objective.rs
+++ b/crates/oximo-macros/src/objective.rs
@@ -1,15 +1,21 @@
-//! `objective!(model, Min|Max, expr)`. The sense also accepts the long forms
-//! `Minimize`/`Maximize` and lowercase `min`/`max`.
+//! `objective!(m, Min|Max, expr)` sets the model objective and sense. The sense
+//! also accepts the long forms `Minimize`/`Maximize` and lowercase `min`/`max`.
+//!
+//! `objective!(m, Feasibility)` (also `feasibility`/`feas`) declares a feasibility
+//! problem: no objective to optimize, just find any point satisfying the model.
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{Expr, Ident, Token};
 
-struct ObjectiveInput {
-    model: Expr,
-    sense: Ident,
-    expr: Expr,
+enum ObjectiveInput {
+    Feasibility { model: Expr },
+    Optimize { model: Expr, sense: Ident, expr: Expr },
+}
+
+fn is_feasibility_kw(ident: &Ident) -> bool {
+    matches!(ident.to_string().as_str(), "Feasibility" | "feasibility" | "Feas" | "feas")
 }
 
 impl Parse for ObjectiveInput {
@@ -17,27 +23,51 @@ impl Parse for ObjectiveInput {
         let model = input.parse::<Expr>()?;
         input.parse::<Token![,]>()?;
         let sense = input.parse::<Ident>()?;
+
+        // Two-argument form: `objective!(m, Feasibility)`.
+        if input.is_empty() {
+            if is_feasibility_kw(&sense) {
+                return Ok(Self::Feasibility { model });
+            }
+            return Err(syn::Error::new(
+                sense.span(),
+                "expected an objective expression after the sense, or \
+                 `Feasibility` for a feasibility problem",
+            ));
+        }
+
+        // Three-argument form: `objective!(m, Min|Max, expr)`.
         input.parse::<Token![,]>()?;
         let expr = input.parse::<Expr>()?;
-        Ok(Self { model, sense, expr })
+        if is_feasibility_kw(&sense) {
+            return Err(syn::Error::new(
+                sense.span(),
+                "`Feasibility` takes no objective expression; write `objective!(m, Feasibility)`",
+            ));
+        }
+        Ok(Self::Optimize { model, sense, expr })
     }
 }
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     // Rewrite `q[i, j, k]` index sugar in the objective expression.
     let input = crate::index::rewrite_index_subscripts(input);
-    let ObjectiveInput { model, sense, expr } = syn::parse2(input)?;
 
-    let method = match sense.to_string().as_str() {
-        "Min" | "Minimize" | "min" => quote!(__minimize),
-        "Max" | "Maximize" | "max" => quote!(__maximize),
-        _ => {
-            return Err(syn::Error::new(
-                sense.span(),
-                "objective sense must be `Min`/`min`/`Minimize` or `Max`/`max`/`Maximize`",
-            ));
+    match syn::parse2(input)? {
+        ObjectiveInput::Feasibility { model } => Ok(quote!( (#model).__feasibility() )),
+        ObjectiveInput::Optimize { model, sense, expr } => {
+            let method = match sense.to_string().as_str() {
+                "Min" | "Minimize" | "min" => quote!(__minimize),
+                "Max" | "Maximize" | "max" => quote!(__maximize),
+                _ => {
+                    return Err(syn::Error::new(
+                        sense.span(),
+                        "objective sense must be `Min`/`min`/`Minimize` or \
+                         `Max`/`max`/`Maximize`",
+                    ));
+                }
+            };
+            Ok(quote!( (#model).#method(#expr) ))
         }
-    };
-
-    Ok(quote!( (#model).#method(#expr) ))
+    }
 }

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -203,14 +203,26 @@ mod tests {
     }
 
     #[test]
-    fn no_objective_is_a_zero_objective() {
+    fn feasibility_is_a_zero_objective() {
         let m = Model::new("feas");
         variable!(m, x >= 0.0);
         variable!(m, y >= 0.0);
         constraint!(m, c, x + y == 5.0);
+        objective!(m, Feasibility);
 
         let s = snapshot(&m).expect("feasibility model snapshots");
         assert!(s.obj_costs.iter().all(|&c| c.abs() < 1e-12), "costs = {:?}", s.obj_costs);
         assert!(s.obj_constant.abs() < 1e-12, "constant = {}", s.obj_constant);
+    }
+
+    #[test]
+    fn undeclared_objective_is_rejected() {
+        let m = Model::new("undeclared");
+        variable!(m, x >= 0.0);
+        constraint!(m, c, x <= 5.0);
+        assert!(matches!(
+            snapshot(&m),
+            Err(crate::status::SolverError::Core(oximo_core::Error::NoObjective))
+        ));
     }
 }

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -46,6 +46,7 @@ pub struct Snapshot {
 /// cone program (explicit [`oximo_core::SocConstraint`]s or SOC-shaped
 /// quadratic constraints detected by [`Model::kind`]).
 pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if model.num_soc_constraints() > 0 || matches!(kind, ModelKind::SOCP | ModelKind::MISOCP) {
         return Err(SolverError::UnsupportedKind(kind));

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -77,6 +77,8 @@ constraint!(m, band, 1.0 <= x + y <= 10.0); // two-sided range -> one constraint
 objective!(m, Min, 3.0 * x + 5.0 * y);
 // or
 objective!(m, Max, x + 2.0 * y); // also Minimize/min, Maximize/max
+// or, for a pure feasibility problem (no objective to optimize):
+objective!(m, Feasibility); // also `feasibility` / `feas`
 ```
 
 ### Indexed variables
@@ -273,7 +275,7 @@ let result = Highs.solve(&m, &HighsOptions::default())?;
 
 match result.termination {
     TerminationStatus::Optimal => {
-        // `objective()` is `Option` (a model may have no objective), so print it
+        // `objective()` is `Option` (a feasibility problem has none), so print it
         // only when present.
         if let Some(obj) = result.objective() {
             println!("optimal: {obj}");

--- a/crates/oximo/examples/baron_robot.rs
+++ b/crates/oximo/examples/baron_robot.rs
@@ -67,7 +67,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     constraint!(m, e7, x5.powi(2) + x6.powi(2) == 1.0);
     constraint!(m, e8, x7.powi(2) + x8.powi(2) == 1.0);
 
-    // Pure feasibility problem: no objective set => `minimize 0`.
+    // Pure feasibility problem.
+    objective!(m, Feasibility);
 
     let opts =
         BaronOptions::default().time_limit(Duration::from_secs(120)).num_sol(20).verbose(true);

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -228,6 +228,31 @@ fn infeasible_returns_status() {
 }
 
 #[test]
+fn feasibility_problem_finds_a_point() {
+    let m = Model::new("feas");
+    variable!(m, 0.0 <= x <= 10.0);
+    variable!(m, 0.0 <= y <= 10.0);
+    constraint!(m, c, x + y == 5.0);
+    objective!(m, Feasibility);
+    let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert!(result.has_solution(), "status: {:?}", result.termination);
+    let (vx, vy) = (result.value_of(x).unwrap(), result.value_of(y).unwrap());
+    assert!((vx + vy - 5.0).abs() < 1e-6, "x + y = {}", vx + vy);
+}
+
+#[test]
+fn no_objective_declared_is_an_error() {
+    let m = Model::new("undeclared");
+    variable!(m, 0.0 <= x <= 1.0);
+    constraint!(m, c, x >= 0.5);
+    let err = Highs.solve(&m, &HighsOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, SolverError::Core(oximo::core::Error::NoObjective)),
+        "expected NoObjective, got {err:?}"
+    );
+}
+
+#[test]
 fn presolve_off_gives_correct_result() {
     let m = Model::new("canon");
     variable!(m, x >= 0.0);


### PR DESCRIPTION
## Description

This PR is a breaking change that requires feasibility problems to explicitly declare a feasibility objective.
I think some users might forget to add an objective and trust the solvers' results without realizing the error. Adding a warning would make this non-breaking, but I think this is fine since the library is relatively new.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)