### PR TITLE
Add oximo-autodiff crate

### DIFF
--- a/.github/workflows/autodiff.yml
+++ b/.github/workflows/autodiff.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: enzyme

--- a/.github/workflows/autodiff.yml
+++ b/.github/workflows/autodiff.yml
@@ -1,0 +1,30 @@
+name: Autodiff (nightly)
+
+# Exercises the `enzyme` feature of oximo-autodiff, which needs a nightly
+# toolchain with the Enzyme engine (`-Zautodiff=Enable`) and the fat-LTO
+# `enzyme` profile.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Cargo test (oximo-autodiff, enzyme)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: enzyme
+      - uses: Swatinem/rust-cache@v2
+      - name: Test oximo-autodiff with Enzyme
+        run: cargo test -p oximo-autodiff --features enzyme --profile enzyme
+        env:
+          RUSTFLAGS: "-Zautodiff=Enable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -37,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --exclude oximo-gurobi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/oximo-gams",
     "crates/oximo-baron",
     "crates/oximo-clarabel",
+    "crates/oximo-autodiff",
     "crates/oximo",
 ]
 
@@ -37,6 +38,7 @@ oximo-gurobi = { path = "crates/oximo-gurobi", version = "0.4.0" }
 oximo-gams   = { path = "crates/oximo-gams",   version = "0.4.0" }
 oximo-baron  = { path = "crates/oximo-baron",  version = "0.4.0" }
 oximo-clarabel = { path = "crates/oximo-clarabel", version = "0.4.0" }
+oximo-autodiff = { path = "crates/oximo-autodiff", version = "0.4.0" }
 
 rayon            = "1.12"
 syn              = { version = "2", features = ["full"] }
@@ -75,3 +77,11 @@ missing_fields_in_debug = "allow"
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+# std::autodiff (Enzyme) needs fat LTO so the differentiated
+# tape interpreter is visible across crate boundaries.
+# Used by the `enzyme` features of oximo-autodiff.
+[profile.enzyme]
+inherits = "release"
+lto = "fat"
+codegen-units = 16

--- a/README.md
+++ b/README.md
@@ -310,17 +310,20 @@ With the `io` feature (default), you can export models to MPS, LP and NL format 
 
 ## Workspace layout
 
-| Crate          | Role                                                  |
-|----------------|-------------------------------------------------------|
-| `oximo`        | Umbrella crate                                        |
-| `oximo-expr`   | Arena-allocated expression tree                       |
-| `oximo-core`   | `Model`, `Variable`, `Constraint`, `Objective`, `Set` |
-| `oximo-solver` | `Solver` trait, `SolverResult`, `SolverOptions`       |
-| `oximo-io`     | MPS, LP and NL writers                                |
-| `oximo-highs`  | HiGHS backend                                         |
-| `oximo-gurobi` | Gurobi backend                                        |
-| `oximo-gams`   | GAMS writer and backend                               |
-| `oximo-baron`  | BARON writer and backend                              |
+| Crate            | Role                                                      |
+|------------------|-----------------------------------------------------------|
+| `oximo`          | Umbrella crate                                            |
+| `oximo-expr`     | Arena-allocated expression tree                           |
+| `oximo-core`     | `Model`, `Variable`, `Constraint`, `Objective`, `Set`     |
+| `oximo-macros`   | `variable!`, `constraint!`, `objective!` and other macros |
+| `oximo-autodiff` | Gradients, sparse Jacobians/Hessians via Enzyme           |
+| `oximo-solver`   | `Solver` trait, `SolverResult`, `SolverOptions`           |
+| `oximo-io`       | MPS, LP and NL writers                                    |
+| `oximo-highs`    | HiGHS backend                                             |
+| `oximo-gurobi`   | Gurobi backend                                            |
+| `oximo-gams`     | GAMS writer and backend                                   |
+| `oximo-baron`    | BARON writer and backend                                  |
+| `oximo-clarabel` | Clarabel backend                                          |
 
 ## Requirements
 

--- a/crates/oximo-autodiff/Cargo.toml
+++ b/crates/oximo-autodiff/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "oximo-autodiff"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Automatic differentiation (gradients, sparse Jacobians and Hessians) for oximo models via std::autodiff"
+readme = "README.md"
+
+[features]
+# Enables the std::autodiff (Enzyme) derivative engine. Requires a nightly
+# toolchain with the `enzyme` component, RUSTFLAGS="-Zautodiff=Enable",
+# and a fat-LTO profile (the workspace provides `--profile enzyme`).
+enzyme = ["dep:rayon"]
+
+[dependencies]
+oximo-expr.workspace = true
+oximo-core.workspace = true
+rustc-hash.workspace = true
+thiserror.workspace = true
+rayon = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/oximo-autodiff/README.md
+++ b/crates/oximo-autodiff/README.md
@@ -1,0 +1,90 @@
+# oximo-autodiff
+
+Automatic differentiation for [oximo](https://github.com/oximo-rs/oximo) models: gradients, sparse Jacobians, and sparse Hessians of the Lagrangian, computed exactly with [`std::autodiff`](https://doc.rust-lang.org/nightly/std/autodiff/) (Enzyme).
+
+Model expressions are runtime data, while Enzyme differentiates compiled Rust.
+This crate bridges the two by compiling each expression into a flat instruction tape and differentiating the tape interpreter once at compile time: reverse mode for gradients, forward-over-reverse for Hessian-vector products.
+
+Linear and quadratic expressions never hit the AD engine, since they use the closed-form `extract_linear`/`extract_quadratic` fast paths.
+
+## Two layers: stable and nightly
+
+The crate is split into a value layer that builds on stable Rust and a derivative layer gated behind the nightly-only `enzyme` feature.
+
+**`Tape` (stable).** `Tape::compile` lowers an expression
+once into a flat SSA instruction tape, deduplicating shared subexpressions. `Tape::value` then evaluates it at any point in a tight loop over owned buffers, without borrowing the model. It is a compile-once, evaluate-many value oracle. Re-walking the expression arena at every point (as the general `oximo_expr::evaluate` does) re-discovers the sharing, re-dispatches per node, and re-borrows the model on each call; the tape pays that structural cost once at compile time and never again. It needs neither nightly nor the `enzyme` feature.
+
+**The derivative engine (`enzyme`, nightly).** Differentiates that same tape interpreter with `std::autodiff` for exact gradients, Jacobians, and Hessians. The stable value path is the primal it differentiates, so finite-difference and exact backends agree on exactly what "the function" is.
+
+## Toolchain requirements
+
+The derivative engine is gated behind the non-default `enzyme` feature and needs:
+
+- a nightly toolchain with the `enzyme` component
+  (See [Enzyme installation instructions](https://rustc-dev-guide.rust-lang.org/autodiff/installation.html)),
+- `RUSTFLAGS="-Zautodiff=Enable"`,
+- a fat-LTO profile, the workspace provides `--profile enzyme`.
+
+```bash
+RUSTFLAGS="-Zautodiff=Enable" cargo +nightly test -p oximo-autodiff --features enzyme --profile enzyme
+```
+
+## Who this is for
+
+Most users never depend on this crate directly. It is the derivative engine that oximo's nonlinear backends use internally to feed exact gradients, Jacobians, and Hessians to the solver.
+
+Reach for `oximo-autodiff` directly only when writing a new NLP backend, when you need raw derivatives of a model's expressions, or when you need a fast compiled evaluator (`Tape`) for their values.
+
+## How a backend uses it
+
+Build a model with the `oximo` modeling macros, then construct one
+`NlpEvaluator`. It owns the compiled tapes, sparsity patterns, and scratch buffers, so evaluation never touches the model again. A backend calls it from its solver callbacks.
+
+```rust,ignore
+use oximo_core::Model;
+use oximo_core::prelude::*;
+use oximo_autodiff::NlpEvaluator;
+
+let m = Model::new("nlp");
+variable!(m, -10.0 <= x <= 10.0);
+variable!(m, -10.0 <= y <= 10.0);
+objective!(m, Min, (1.0 - x).powi(2) + 100.0 * (y - x.powi(2)).powi(2));
+constraint!(m, disk, x.powi(2) + y.powi(2) <= 4.0);
+
+let eval = NlpEvaluator::new(&m)?;
+let point = [0.5, 0.5];
+
+// Objective value and its dense gradient
+let f = eval.eval_objective(&point);
+let mut grad = vec![0.0; eval.num_variables()];
+eval.eval_objective_gradient(&point, &mut grad);
+
+// Constraint values
+let mut g = vec![0.0; eval.num_constraints()];
+eval.eval_constraint(&point, &mut g);
+
+// Sparse constraint Jacobian
+let jac_pattern = eval.jacobian_structure(); // &[(usize, usize)]
+let mut jac = vec![0.0; jac_pattern.len()];
+eval.eval_constraint_jacobian(&point, &mut jac);
+
+// Sparse lower-triangle Hessian of the Lagrangian
+let hess_pattern = eval.hessian_lagrangian_structure();
+let mut hess = vec![0.0; hess_pattern.len()];
+let sigma = 1.0;
+let lambda = vec![0.0; eval.num_constraints()];
+eval.eval_hessian_lagrangian(&point, sigma, &lambda, &mut hess);
+```
+
+For a parameter sweep, a resident backend can keep one evaluator and update it in place with `eval.try_refresh(&m)` (reuses the tapes when the structure is unchanged, returns `false` to signal a rebuild).
+
+The dense gradient of a single expression at a point is also available directly, without a full evaluator:
+
+```rust,ignore
+// grad indexed by variable
+let grad = oximo_autodiff::gradient_at(&m, expr, &x_bar)?;
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/oximo-autodiff/src/enzyme.rs
+++ b/crates/oximo-autodiff/src/enzyme.rs
@@ -1,0 +1,176 @@
+//! The `std::autodiff` (Enzyme) wrappers around the tape interpreter.
+//!
+//! [`eval_tape_ad`] is differentiated once in reverse mode for gradients,
+//! [`grad_eval_tape`] (which runs the reverse pass) is differentiated in
+//! forward mode for Hessian-vector products (forward-over-reverse).
+//!
+//! An `Active` return is implemented via an `enzyme_primal_return`
+//! marker global that Enzyme cannot shadow when the forward-over-reverse
+//! pass runs in a downstream crate's fat-LTO step.
+
+#![allow(clippy::too_many_arguments)]
+
+use std::autodiff::{autodiff_forward, autodiff_reverse};
+
+use crate::tape::Tape;
+
+/// Reverse-differentiated interpreter: `d_eval_tape(.., x, dx, .., regs,
+/// dregs, out, dout)` accumulates `dout[0] * (partial f)/(partial x)` into `dx`.
+#[autodiff_reverse(
+    d_eval_tape,
+    Const,
+    Const,
+    Const,
+    Const,
+    Const,
+    Const,
+    Duplicated,
+    Const,
+    Const,
+    Duplicated,
+    Duplicated
+)]
+#[allow(clippy::too_many_arguments)]
+#[inline(never)]
+pub fn eval_tape_ad(
+    ops: &[u32],
+    a: &[u32],
+    b: &[u32],
+    consts: &[f64],
+    lin_vars: &[u32],
+    lin_coeffs: &[f64],
+    x: &[f64],
+    params: &[f64],
+    mults: &[f64],
+    regs: &mut [f64],
+    out: &mut [f64],
+) {
+    crate::tape::eval_tape(ops, a, b, consts, lin_vars, lin_coeffs, x, params, mults, regs, out);
+}
+
+/// Gradient entry point: zeroes the shadows, seeds `dout[0] = 1.0`, then runs
+/// one reverse sweep. `grad_out` receives `(partial f/partial x)` (dense, indexed by
+/// variable) and `out[0]` the primal value.
+///
+/// Forward-differentiated as `hvp_eval_tape` for Hessian-vector products:
+/// seeding the `x` tangent with a direction `v` makes the `grad_out` tangent
+/// come back as `H*v`.
+#[autodiff_forward(
+    hvp_eval_tape,
+    Const,
+    Const,
+    Const,
+    Const,
+    Const,
+    Const,
+    Dual,
+    Const,
+    Const,
+    Dual,
+    Dual,
+    Dual,
+    Dual,
+    Dual
+)]
+#[allow(clippy::too_many_arguments)]
+#[inline(never)]
+pub fn grad_eval_tape(
+    ops: &[u32],
+    a: &[u32],
+    b: &[u32],
+    consts: &[f64],
+    lin_vars: &[u32],
+    lin_coeffs: &[f64],
+    x: &[f64],
+    params: &[f64],
+    mults: &[f64],
+    regs: &mut [f64],
+    dregs: &mut [f64],
+    out: &mut [f64],
+    dout: &mut [f64],
+    grad_out: &mut [f64],
+) {
+    // This function is the primal that `hvp_eval_tape` forward-differentiates, so
+    // it is kept deliberately free of a `memset` intrinsic that Enzyme's type
+    // analysis would otherwise have to see through inside the differentiated
+    // region.
+    for g in grad_out.iter_mut() {
+        *g = 0.0;
+    }
+    for d in dregs.iter_mut() {
+        *d = 0.0;
+    }
+    dout[0] = 1.0;
+    d_eval_tape(
+        ops, a, b, consts, lin_vars, lin_coeffs, x, grad_out, params, mults, regs, dregs, out, dout,
+    );
+}
+
+/// Compute the dense gradient of `tape` at `x` into `grad_out` (overwritten).
+/// `regs`/`dregs` are scratch of length [`Tape::n_regs`].
+pub(crate) fn tape_gradient(
+    tape: &Tape,
+    x: &[f64],
+    params: &[f64],
+    mults: &[f64],
+    regs: &mut [f64],
+    dregs: &mut [f64],
+    grad_out: &mut [f64],
+) {
+    let (ops, a, b, consts, lin_vars, lin_coeffs) = tape.parts();
+    let mut out = [0.0];
+    let mut dout = [0.0];
+    grad_eval_tape(
+        ops, a, b, consts, lin_vars, lin_coeffs, x, params, mults, regs, dregs, &mut out,
+        &mut dout, grad_out,
+    );
+}
+
+/// Forward-over-reverse Hessian-vector product of `tape` at `x` along `dir`.
+/// `grad_out` receives the gradient, `hv_out` receives `H*dir` (both
+/// overwritten).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn tape_hvp(
+    tape: &Tape,
+    x: &[f64],
+    dir: &[f64],
+    params: &[f64],
+    mults: &[f64],
+    regs: &mut [f64],
+    regs_t: &mut [f64],
+    dregs: &mut [f64],
+    dregs_t: &mut [f64],
+    grad_out: &mut [f64],
+    hv_out: &mut [f64],
+) {
+    let (ops, a, b, consts, lin_vars, lin_coeffs) = tape.parts();
+    regs_t.fill(0.0);
+    dregs_t.fill(0.0);
+    hv_out.fill(0.0);
+    let mut out = [0.0];
+    let mut out_t = [0.0];
+    let mut dout = [0.0];
+    let mut dout_t = [0.0];
+    hvp_eval_tape(
+        ops,
+        a,
+        b,
+        consts,
+        lin_vars,
+        lin_coeffs,
+        x,
+        dir,
+        params,
+        mults,
+        regs,
+        regs_t,
+        dregs,
+        dregs_t,
+        &mut out,
+        &mut out_t,
+        &mut dout,
+        &mut dout_t,
+        grad_out,
+        hv_out,
+    );
+}

--- a/crates/oximo-autodiff/src/error.rs
+++ b/crates/oximo-autodiff/src/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+/// Errors produced while building derivatives from a model.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AutodiffError {
+    #[error("model has no objective")]
+    NoObjective,
+    #[error("point has {got} entries but the model has {expected} variables")]
+    DimensionMismatch { expected: usize, got: usize },
+}

--- a/crates/oximo-autodiff/src/evaluator.rs
+++ b/crates/oximo-autodiff/src/evaluator.rs
@@ -1,0 +1,758 @@
+//! [`NlpEvaluator`]: derivative oracle for a continuous model, built from a [`Model`] and
+//! classifying every function as linear, quadratic, or nonlinear. Linear and
+//! quadratic functions use closed forms for values and derivatives, only
+//! nonlinear functions go through the Enzyme-differentiated tape interpreter.
+//!
+//! Built once from a [`Model`], owns compiled tapes, sparsity patterns, and
+//! scratch buffers, so evaluation never touches the model's `RefCell`s again.
+
+use std::cell::RefCell;
+
+use oximo_core::Model;
+use oximo_expr::ExprId;
+use rayon::prelude::*;
+
+use crate::enzyme::{tape_gradient, tape_hvp};
+use crate::error::AutodiffError;
+use crate::slot::{
+    FunctionSlot, SlotKind, linear_gradient_add, linear_value, quadratic_gradient_add,
+    quadratic_value,
+};
+use crate::sparsity::{hessian_lagrangian_structure, jacobian_structure, star_hessian_coloring};
+use crate::tape::Tape;
+
+// Above these counts a derivative call fans its independent units of work out
+// across rayon's thread pool; below, it stays on the single reusable scratch
+// buffer (the zero-allocation fast path). Counts are a coarse proxy for work:
+// a Hessian seed is a whole forward-over-reverse tape pass, and a Jacobian row
+// / nonlinear constraint value is a reverse pass, so linear/quadratic slots
+// make the constraint thresholds conservative.
+// TODO: benchmark and tune these thresholds (ideally weighting by tape size and
+// the nonlinear-slot count rather than a raw element count).
+const PAR_SEED_THRESHOLD: usize = 16;
+const PAR_CONSTRAINT_THRESHOLD: usize = 64;
+
+/// Where each Lagrangian-tape multiplier slot takes its weight from.
+#[derive(Copy, Clone, Debug)]
+enum NlSource {
+    Objective,
+    Constraint(usize),
+}
+
+/// One compressed Hessian-vector product. The direction seeds every column in
+/// a structurally orthogonal group, and `fills` scatters the result.
+#[derive(Debug)]
+struct Seed {
+    /// Columns receiving 1.0 in the HVP direction.
+    cols: Vec<usize>,
+    /// `(position-in-vals, dense row)` of the nonlinear-pattern entries this
+    /// HVP fills. Built from the nonlinear-only pattern.
+    fills: Vec<(usize, usize)>,
+}
+
+/// Per-worker-thread scratch for the parallel derivative paths, allocated once
+/// per rayon worker by `map_init`. The serial paths keep using the shared
+/// [`Scratch`] behind the `RefCell`. Only the above-threshold parallel branches
+/// allocate these, so we keep the zero-allocation fast path for small problems.
+struct ParScratch {
+    regs: Vec<f64>,
+    dregs: Vec<f64>,
+    regs_t: Vec<f64>,
+    dregs_t: Vec<f64>,
+    dir: Vec<f64>,
+    grad: Vec<f64>,
+    hv: Vec<f64>,
+}
+
+impl ParScratch {
+    fn new(max_regs: usize, n_vars: usize) -> Self {
+        Self {
+            regs: vec![0.0; max_regs],
+            dregs: vec![0.0; max_regs],
+            regs_t: vec![0.0; max_regs],
+            dregs_t: vec![0.0; max_regs],
+            dir: vec![0.0; n_vars],
+            grad: vec![0.0; n_vars],
+            hv: vec![0.0; n_vars],
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Scratch {
+    /// Dense gradient buffer, length `n_vars`.
+    grad: Vec<f64>,
+    /// Dense HVP seed direction, length `n_vars`.
+    dir: Vec<f64>,
+    /// Dense `H·dir` output, length `n_vars`.
+    hv: Vec<f64>,
+    /// Lagrangian-tape multipliers.
+    mults: Vec<f64>,
+    /// Tape register files and their reverse/tangent shadows, sized for the
+    /// largest tape.
+    regs: Vec<f64>,
+    dregs: Vec<f64>,
+    regs_t: Vec<f64>,
+    dregs_t: Vec<f64>,
+}
+
+/// Derivative oracle for a continuous model.
+/// Objective/constraint values, gradients, sparse Jacobian,
+/// and the sparse lower-triangle Hessian of the Lagrangian
+/// `sigma * laplacian(f) + sum_i(lambda_i * laplacian(g_i))`.
+///
+/// All nonlinear Hessian contributions come from a single weighted "Lagrangian
+/// tape", one Hessian-vector product per structurally orthogonal column group
+/// of the exact nonlinear pattern.
+///
+/// Variable domains are ignored here, we keep integrality in the solver.
+#[derive(Debug)]
+pub struct NlpEvaluator {
+    n_vars: usize,
+    params: Vec<f64>,
+    /// `None` for a feasibility problem, whose objective is the constant zero.
+    objective_expr: Option<ExprId>,
+    constraint_exprs: Vec<ExprId>,
+    objective: FunctionSlot,
+    constraints: Vec<FunctionSlot>,
+    /// Weighted tape over the nonlinear functions (empty if there are none).
+    lagrangian: Tape,
+    /// Weight source for each Lagrangian multiplier slot.
+    nl_sources: Vec<NlSource>,
+    jac_structure: Vec<(usize, usize)>,
+    hess_structure: Vec<(usize, usize)>,
+    /// Position in `hess_structure` of each entry of the objective's quadratic
+    /// Hessian (in `QuadraticTerms::hessian` order). Empty unless the objective
+    /// is quadratic.
+    obj_hess_pos: Vec<usize>,
+    /// Same as `obj_hess_pos`, per constraint.
+    con_hess_pos: Vec<Vec<usize>>,
+    /// Compressed HVP seeds covering the nonlinear Hessian pattern.
+    seeds: Vec<Seed>,
+    /// Largest tape register count, sizing both [`Scratch`] and [`ParScratch`].
+    max_regs: usize,
+    scratch: RefCell<Scratch>,
+}
+
+impl NlpEvaluator {
+    /// Build the oracle from `model`, classifying every function and
+    /// compiling tapes for the nonlinear ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AutodiffError::NoObjective`] if the model declares neither an
+    /// objective nor a feasibility problem.
+    pub fn new(model: &Model) -> Result<Self, AutodiffError> {
+        let arena = model.arena();
+        let n_vars = model.variables().len();
+        model.ensure_objective_declared().map_err(|_| AutodiffError::NoObjective)?;
+        let objective_expr: Option<ExprId> = model.objective().as_ref().map(|o| o.expr);
+        let constraint_exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
+
+        let objective = match objective_expr {
+            Some(e) => FunctionSlot::classify(&arena, e),
+            None => FunctionSlot::zero(),
+        };
+        let constraints: Vec<FunctionSlot> =
+            constraint_exprs.iter().map(|&e| FunctionSlot::classify(&arena, e)).collect();
+
+        // Lagrangian tape over the nonlinear functions only.
+        let mut nl_sources = Vec::new();
+        let mut nl_exprs = Vec::new();
+        if let Some(e) = objective_expr {
+            if objective.is_nonlinear() {
+                nl_sources.push(NlSource::Objective);
+                nl_exprs.push(e);
+            }
+        }
+        for (i, slot) in constraints.iter().enumerate() {
+            if slot.is_nonlinear() {
+                nl_sources.push(NlSource::Constraint(i));
+                nl_exprs.push(constraint_exprs[i]);
+            }
+        }
+        let lagrangian = Tape::compile_weighted(&arena, &nl_exprs);
+
+        let params = crate::tape::params_snapshot(&arena);
+        drop(arena);
+
+        let jac_structure = jacobian_structure(&constraints);
+        let hess_structure =
+            hessian_lagrangian_structure(std::iter::once(&objective).chain(&constraints));
+
+        let obj_hess_pos = quad_scatter_positions(&objective, &hess_structure);
+        let con_hess_pos =
+            constraints.iter().map(|s| quad_scatter_positions(s, &hess_structure)).collect();
+
+        let seeds = build_seeds(&objective, &constraints, &hess_structure);
+
+        let max_regs = std::iter::once(&objective)
+            .chain(&constraints)
+            .filter_map(|s| match &s.kind {
+                SlotKind::Nonlinear(t) => Some(t.n_regs()),
+                _ => None,
+            })
+            .chain(std::iter::once(lagrangian.n_regs()))
+            .max()
+            .unwrap_or(0);
+
+        let scratch = RefCell::new(Scratch {
+            grad: vec![0.0; n_vars],
+            dir: vec![0.0; n_vars],
+            hv: vec![0.0; n_vars],
+            mults: vec![0.0; nl_sources.len()],
+            regs: vec![0.0; max_regs],
+            dregs: vec![0.0; max_regs],
+            regs_t: vec![0.0; max_regs],
+            dregs_t: vec![0.0; max_regs],
+        });
+
+        Ok(Self {
+            n_vars,
+            params,
+            objective_expr,
+            constraint_exprs,
+            objective,
+            constraints,
+            lagrangian,
+            nl_sources,
+            jac_structure,
+            hess_structure,
+            obj_hess_pos,
+            con_hess_pos,
+            seeds,
+            max_regs,
+            scratch,
+        })
+    }
+
+    /// Re-snapshot parameter values (and the parameter-dependent linear /
+    /// quadratic coefficients) after `set_param` on the model. Tapes are not
+    /// recompiled and sparsity structures are kept. A coefficient that was
+    /// exactly zero at construction and became nonzero may fall outside the
+    /// original pattern, so build the evaluator with representative parameter
+    /// values.
+    ///
+    /// Only the cached quadratic scatter positions are rebuilt, `jac_structure`,
+    /// `hess_structure`, and `seeds` are reused as-is. Nonlinear tapes (and
+    /// therefore the nonlinear Hessian pattern the seeds cover) are
+    /// parameter-independent, and the representative-parameter assumption
+    /// keeps the linear/quadratic patterns fixed too. If that assumption is
+    /// violated so a new quadratic entry appears outside the pattern, the
+    /// `expect` in `quad_scatter_positions` panics. Use [`Self::try_refresh`]
+    /// when the caller cannot guarantee representative parameters.
+    pub fn refresh_params(&mut self, model: &Model) {
+        let arena = model.arena();
+        self.params = crate::tape::params_snapshot(&arena);
+        if let Some(e) = self.objective_expr {
+            self.objective = self.objective.reclassify(&arena, e);
+        }
+        for (slot, &expr) in self.constraints.iter_mut().zip(&self.constraint_exprs) {
+            *slot = slot.reclassify(&arena, expr);
+        }
+        // Reclassification can drop a zeroed quadratic entry or flip a slot's
+        // kind, so realign the cached scatter positions with the new
+        // `QuadraticTerms`. The Hessian pattern is assumed unchanged (see the
+        // representative-parameter note above), so `hess_structure` still
+        // contains every entry.
+        self.rebuild_quad_scatter();
+    }
+
+    /// Try to reuse this evaluator for `model` after a `set_param`/bound
+    /// change, validating that the sparsity structure is unchanged.
+    ///
+    /// Returns `true` when the model has the same variables, the same objective
+    /// and constraint expressions and, after re-extracting linear/quadratic
+    /// coefficients at the new parameter values, the same Jacobian and
+    /// Lagrangian-Hessian patterns. The evaluator is refreshed in place
+    /// and is ready to solve.
+    /// Returns `false` when anything structural changed, leaving the evaluator
+    /// unmodified so the caller can rebuild with [`Self::new`].
+    /// Enables a resident/persistent solver to skip retaping across
+    /// a parametric sweep while staying correct.
+    pub fn try_refresh(&mut self, model: &Model) -> bool {
+        let arena = model.arena();
+        if model.variables().len() != self.n_vars
+            || model.objective().as_ref().map(|o| o.expr) != self.objective_expr
+        {
+            return false;
+        }
+        let con_exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
+        if con_exprs != self.constraint_exprs {
+            return false;
+        }
+
+        let objective = match self.objective_expr {
+            Some(e) => self.objective.reclassify(&arena, e),
+            None => FunctionSlot::zero(),
+        };
+        let constraints: Vec<FunctionSlot> = self
+            .constraints
+            .iter()
+            .zip(&con_exprs)
+            .map(|(s, &e)| s.reclassify(&arena, e))
+            .collect();
+
+        // A parameter can move a coefficient across zero and change the pattern.
+        // Rebuild rather than evaluate against a stale structure.
+        let jac = jacobian_structure(&constraints);
+        let hess = hessian_lagrangian_structure(std::iter::once(&objective).chain(&constraints));
+        if jac != self.jac_structure || hess != self.hess_structure {
+            return false;
+        }
+
+        self.params = crate::tape::params_snapshot(&arena);
+        self.objective = objective;
+        self.constraints = constraints;
+        self.rebuild_quad_scatter();
+        true
+    }
+
+    /// Recompute the cached quadratic-Hessian scatter positions from the current
+    /// slots against `hess_structure`. Called after any reclassification.
+    fn rebuild_quad_scatter(&mut self) {
+        self.obj_hess_pos = quad_scatter_positions(&self.objective, &self.hess_structure);
+        self.con_hess_pos = self
+            .constraints
+            .iter()
+            .map(|s| quad_scatter_positions(s, &self.hess_structure))
+            .collect();
+    }
+
+    pub fn num_variables(&self) -> usize {
+        self.n_vars
+    }
+
+    pub fn num_constraints(&self) -> usize {
+        self.constraints.len()
+    }
+
+    /// Number of Hessian-vector products performed per
+    /// [`Self::eval_hessian_lagrangian`] call (compressed seed count).
+    pub fn num_hessian_seeds(&self) -> usize {
+        self.seeds.len()
+    }
+
+    /// Objective value at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len()` differs from [`Self::num_variables`].
+    pub fn eval_objective(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.n_vars, "point dimension");
+        let scratch = &mut *self.scratch.borrow_mut();
+        slot_value(&self.objective, x, &self.params, &mut scratch.regs)
+    }
+
+    /// Dense objective gradient at `x` into `grad` (overwritten).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x` or `grad` have the wrong length.
+    pub fn eval_objective_gradient(&self, x: &[f64], grad: &mut [f64]) {
+        assert_eq!(x.len(), self.n_vars, "point dimension");
+        assert_eq!(grad.len(), self.n_vars, "gradient dimension");
+        let scratch = &mut *self.scratch.borrow_mut();
+        grad.fill(0.0);
+        slot_gradient_into(
+            &self.objective,
+            x,
+            &self.params,
+            &mut scratch.regs,
+            &mut scratch.dregs,
+            grad,
+        );
+    }
+
+    /// Constraint LHS values at `x` into `g` (overwritten), in declaration
+    /// order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x` or `g` have the wrong length.
+    pub fn eval_constraint(&self, x: &[f64], g: &mut [f64]) {
+        assert_eq!(x.len(), self.n_vars, "point dimension");
+        assert_eq!(g.len(), self.constraints.len(), "constraint dimension");
+        if self.constraints.len() < PAR_CONSTRAINT_THRESHOLD {
+            self.eval_constraint_serial(x, g);
+        } else {
+            self.eval_constraint_parallel(x, g);
+        }
+    }
+
+    /// Serial constraint values.
+    fn eval_constraint_serial(&self, x: &[f64], g: &mut [f64]) {
+        let scratch = &mut *self.scratch.borrow_mut();
+        for (out, slot) in g.iter_mut().zip(&self.constraints) {
+            *out = slot_value(slot, x, &self.params, &mut scratch.regs);
+        }
+    }
+
+    /// Parallel constraint values.
+    fn eval_constraint_parallel(&self, x: &[f64], g: &mut [f64]) {
+        let (params, max_regs) = (self.params.as_slice(), self.max_regs);
+        let values: Vec<f64> = self
+            .constraints
+            .par_iter()
+            .map_init(|| vec![0.0; max_regs], |regs, slot| slot_value(slot, x, params, regs))
+            .collect();
+        g.copy_from_slice(&values);
+    }
+
+    /// `(constraint, variable)` Jacobian pattern, row-major.
+    /// Rows are sorted by variable.
+    pub fn jacobian_structure(&self) -> &[(usize, usize)] {
+        &self.jac_structure
+    }
+
+    /// Jacobian values at `x` into `vals`, aligned with
+    /// [`Self::jacobian_structure`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x` or `vals` have the wrong length.
+    pub fn eval_constraint_jacobian(&self, x: &[f64], vals: &mut [f64]) {
+        assert_eq!(x.len(), self.n_vars, "point dimension");
+        assert_eq!(vals.len(), self.jac_structure.len(), "jacobian nnz");
+        if self.constraints.len() < PAR_CONSTRAINT_THRESHOLD {
+            self.eval_constraint_jacobian_serial(x, vals);
+        } else {
+            self.eval_constraint_jacobian_parallel(x, vals);
+        }
+    }
+
+    /// Serial Jacobian.
+    fn eval_constraint_jacobian_serial(&self, x: &[f64], vals: &mut [f64]) {
+        let scratch = &mut *self.scratch.borrow_mut();
+        let mut out = 0;
+        for slot in &self.constraints {
+            // Linear/Quadratic add into grad, so pre-zero just their support.
+            // Nonlinear's tape_gradient overwrites the whole buffer.
+            for &v in &slot.support {
+                scratch.grad[v as usize] = 0.0;
+            }
+            slot_gradient_into(
+                slot,
+                x,
+                &self.params,
+                &mut scratch.regs,
+                &mut scratch.dregs,
+                &mut scratch.grad,
+            );
+            for &v in &slot.support {
+                vals[out] = scratch.grad[v as usize];
+                out += 1;
+            }
+        }
+        debug_assert_eq!(out, vals.len());
+    }
+
+    // TODO: Can we write disjoint slices of `vals` from worker threads if we
+    // add unsafe?
+
+    /// Parallel Jacobian
+    /// Each row's gradient is independent. Compute each into a er-thread
+    /// scratch, collect the support values, then concatenate in row order.
+    fn eval_constraint_jacobian_parallel(&self, x: &[f64], vals: &mut [f64]) {
+        let (params, max_regs, n_vars) = (self.params.as_slice(), self.max_regs, self.n_vars);
+        let rows: Vec<Vec<f64>> = self
+            .constraints
+            .par_iter()
+            .map_init(
+                || ParScratch::new(max_regs, n_vars),
+                |sc, slot| {
+                    for &v in &slot.support {
+                        sc.grad[v as usize] = 0.0;
+                    }
+                    slot_gradient_into(slot, x, params, &mut sc.regs, &mut sc.dregs, &mut sc.grad);
+                    slot.support.iter().map(|&v| sc.grad[v as usize]).collect()
+                },
+            )
+            .collect();
+        let mut out = 0;
+        for row in &rows {
+            vals[out..out + row.len()].copy_from_slice(row);
+            out += row.len();
+        }
+        debug_assert_eq!(out, vals.len());
+    }
+
+    /// Lower-triangle (`row >= col`) Hessian-of-the-Lagrangian pattern,
+    /// sorted and deduplicated.
+    pub fn hessian_lagrangian_structure(&self) -> &[(usize, usize)] {
+        &self.hess_structure
+    }
+
+    /// Hessian of `obj_factor * f + sum(lambda[i] * g_i)` at `x` into `vals`,
+    /// aligned with [`Self::hessian_lagrangian_structure`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x`, `lambda`, or `vals` have the wrong length.
+    pub fn eval_hessian_lagrangian(
+        &self,
+        x: &[f64],
+        obj_factor: f64,
+        lambda: &[f64],
+        vals: &mut [f64],
+    ) {
+        assert_eq!(x.len(), self.n_vars, "point dimension");
+        assert_eq!(lambda.len(), self.constraints.len(), "multiplier dimension");
+        assert_eq!(vals.len(), self.hess_structure.len(), "hessian nnz");
+        vals.fill(0.0);
+
+        // Constant quadratic contributions, scaled by sigma/lambda. The
+        // scatter positions are cached (see `obj_hess_pos`/`con_hess_pos`), so
+        // this reads `h` live but does no per-call binary search.
+        if let SlotKind::Quadratic(q) = &self.objective.kind {
+            for (&pos, &(_, _, h)) in self.obj_hess_pos.iter().zip(&q.hessian) {
+                vals[pos] += obj_factor * h;
+            }
+        }
+        for ((slot, positions), &mult) in
+            self.constraints.iter().zip(&self.con_hess_pos).zip(lambda)
+        {
+            if let SlotKind::Quadratic(q) = &slot.kind {
+                for (&pos, &(_, _, h)) in positions.iter().zip(&q.hessian) {
+                    vals[pos] += mult * h;
+                }
+            }
+        }
+
+        if self.seeds.is_empty() {
+            return;
+        }
+
+        if self.seeds.len() < PAR_SEED_THRESHOLD {
+            self.hessian_seeds_serial(x, obj_factor, lambda, vals);
+        } else {
+            self.hessian_seeds_parallel(x, obj_factor, lambda, vals);
+        }
+    }
+
+    /// Serial nonlinear Hessian contributions.
+    /// One HVP per seed on the shared scratch, each result
+    /// scattered (added) into `vals`, which must already
+    /// hold the closed-form quadratic contributions.
+    fn hessian_seeds_serial(&self, x: &[f64], obj_factor: f64, lambda: &[f64], vals: &mut [f64]) {
+        let scratch = &mut *self.scratch.borrow_mut();
+        for (k, source) in self.nl_sources.iter().enumerate() {
+            scratch.mults[k] = mult_of(source, obj_factor, lambda);
+        }
+        for seed in &self.seeds {
+            scratch.dir.fill(0.0);
+            for &col in &seed.cols {
+                scratch.dir[col] = 1.0;
+            }
+            tape_hvp(
+                &self.lagrangian,
+                x,
+                &scratch.dir,
+                &self.params,
+                &scratch.mults,
+                &mut scratch.regs,
+                &mut scratch.regs_t,
+                &mut scratch.dregs,
+                &mut scratch.dregs_t,
+                &mut scratch.grad,
+                &mut scratch.hv,
+            );
+            for &(pos, row) in &seed.fills {
+                vals[pos] += scratch.hv[row];
+            }
+        }
+    }
+
+    /// Parallel nonlinear Hessian contributions.
+    /// Each seed is an independent forward-over-reverse HVP over the whole
+    /// Lagrangian tape, and seeds fill disjoint `vals` positions.
+    /// Run them on the pool with per-thread scratch, returning each seed's
+    /// `(pos, value)` contributions, then apply serially.
+    /// `vals` must already hold the closed-form quadratic contributions.
+    fn hessian_seeds_parallel(&self, x: &[f64], obj_factor: f64, lambda: &[f64], vals: &mut [f64]) {
+        let mults: Vec<f64> =
+            self.nl_sources.iter().map(|s| mult_of(s, obj_factor, lambda)).collect();
+        let (lagrangian, params) = (&self.lagrangian, self.params.as_slice());
+        let (max_regs, n_vars) = (self.max_regs, self.n_vars);
+        let contributions: Vec<Vec<(usize, f64)>> = self
+            .seeds
+            .par_iter()
+            .map_init(
+                || ParScratch::new(max_regs, n_vars),
+                |sc, seed| {
+                    sc.dir.fill(0.0);
+                    for &col in &seed.cols {
+                        sc.dir[col] = 1.0;
+                    }
+                    tape_hvp(
+                        lagrangian,
+                        x,
+                        &sc.dir,
+                        params,
+                        &mults,
+                        &mut sc.regs,
+                        &mut sc.regs_t,
+                        &mut sc.dregs,
+                        &mut sc.dregs_t,
+                        &mut sc.grad,
+                        &mut sc.hv,
+                    );
+                    seed.fills.iter().map(|&(pos, row)| (pos, sc.hv[row])).collect()
+                },
+            )
+            .collect();
+        for contribution in &contributions {
+            for &(pos, v) in contribution {
+                vals[pos] += v;
+            }
+        }
+    }
+}
+
+/// Value of `slot` at `x`. Nonlinear slots use `regs` as tape scratch, the
+/// closed-form kinds ignore it.
+fn slot_value(slot: &FunctionSlot, x: &[f64], params: &[f64], regs: &mut [f64]) -> f64 {
+    match &slot.kind {
+        SlotKind::Linear(t) => linear_value(t, x),
+        SlotKind::Quadratic(q) => quadratic_value(q, x),
+        SlotKind::Nonlinear(tape) => tape.value(x, params, &[], regs),
+    }
+}
+
+/// Write `slot`'s dense gradient at `x` into `grad`. Linear/Quadratic add
+/// into `grad`.
+/// Nonlinear overwrites the full dense buffer via `tape_gradient`.
+/// `regs`/`dregs` are the tape scratch, passed as separate slices to
+/// keep the caller's disjoint borrows of a `Scratch`/`ParScratch` valid.
+fn slot_gradient_into(
+    slot: &FunctionSlot,
+    x: &[f64],
+    params: &[f64],
+    regs: &mut [f64],
+    dregs: &mut [f64],
+    grad: &mut [f64],
+) {
+    match &slot.kind {
+        SlotKind::Linear(t) => linear_gradient_add(t, 1.0, grad),
+        SlotKind::Quadratic(q) => quadratic_gradient_add(q, x, 1.0, grad),
+        SlotKind::Nonlinear(tape) => {
+            tape_gradient(tape, x, params, &[], regs, dregs, grad);
+        }
+    }
+}
+
+/// Weight of a Lagrangian multiplier slot.
+fn mult_of(source: &NlSource, obj_factor: f64, lambda: &[f64]) -> f64 {
+    match source {
+        NlSource::Objective => obj_factor,
+        NlSource::Constraint(i) => lambda[*i],
+    }
+}
+
+/// Position in `hess` of each entry of `slot`'s quadratic Hessian, in
+/// `QuadraticTerms::hessian` order, so `eval_hessian_lagrangian` can scatter the
+/// constant quadratic terms without a per-call binary search. Empty for
+/// non-quadratic slots.
+fn quad_scatter_positions(slot: &FunctionSlot, hess: &[(usize, usize)]) -> Vec<usize> {
+    match &slot.kind {
+        SlotKind::Quadratic(q) => q
+            .hessian
+            .iter()
+            .map(|&(r, c, _)| {
+                hess.binary_search(&(r.index(), c.index()))
+                    .expect("quadratic entry is in the pattern by construction")
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Compressed HVP seeds over the exact non-linear pattern only.
+/// The quadratic entries in `hess_structure` are filled in
+/// closed form and must neither constrain the grouping nor
+/// receive `hv` values.
+fn build_seeds(
+    objective: &FunctionSlot,
+    constraints: &[FunctionSlot],
+    hess_structure: &[(usize, usize)],
+) -> Vec<Seed> {
+    let mut nl_pattern: Vec<(usize, usize)> = std::iter::once(objective)
+        .chain(constraints)
+        .filter(|s| s.is_nonlinear())
+        .flat_map(|s| s.hess_pairs.iter().map(|&(r, c)| (r as usize, c as usize)))
+        .collect();
+    nl_pattern.sort_unstable();
+    nl_pattern.dedup();
+
+    // Star-color the nonlinear pattern.
+    let coloring = star_hessian_coloring(&nl_pattern);
+    let mut seeds: Vec<Seed> =
+        coloring.groups.into_iter().map(|cols| Seed { cols, fills: Vec::new() }).collect();
+    for (&(row, col), &(group, hv_row)) in nl_pattern.iter().zip(&coloring.recover) {
+        let pos = hess_structure
+            .binary_search(&(row, col))
+            .expect("nonlinear entry is in the merged pattern by construction");
+        seeds[group].fills.push((pos, hv_row));
+    }
+    seeds
+}
+
+#[cfg(test)]
+mod tests {
+    //! Serial vs parallel equivalence of the threshold-gated derivative paths.
+    //!
+    //! `eval_constraint`, `eval_constraint_jacobian`, and `eval_hessian_lagrangian`
+    //! each pick a serial or parallel implementation by problem size. These tests
+    //! call both implementations directly and assert they agree bit-for-bit.
+    use super::*;
+    use oximo_core::Model;
+    use oximo_core::prelude::*;
+
+    fn mixed_model() -> Model {
+        let m = Model::new("equiv");
+        variable!(m, -3.0 <= x <= 3.0);
+        variable!(m, -3.0 <= y <= 3.0);
+        variable!(m, -3.0 <= z <= 3.0);
+        objective!(m, Min, x.sin() * y + z.powi(3) + x * z);
+        constraint!(m, cq, x.powi(2) + y.powi(2) <= 10.0);
+        constraint!(m, cn, x * y.exp() + z.sin() <= 5.0);
+        constraint!(m, cl, 2.0 * x + 3.0 * z <= 7.0);
+        m
+    }
+
+    const POINT: [f64; 3] = [0.7, -1.1, 0.4];
+
+    #[test]
+    fn constraint_values_serial_and_parallel_agree() {
+        let ev = NlpEvaluator::new(&mixed_model()).unwrap();
+        let mut serial = vec![0.0; ev.num_constraints()];
+        let mut parallel = vec![0.0; ev.num_constraints()];
+        ev.eval_constraint_serial(&POINT, &mut serial);
+        ev.eval_constraint_parallel(&POINT, &mut parallel);
+        assert_eq!(serial, parallel);
+    }
+
+    #[test]
+    fn constraint_jacobian_serial_and_parallel_agree() {
+        let ev = NlpEvaluator::new(&mixed_model()).unwrap();
+        let nnz = ev.jacobian_structure().len();
+        let mut serial = vec![0.0; nnz];
+        let mut parallel = vec![0.0; nnz];
+        ev.eval_constraint_jacobian_serial(&POINT, &mut serial);
+        ev.eval_constraint_jacobian_parallel(&POINT, &mut parallel);
+        assert_eq!(serial, parallel);
+    }
+
+    #[test]
+    fn hessian_seeds_serial_and_parallel_agree() {
+        let ev = NlpEvaluator::new(&mixed_model()).unwrap();
+        let sigma = 0.9;
+        let lambda = [1.2, -0.7, 0.3];
+        let nnz = ev.hessian_lagrangian_structure().len();
+        let mut serial = vec![0.0; nnz];
+        let mut parallel = vec![0.0; nnz];
+        ev.hessian_seeds_serial(&POINT, sigma, &lambda, &mut serial);
+        ev.hessian_seeds_parallel(&POINT, sigma, &lambda, &mut parallel);
+        assert_eq!(serial, parallel);
+    }
+}

--- a/crates/oximo-autodiff/src/lib.rs
+++ b/crates/oximo-autodiff/src/lib.rs
@@ -1,0 +1,24 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "enzyme", feature(autodiff))]
+#![forbid(unsafe_code)]
+
+mod error;
+pub mod slot;
+pub mod sparsity;
+pub mod tape;
+
+#[cfg(feature = "enzyme")]
+mod enzyme;
+#[cfg(feature = "enzyme")]
+mod evaluator;
+#[cfg(feature = "enzyme")]
+mod linearize;
+
+pub use error::AutodiffError;
+pub use slot::{FunctionSlot, SlotKind};
+pub use tape::Tape;
+
+#[cfg(feature = "enzyme")]
+pub use evaluator::NlpEvaluator;
+#[cfg(feature = "enzyme")]
+pub use linearize::gradient_at;

--- a/crates/oximo-autodiff/src/linearize.rs
+++ b/crates/oximo-autodiff/src/linearize.rs
@@ -1,0 +1,35 @@
+//! Gradient values at a point, evaluated with reverse-mode autodiff.
+
+use oximo_core::Model;
+use oximo_expr::Expr;
+
+use crate::enzyme::tape_gradient;
+use crate::error::AutodiffError;
+use crate::tape::Tape;
+
+/// Dense gradient of `expr` (an expression on `model`'s arena) at `x`,
+/// indexed by variable.
+///
+/// # Errors
+///
+/// Returns [`AutodiffError::DimensionMismatch`] if `x.len()` differs from the
+/// model's variable count.
+pub fn gradient_at(model: &Model, expr: Expr<'_>, x: &[f64]) -> Result<Vec<f64>, AutodiffError> {
+    let n = model.variables().len();
+    if x.len() != n {
+        return Err(AutodiffError::DimensionMismatch { expected: n, got: x.len() });
+    }
+    let (tape, params) = compile(expr);
+    let mut regs = vec![0.0; tape.n_regs()];
+    let mut dregs = vec![0.0; tape.n_regs()];
+    let mut grad = vec![0.0; n];
+    tape_gradient(&tape, x, &params, &[], &mut regs, &mut dregs, &mut grad);
+    Ok(grad)
+}
+
+fn compile(expr: Expr<'_>) -> (Tape, Vec<f64>) {
+    let arena = expr.arena.borrow();
+    let tape = Tape::compile(&arena, expr.id);
+    let params = crate::tape::params_snapshot(&arena);
+    (tape, params)
+}

--- a/crates/oximo-autodiff/src/slot.rs
+++ b/crates/oximo-autodiff/src/slot.rs
@@ -1,0 +1,157 @@
+//! Per-function classification.
+
+use oximo_expr::{
+    ExprArena, ExprId, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,
+};
+
+use crate::sparsity::{hessian_pattern, variable_support};
+use crate::tape::Tape;
+
+/// One objective or constraint function, classified for derivative purposes.
+#[derive(Clone, Debug)]
+pub struct FunctionSlot {
+    pub kind: SlotKind,
+    /// Sorted, deduplicated indices of the variables this function touches.
+    pub support: Vec<u32>,
+    /// Exact structural lower-triangle Hessian pattern. Populated only for
+    /// `Nonlinear` slots.
+    pub hess_pairs: Vec<(u32, u32)>,
+}
+
+#[derive(Clone, Debug)]
+pub enum SlotKind {
+    /// Affine: constant gradient, zero Hessian.
+    Linear(LinearTerms),
+    /// Degree-2 polynomial: affine gradient `Qx + c`, constant Hessian.
+    /// `QuadraticTerms.hessian` follows the `0.5 x'Qx` convention
+    Quadratic(QuadraticTerms),
+    /// Everything else: evaluated and differentiated through the tape
+    /// interpreter.
+    Nonlinear(Tape),
+}
+
+impl FunctionSlot {
+    /// The constant-zero function.
+    /// A `Linear` slot with no terms, so it has no support,
+    /// a zero gradient, and no Hessian.
+    /// Used for a feasibility problem's absent objective.
+    pub fn zero() -> Self {
+        Self {
+            kind: SlotKind::Linear(LinearTerms { coeffs: Vec::new(), constant: 0.0 }),
+            support: Vec::new(),
+            hess_pairs: Vec::new(),
+        }
+    }
+
+    /// Classify the expression rooted at `root`.
+    ///
+    /// `extract_linear`/`extract_quadratic` fold parameters to
+    /// their current values, so linear and quadratic slots must be
+    /// re-classified after `set_param`.
+    pub fn classify(arena: &ExprArena, root: ExprId) -> Self {
+        Self::closed_form(arena, root).unwrap_or_else(|| {
+            let tape = Tape::compile(arena, root);
+            let support = variable_support(arena, root);
+            let hess_pairs = hessian_pattern(arena, root);
+            Self { kind: SlotKind::Nonlinear(tape), support, hess_pairs }
+        })
+    }
+
+    /// The linear/quadratic closed-form classification, or `None` when the
+    /// expression is nonlinear. Both `classify` and `reclassify` share this so
+    /// the extraction-and-support logic lives in one place, the two differ only
+    /// in their nonlinear fallback.
+    fn closed_form(arena: &ExprArena, root: ExprId) -> Option<Self> {
+        if let Some(linear) = extract_linear(arena, root) {
+            let support = sorted_dedup(linear.coeffs.iter().map(|(v, _)| v.0));
+            return Some(Self { kind: SlotKind::Linear(linear), support, hess_pairs: Vec::new() });
+        }
+        if let Some(quadratic) = extract_quadratic(arena, root) {
+            let support = sorted_dedup(
+                quadratic
+                    .linear
+                    .iter()
+                    .map(|(v, _)| v.0)
+                    .chain(quadratic.hessian.iter().flat_map(|&(r, c, _)| [r.0, c.0])),
+            );
+            return Some(Self {
+                kind: SlotKind::Quadratic(quadratic),
+                support,
+                hess_pairs: Vec::new(),
+            });
+        }
+        None
+    }
+
+    pub fn is_nonlinear(&self) -> bool {
+        matches!(self.kind, SlotKind::Nonlinear(_))
+    }
+
+    /// Re-classify `root` at the current parameter values, reusing `self`'s
+    /// compiled tape (and its support/Hessian pattern) when the function is
+    /// still nonlinear.
+    /// A nonlinear tape is parameter-independent, so it never needs recompiling.
+    /// Linear/quadratic functions are re-extracted because their coefficients
+    /// can move with parameters.
+    ///
+    /// Used by `NlpEvaluator::refresh_params` (behind the `enzyme` feature) to
+    /// update a resident evaluator after `set_param` without retaping.
+    pub fn reclassify(&self, arena: &ExprArena, root: ExprId) -> Self {
+        Self::closed_form(arena, root).unwrap_or_else(|| {
+            // Still nonlinear, reuse the existing tape/pattern when we have one,
+            // otherwise fall back to a full classify.
+            match self.kind {
+                SlotKind::Nonlinear(_) => self.clone(),
+                _ => Self::classify(arena, root),
+            }
+        })
+    }
+}
+
+/// Collect variable indices into a sorted, deduplicated support vector.
+fn sorted_dedup(vars: impl Iterator<Item = u32>) -> Vec<u32> {
+    let mut support: Vec<u32> = vars.collect();
+    support.sort_unstable();
+    support.dedup();
+    support
+}
+
+/// `t.constant + t.coeffs * x`
+pub fn linear_value(t: &LinearTerms, x: &[f64]) -> f64 {
+    t.coeffs.iter().fold(t.constant, |acc, &(v, c)| acc + c * x[v.index()])
+}
+
+/// Add the (constant) gradient of `t` into `grad`, scaled by `scale`.
+pub fn linear_gradient_add(t: &LinearTerms, scale: f64, grad: &mut [f64]) {
+    for &(v, c) in &t.coeffs {
+        grad[v.index()] += scale * c;
+    }
+}
+
+/// Value of the quadratic at `x`: `constant + linear * x + 0.5 x' Q x`.
+pub fn quadratic_value(q: &QuadraticTerms, x: &[f64]) -> f64 {
+    let mut acc = q.constant;
+    for &(v, c) in &q.linear {
+        acc += c * x[v.index()];
+    }
+    for &(r, c, h) in &q.hessian {
+        let term = h * x[r.index()] * x[c.index()];
+        acc += if r == c { 0.5 * term } else { term };
+    }
+    acc
+}
+
+/// Add the gradient of the quadratic at `x` into `grad`, scaled by `scale`.
+pub fn quadratic_gradient_add(q: &QuadraticTerms, x: &[f64], scale: f64, grad: &mut [f64]) {
+    for &(v, c) in &q.linear {
+        grad[v.index()] += scale * c;
+    }
+    for &(r, c, h) in &q.hessian {
+        if r == c {
+            grad[r.index()] += scale * h * x[r.index()];
+        } else {
+            grad[r.index()] += scale * h * x[c.index()];
+            grad[c.index()] += scale * h * x[r.index()];
+        }
+    }
+}

--- a/crates/oximo-autodiff/src/sparsity.rs
+++ b/crates/oximo-autodiff/src/sparsity.rs
@@ -131,14 +131,12 @@ fn compute_node_sparsity(
         }
         // a/b = a * (1/b), and 1/b is nonlinear in all of b's variables.
         ExprNode::Div(num, den) => {
-            let n = node_sparsity(arena, *num, memo).clone();
+            let mut acc = node_sparsity(arena, *num, memo).clone();
             let d = node_sparsity(arena, *den, memo);
-            let mut acc = NodeSparsity {
-                vars: n.vars.union(&d.vars).copied().collect(),
-                pairs: n.pairs.union(&d.pairs).copied().collect(),
-            };
+            acc.pairs.extend(d.pairs.iter().copied());
             add_clique(&d.vars, &mut acc.pairs);
-            add_cross(&n.vars, &d.vars, &mut acc.pairs);
+            add_cross(&acc.vars, &d.vars, &mut acc.pairs);
+            acc.vars.extend(d.vars.iter().copied());
             acc
         }
         // phi(g) for smooth nonlinear phi: phi''*g_i'g_j' + phi'·g''_ij.
@@ -159,12 +157,10 @@ fn compute_node_sparsity(
             } else {
                 // g^e = exp(e*ln g): the first-derivative products alone fill
                 // the clique over vars(g) U vars(e).
-                let b = node_sparsity(arena, *base, memo).clone();
+                let mut acc = node_sparsity(arena, *base, memo).clone();
                 let e = node_sparsity(arena, *exp, memo);
-                let mut acc = NodeSparsity {
-                    vars: b.vars.union(&e.vars).copied().collect(),
-                    pairs: b.pairs.union(&e.pairs).copied().collect(),
-                };
+                acc.vars.extend(e.vars.iter().copied());
+                acc.pairs.extend(e.pairs.iter().copied());
                 add_clique(&acc.vars, &mut acc.pairs);
                 acc
             }

--- a/crates/oximo-autodiff/src/sparsity.rs
+++ b/crates/oximo-autodiff/src/sparsity.rs
@@ -1,0 +1,384 @@
+//! Structural sparsity analysis: which variables an expression touches, the
+//! exact second-order interaction pattern, and the Jacobian/Hessian
+//! patterns derivative-based solvers ask for up front.
+
+use oximo_expr::{ExprArena, ExprId, ExprNode, Visitor, walk};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::slot::{FunctionSlot, SlotKind};
+
+/// Sorted, deduplicated indices of the variables appearing under `root`.
+pub fn variable_support(arena: &ExprArena, root: ExprId) -> Vec<u32> {
+    struct Support(FxHashSet<u32>);
+    impl Visitor for Support {
+        fn visit(&mut self, _arena: &ExprArena, _id: ExprId, node: &ExprNode) {
+            match node {
+                ExprNode::Var(v) => {
+                    self.0.insert(v.0);
+                }
+                ExprNode::Linear { coeffs, .. } => {
+                    self.0.extend(coeffs.iter().map(|(v, _)| v.0));
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut visitor = Support(FxHashSet::default());
+    walk(arena, root, &mut visitor);
+    let mut support: Vec<u32> = visitor.0.into_iter().collect();
+    support.sort_unstable();
+    support
+}
+
+/// Per-node first/second-order structural sparsity.
+/// `vars` is the gradient support, `pairs` the normalized
+/// lower-triangle second-partial support.
+#[derive(Clone, Debug, Default)]
+struct NodeSparsity {
+    vars: FxHashSet<u32>,
+    pairs: FxHashSet<(u32, u32)>,
+}
+
+fn norm(i: u32, j: u32) -> (u32, u32) {
+    if i >= j { (i, j) } else { (j, i) }
+}
+
+fn add_clique(vars: &FxHashSet<u32>, pairs: &mut FxHashSet<(u32, u32)>) {
+    for &i in vars {
+        for &j in vars {
+            if i >= j {
+                pairs.insert((i, j));
+            }
+        }
+    }
+}
+
+fn add_cross(a: &FxHashSet<u32>, b: &FxHashSet<u32>, pairs: &mut FxHashSet<(u32, u32)>) {
+    for &i in a {
+        for &j in b {
+            pairs.insert(norm(i, j));
+        }
+    }
+}
+
+/// Exact structural lower-triangle Hessian pattern of the expression rooted
+/// at `root`. Normalized `(row, col)` index pairs with `row >= col`, sorted
+/// and deduplicated.
+///
+/// "Exact structural" means a superset of the numerically nonzero second
+/// partials that ignores value cancellation. Parameters stay symbolic, so the
+/// pattern is independent of current parameter values.
+/// `Abs` contributes only its argument's pattern.
+pub fn hessian_pattern(arena: &ExprArena, root: ExprId) -> Vec<(u32, u32)> {
+    let mut memo: FxHashMap<ExprId, NodeSparsity> = FxHashMap::default();
+    let result = node_sparsity(arena, root, &mut memo);
+    let mut pattern: Vec<(u32, u32)> = result.pairs.iter().copied().collect();
+    pattern.sort_unstable();
+    pattern
+}
+
+fn node_sparsity<'m>(
+    arena: &ExprArena,
+    id: ExprId,
+    memo: &'m mut FxHashMap<ExprId, NodeSparsity>,
+) -> &'m NodeSparsity {
+    if !memo.contains_key(&id) {
+        let computed = compute_node_sparsity(arena, id, memo);
+        memo.insert(id, computed);
+    }
+    &memo[&id]
+}
+
+// Exact 0.0/1.0 exponent bucketing matches the semantics of `classify` and
+// the tape's PowC lowering.
+#[allow(clippy::float_cmp)]
+fn compute_node_sparsity(
+    arena: &ExprArena,
+    id: ExprId,
+    memo: &mut FxHashMap<ExprId, NodeSparsity>,
+) -> NodeSparsity {
+    match arena.get(id) {
+        ExprNode::Const(_) | ExprNode::Param(_) => NodeSparsity::default(),
+        ExprNode::Var(v) => {
+            NodeSparsity { vars: std::iter::once(v.0).collect(), pairs: FxHashSet::default() }
+        }
+        ExprNode::Linear { coeffs, .. } => NodeSparsity {
+            vars: coeffs.iter().map(|(v, _)| v.0).collect(),
+            pairs: FxHashSet::default(),
+        },
+        ExprNode::Neg(inner) | ExprNode::Abs(inner) => node_sparsity(arena, *inner, memo).clone(),
+        ExprNode::Add(children) => {
+            let mut acc = NodeSparsity::default();
+            for &c in children {
+                let s = node_sparsity(arena, c, memo);
+                acc.vars.extend(s.vars.iter().copied());
+                acc.pairs.extend(s.pairs.iter().copied());
+            }
+            acc
+        }
+        // Pairwise left fold is exactly the n-ary rule, at each step the
+        // accumulated vars are the union of earlier factors, so the cross
+        // products cover every distinct factor pair.
+        ExprNode::Mul(children) => {
+            let mut acc = NodeSparsity::default();
+            for &c in children {
+                let s = node_sparsity(arena, c, memo);
+                add_cross(&acc.vars, &s.vars, &mut acc.pairs);
+                acc.vars.extend(s.vars.iter().copied());
+                acc.pairs.extend(s.pairs.iter().copied());
+            }
+            acc
+        }
+        // a/b = a * (1/b), and 1/b is nonlinear in all of b's variables.
+        ExprNode::Div(num, den) => {
+            let n = node_sparsity(arena, *num, memo).clone();
+            let d = node_sparsity(arena, *den, memo);
+            let mut acc = NodeSparsity {
+                vars: n.vars.union(&d.vars).copied().collect(),
+                pairs: n.pairs.union(&d.pairs).copied().collect(),
+            };
+            add_clique(&d.vars, &mut acc.pairs);
+            add_cross(&n.vars, &d.vars, &mut acc.pairs);
+            acc
+        }
+        // phi(g) for smooth nonlinear phi: phi''*g_i'g_j' + phi'·g''_ij.
+        ExprNode::Sin(inner)
+        | ExprNode::Cos(inner)
+        | ExprNode::Exp(inner)
+        | ExprNode::Log(inner) => smooth_unary(arena, *inner, memo),
+        ExprNode::Pow(base, exp) => {
+            // Constant-exponent detection mirrors the tape's PowC check.
+            if let ExprNode::Const(e) = arena.get(*exp) {
+                if *e == 0.0 {
+                    NodeSparsity::default()
+                } else if *e == 1.0 {
+                    node_sparsity(arena, *base, memo).clone()
+                } else {
+                    smooth_unary(arena, *base, memo)
+                }
+            } else {
+                // g^e = exp(e*ln g): the first-derivative products alone fill
+                // the clique over vars(g) U vars(e).
+                let b = node_sparsity(arena, *base, memo).clone();
+                let e = node_sparsity(arena, *exp, memo);
+                let mut acc = NodeSparsity {
+                    vars: b.vars.union(&e.vars).copied().collect(),
+                    pairs: b.pairs.union(&e.pairs).copied().collect(),
+                };
+                add_clique(&acc.vars, &mut acc.pairs);
+                acc
+            }
+        }
+    }
+}
+
+fn smooth_unary(
+    arena: &ExprArena,
+    inner: ExprId,
+    memo: &mut FxHashMap<ExprId, NodeSparsity>,
+) -> NodeSparsity {
+    let mut acc = node_sparsity(arena, inner, memo).clone();
+    add_clique(&acc.vars, &mut acc.pairs);
+    acc
+}
+
+/// Constraint Jacobian pattern as `(constraint, variable)` index pairs in
+/// row-major order. Row `i`'s entries are exactly `slots[i].support`.
+pub fn jacobian_structure(slots: &[FunctionSlot]) -> Vec<(usize, usize)> {
+    let mut entries = Vec::with_capacity(slots.iter().map(|s| s.support.len()).sum());
+    for (row, slot) in slots.iter().enumerate() {
+        entries.extend(slot.support.iter().map(|&v| (row, v as usize)));
+    }
+    entries
+}
+
+/// Lower-triangle Hessian-of-the-Lagrangian pattern (`row >= col`), sorted and
+/// deduplicated, over the objective and all constraints.
+///
+/// Quadratic slots contribute their exact constant-Hessian entries, nonlinear
+/// slots their exact structural pattern (`FunctionSlot::hess_pairs`, computed
+/// by [`hessian_pattern`]).
+pub fn hessian_lagrangian_structure<'a, I>(slots: I) -> Vec<(usize, usize)>
+where
+    I: IntoIterator<Item = &'a FunctionSlot>,
+{
+    let mut entries = FxHashSet::default();
+    for slot in slots {
+        match &slot.kind {
+            SlotKind::Linear(_) => {}
+            SlotKind::Quadratic(q) => {
+                for &(r, c, _) in &q.hessian {
+                    entries.insert((r.index(), c.index()));
+                }
+            }
+            SlotKind::Nonlinear(_) => {
+                entries.extend(slot.hess_pairs.iter().map(|&(r, c)| (r as usize, c as usize)));
+            }
+        }
+    }
+    let mut entries: Vec<(usize, usize)> = entries.into_iter().collect();
+    entries.sort_unstable();
+    entries
+}
+
+/// Direct-recovery coloring of a symmetric Hessian pattern.
+/// One Hessian-vector product per group, then each entry is read
+/// from a single group/row with no linear solve.
+#[derive(Clone, Debug)]
+pub struct HessianColoring {
+    /// Columns seeded together, the caller performs one HVP per group.
+    pub groups: Vec<Vec<usize>>,
+    /// Aligned with the input `pattern`: entry `i` is recovered directly as
+    /// `value = hv_of[group][row]`, where `(group, row) = recover[i]`.
+    pub recover: Vec<(usize, usize)>,
+}
+
+/// Star-coloring compression of a symmetric Hessian `pattern` for direct
+/// recovery from Hessian-vector products.
+///
+/// Builds the adjacency graph of the pattern (vertices=variables, edges=
+/// off-diagonal structural nonzeros), star-colors it, and seeds one HVP per
+/// color class that some entry reads from. Recovery is direct, since a diagonal
+/// `(i, i)` is read from `i`'s own color at row `i` (proper coloring isolates
+/// it); an off-diagonal `(u, w)` is read from whichever endpoint has the other
+/// as its only neighbor of that color falling back to a lone seed of `u`
+/// if neither does, so the returned is exact regardless of coloring quality.
+///
+/// `pattern` is a normalized lower-triangle pattern (`row >= col`).
+pub fn star_hessian_coloring(pattern: &[(usize, usize)]) -> HessianColoring {
+    let mut adj: FxHashMap<usize, FxHashSet<usize>> = FxHashMap::default();
+    for &(r, c) in pattern {
+        adj.entry(r).or_default(); // ensure diagonal-only vertices are colored
+        if r != c {
+            adj.entry(r).or_default().insert(c);
+            adj.entry(c).or_default().insert(r);
+        }
+    }
+
+    let color = greedy_star_coloring(&adj);
+
+    let mut nbr_colors: FxHashMap<usize, FxHashMap<usize, usize>> = FxHashMap::default();
+    for (&v, nbrs) in &adj {
+        let mut counts: FxHashMap<usize, usize> = FxHashMap::default();
+        for &w in nbrs {
+            *counts.entry(color[&w]).or_insert(0) += 1;
+        }
+        nbr_colors.insert(v, counts);
+    }
+
+    // Members of each color class (sorted), materialized into a seed group only
+    // when some entry reads from that class.
+    let mut class: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+    for (&v, &col) in &color {
+        class.entry(col).or_default().push(v);
+    }
+    for members in class.values_mut() {
+        members.sort_unstable();
+    }
+
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    let mut group_of_color: FxHashMap<usize, usize> = FxHashMap::default();
+    let mut singleton_of: FxHashMap<usize, usize> = FxHashMap::default();
+    let mut recover: Vec<(usize, usize)> = Vec::with_capacity(pattern.len());
+
+    let unique = |v: usize, col: usize| nbr_colors[&v].get(&col) == Some(&1);
+
+    for &(r, c) in pattern {
+        let entry = if r == c {
+            (color_group(color[&r], &class, &mut groups, &mut group_of_color), r)
+        } else if unique(r, color[&c]) {
+            // `c` is `r`'s only color[c] neighbor -> seed color[c], read row r.
+            (color_group(color[&c], &class, &mut groups, &mut group_of_color), r)
+        } else if unique(c, color[&r]) {
+            (color_group(color[&r], &class, &mut groups, &mut group_of_color), c)
+        } else {
+            // No clean class read (a non-star edge).
+            (singleton_group(r, &mut groups, &mut singleton_of), c)
+        };
+        recover.push(entry);
+    }
+
+    HessianColoring { groups, recover }
+}
+
+/// Greedy star coloring of `adj`, a proper coloring in which no path on four
+/// vertices is two-colored, so every pair of colors induces a star forest and
+/// the Hessian is directly recoverable.
+fn greedy_star_coloring(adj: &FxHashMap<usize, FxHashSet<usize>>) -> FxHashMap<usize, usize> {
+    let mut order: Vec<usize> = adj.keys().copied().collect();
+    order.sort_unstable_by_key(|&v| (usize::MAX - adj[&v].len(), v));
+
+    let mut color: FxHashMap<usize, usize> = FxHashMap::default();
+    for &v in &order {
+        let nbrs = &adj[&v];
+        // Colored-neighbor color multiplicities, for the internal-P4 rule.
+        let mut nbr_count: FxHashMap<usize, usize> = FxHashMap::default();
+        for &w in nbrs {
+            if let Some(&cw) = color.get(&w) {
+                *nbr_count.entry(cw).or_insert(0) += 1;
+            }
+        }
+        // Proper coloring forbids neighbor colors outright.
+        let mut forbidden: FxHashSet<usize> = nbr_count.keys().copied().collect();
+
+        for &w in nbrs {
+            let Some(&b) = color.get(&w) else { continue };
+            // Endpoint P4  v-w-x-y  colored c,b,c,b: forbid color(x) = c when x has
+            // another b-colored neighbor y != w (assigning c to v closes the P4).
+            for &x in &adj[&w] {
+                if x == v {
+                    continue;
+                }
+                let Some(&cx) = color.get(&x) else { continue };
+                if adj[&x].iter().any(|&y| y != w && color.get(&y) == Some(&b)) {
+                    forbidden.insert(cx);
+                }
+            }
+            // Internal P4  u-v-w-x  colored b,c,b,c: if v already has another
+            // b-colored neighbor (u), forbid color(x) for x adjacent to w.
+            if nbr_count[&b] >= 2 {
+                for &x in &adj[&w] {
+                    if x != v {
+                        if let Some(&cx) = color.get(&x) {
+                            forbidden.insert(cx);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut c = 0;
+        while forbidden.contains(&c) {
+            c += 1;
+        }
+        color.insert(v, c);
+    }
+    color
+}
+
+/// Index of the seed group for color `col`, creating it on first use.
+fn color_group(
+    col: usize,
+    class: &FxHashMap<usize, Vec<usize>>,
+    groups: &mut Vec<Vec<usize>>,
+    group_of_color: &mut FxHashMap<usize, usize>,
+) -> usize {
+    *group_of_color.entry(col).or_insert_with(|| {
+        let idx = groups.len();
+        groups.push(class[&col].clone());
+        idx
+    })
+}
+
+/// Index of a lone-column seed group for `v`, created once per vertex.
+fn singleton_group(
+    v: usize,
+    groups: &mut Vec<Vec<usize>>,
+    singleton_of: &mut FxHashMap<usize, usize>,
+) -> usize {
+    *singleton_of.entry(v).or_insert_with(|| {
+        let idx = groups.len();
+        groups.push(vec![v]);
+        idx
+    })
+}

--- a/crates/oximo-autodiff/src/sparsity.rs
+++ b/crates/oximo-autodiff/src/sparsity.rs
@@ -317,30 +317,12 @@ fn greedy_star_coloring(adj: &FxHashMap<usize, FxHashSet<usize>>) -> FxHashMap<u
         // Proper coloring forbids neighbor colors outright.
         let mut forbidden: FxHashSet<usize> = nbr_count.keys().copied().collect();
 
+        // Each colored neighbor `w` of `v` (with color `b = color[w]`) can close
+        // a two-colored path on four vertices in two distinct ways.
         for &w in nbrs {
             let Some(&b) = color.get(&w) else { continue };
-            // Endpoint P4  v-w-x-y  colored c,b,c,b: forbid color(x) = c when x has
-            // another b-colored neighbor y != w (assigning c to v closes the P4).
-            for &x in &adj[&w] {
-                if x == v {
-                    continue;
-                }
-                let Some(&cx) = color.get(&x) else { continue };
-                if adj[&x].iter().any(|&y| y != w && color.get(&y) == Some(&b)) {
-                    forbidden.insert(cx);
-                }
-            }
-            // Internal P4  u-v-w-x  colored b,c,b,c: if v already has another
-            // b-colored neighbor (u), forbid color(x) for x adjacent to w.
-            if nbr_count[&b] >= 2 {
-                for &x in &adj[&w] {
-                    if x != v {
-                        if let Some(&cx) = color.get(&x) {
-                            forbidden.insert(cx);
-                        }
-                    }
-                }
-            }
+            forbid_endpoint_p4(adj, &color, v, w, b, &mut forbidden);
+            forbid_internal_p4(adj, &color, v, w, nbr_count[&b] >= 2, &mut forbidden);
         }
 
         let mut c = 0;
@@ -350,6 +332,58 @@ fn greedy_star_coloring(adj: &FxHashMap<usize, FxHashSet<usize>>) -> FxHashMap<u
         color.insert(v, c);
     }
     color
+}
+
+/// Endpoint-P4 rule while choosing `v`'s color, for a candidate path
+/// `v - w - x - y` colored `c, b, c, b` (with `b = color[w]`).
+///
+/// For each colored neighbor `x` of `w` (`x != v`): if `x` has some other
+/// `b`-colored neighbor `y != w`, then giving `v` the color `c = color[x]` would
+/// complete the two-colored P4 `v-w-x-y`. Forbid `color[x]`.
+fn forbid_endpoint_p4(
+    adj: &FxHashMap<usize, FxHashSet<usize>>,
+    color: &FxHashMap<usize, usize>,
+    v: usize,
+    w: usize,
+    b: usize,
+    forbidden: &mut FxHashSet<usize>,
+) {
+    for &x in &adj[&w] {
+        if x == v {
+            continue;
+        }
+        let Some(&cx) = color.get(&x) else { continue };
+        if adj[&x].iter().any(|&y| y != w && color.get(&y) == Some(&b)) {
+            forbidden.insert(cx);
+        }
+    }
+}
+
+/// Internal-P4 rule while choosing `v`'s color, for a candidate path
+/// `u - v - w - x` colored `b, c, b, c` (with `b = color[w]`).
+///
+/// Applies only when `v` already has another `b`-colored neighbor `u`. Then
+/// giving `v` the color `c = color[x]` of any colored neighbor `x != v` of `w`
+/// completes the two-colored P4 `u-v-w-x`. Forbid every such `color[x]`.
+fn forbid_internal_p4(
+    adj: &FxHashMap<usize, FxHashSet<usize>>,
+    color: &FxHashMap<usize, usize>,
+    v: usize,
+    w: usize,
+    v_has_another_b_neighbor: bool,
+    forbidden: &mut FxHashSet<usize>,
+) {
+    if !v_has_another_b_neighbor {
+        return;
+    }
+    for &x in &adj[&w] {
+        if x == v {
+            continue;
+        }
+        if let Some(&cx) = color.get(&x) {
+            forbidden.insert(cx);
+        }
+    }
 }
 
 /// Index of the seed group for color `col`, creating it on first use.

--- a/crates/oximo-autodiff/src/sparsity.rs
+++ b/crates/oximo-autodiff/src/sparsity.rs
@@ -44,11 +44,11 @@ fn norm(i: u32, j: u32) -> (u32, u32) {
 }
 
 fn add_clique(vars: &FxHashSet<u32>, pairs: &mut FxHashSet<(u32, u32)>) {
-    for &i in vars {
-        for &j in vars {
-            if i >= j {
-                pairs.insert((i, j));
-            }
+    let mut sorted: Vec<u32> = vars.iter().copied().collect();
+    sorted.sort_unstable();
+    for (i, &row) in sorted.iter().enumerate() {
+        for &col in &sorted[..=i] {
+            pairs.insert((row, col));
         }
     }
 }

--- a/crates/oximo-autodiff/src/tape.rs
+++ b/crates/oximo-autodiff/src/tape.rs
@@ -1,0 +1,338 @@
+//! Flat instruction tapes compiled from [`ExprArena`] subtrees.
+//!
+//! A [`Tape`] is the bridge between oximo's runtime expression data and
+//! `std::autodiff`, which differentiates compiled Rust functions. Every
+//! expression is lowered to instructions executed by the single interpreter
+//! `eval_tape`, and the `enzyme` feature differentiates that interpreter
+//! once at compile time.
+//!
+//! The tape is in SSA form.
+use oximo_expr::{ExprArena, ExprId, ExprNode};
+use rustc_hash::FxHashMap;
+
+// Opcodes. `a`/`b` are operand register indices unless noted.
+pub(crate) const OP_CONST: u32 = 0; // consts[a]
+pub(crate) const OP_VAR: u32 = 1; // x[a]
+pub(crate) const OP_PARAM: u32 = 2; // params[a]
+pub(crate) const OP_MULT: u32 = 3; // mults[a]
+pub(crate) const OP_ADD: u32 = 4;
+pub(crate) const OP_MUL: u32 = 5;
+pub(crate) const OP_DIV: u32 = 6;
+pub(crate) const OP_NEG: u32 = 7;
+pub(crate) const OP_POWC: u32 = 8; // regs[a] ^ consts[b]
+pub(crate) const OP_POW: u32 = 9; // regs[a] ^ regs[b]
+pub(crate) const OP_SIN: u32 = 10;
+pub(crate) const OP_COS: u32 = 11;
+pub(crate) const OP_EXP: u32 = 12;
+pub(crate) const OP_LOG: u32 = 13;
+pub(crate) const OP_ABS: u32 = 14;
+pub(crate) const OP_LINEAR: u32 = 15; // sum of lin_coeffs[a..b] * x[lin_vars[a..b]]
+
+/// An expression (or weighted sum of expressions) compiled to a flat
+/// instruction tape, evaluable at any point without touching the arena.
+///
+/// Parameter and multiplier values are not baked in. [`Tape::value`] takes
+/// them as slices, so `set_param` or new Lagrange multipliers never force a
+/// recompile.
+#[derive(Clone, Debug, Default)]
+pub struct Tape {
+    ops: Vec<u32>,
+    a: Vec<u32>,
+    b: Vec<u32>,
+    consts: Vec<f64>,
+    lin_vars: Vec<u32>,
+    lin_coeffs: Vec<f64>,
+    n_mults: usize,
+}
+
+impl Tape {
+    /// Compile the subtree rooted at `root`.
+    pub fn compile(arena: &ExprArena, root: ExprId) -> Self {
+        let mut builder = Builder::default();
+        let reg = builder.lower(arena, root);
+        builder.finish_root(reg);
+        builder.tape
+    }
+
+    /// Compile `sum_k mults[k] * exprs[k]` with the weights resolved at
+    /// evaluation time. The Lagrangian tape used for Hessian computation.
+    /// Shared subexpressions across the `exprs` are lowered once.
+    pub fn compile_weighted(arena: &ExprArena, exprs: &[ExprId]) -> Self {
+        let mut builder = Builder::default();
+        let mut acc: Option<u32> = None;
+        for (k, &expr) in exprs.iter().enumerate() {
+            let value = builder.lower(arena, expr);
+            let weight = builder.push(OP_MULT, to_u32(k), 0);
+            let term = builder.push(OP_MUL, weight, value);
+            acc = Some(match acc {
+                None => term,
+                Some(prev) => builder.push(OP_ADD, prev, term),
+            });
+        }
+        let root = match acc {
+            Some(reg) => reg,
+            None => builder.push_const(0.0),
+        };
+        builder.finish_root(root);
+        builder.tape.n_mults = exprs.len();
+        builder.tape
+    }
+
+    /// Number of registers the interpreter needs, equal to the instruction
+    /// count. A compiled tape always has at least one instruction (`compile`
+    /// lowers a root, `compile_weighted` emits a `0.0` constant for an empty
+    /// sum), so this is only `0` for a `Tape::default()` that was never
+    /// compiled.
+    pub fn n_regs(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// Number of multiplier slots expected in the `mults` slice.
+    pub fn n_mults(&self) -> usize {
+        self.n_mults
+    }
+
+    /// Evaluate the tape at `x`. `regs` is caller-provided scratch of length
+    /// [`Tape::n_regs`], `mults` must have length [`Tape::n_mults`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `regs` is shorter than [`Tape::n_regs`], or if `mults` is
+    /// shorter than [`Tape::n_mults`] (indexed by `OP_MULT`). Also panics on an
+    /// empty (never-compiled) tape, which has no result register.
+    pub fn value(&self, x: &[f64], params: &[f64], mults: &[f64], regs: &mut [f64]) -> f64 {
+        assert!(regs.len() >= self.n_regs(), "register scratch too short");
+        debug_assert!(!self.ops.is_empty(), "cannot evaluate an empty tape");
+        let mut out = [0.0];
+        eval_tape(
+            &self.ops,
+            &self.a,
+            &self.b,
+            &self.consts,
+            &self.lin_vars,
+            &self.lin_coeffs,
+            x,
+            params,
+            mults,
+            regs,
+            &mut out,
+        );
+        out[0]
+    }
+
+    /// The raw tape slices, in [`eval_tape`] argument order. Used by the
+    /// `enzyme` module to drive the differentiated interpreter.
+    #[cfg_attr(not(feature = "enzyme"), allow(dead_code))]
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn parts(&self) -> (&[u32], &[u32], &[u32], &[f64], &[u32], &[f64]) {
+        (&self.ops, &self.a, &self.b, &self.consts, &self.lin_vars, &self.lin_coeffs)
+    }
+}
+
+/// The tape interpreter, the one function `std::autodiff` differentiates.
+///
+/// Three properties are load-bearing for Enzyme's type analysis:
+/// - every match arm stores into `regs[i]` directly. Collecting arm results
+///   into one value first creates an LLVM `phi` mixing typed and untyped
+///   constants,
+/// - the result leaves through the `out` parameter instead of a return value,
+///   an `Active` return is plumbed through an `enzyme_primal_return` marker
+///   global that breaks forward-over-reverse across crate boundaries,
+/// - `OP_LINEAR` ranges are non-empty (builder invariant) and the accumulator
+///   starts from the first product, not a `0.0` literal, and there is no
+///   `n == 0` fallback (builder emits at least one instruction), both would
+///   store-sink into untyped-`0.0` phis.
+#[allow(clippy::needless_range_loop, clippy::too_many_arguments)]
+#[inline]
+pub(crate) fn eval_tape(
+    ops: &[u32],
+    a: &[u32],
+    b: &[u32],
+    consts: &[f64],
+    lin_vars: &[u32],
+    lin_coeffs: &[f64],
+    x: &[f64],
+    params: &[f64],
+    mults: &[f64],
+    regs: &mut [f64],
+    out: &mut [f64],
+) {
+    let n = ops.len();
+    for i in 0..n {
+        let ai = a[i] as usize;
+        let bi = b[i] as usize;
+        match ops[i] {
+            OP_CONST => regs[i] = consts[ai],
+            OP_VAR => regs[i] = x[ai],
+            OP_PARAM => regs[i] = params[ai],
+            OP_MULT => regs[i] = mults[ai],
+            OP_ADD => regs[i] = regs[ai] + regs[bi],
+            OP_MUL => regs[i] = regs[ai] * regs[bi],
+            OP_DIV => regs[i] = regs[ai] / regs[bi],
+            OP_NEG => regs[i] = -regs[ai],
+            OP_POWC => regs[i] = regs[ai].powf(consts[bi]),
+            OP_POW => regs[i] = regs[ai].powf(regs[bi]),
+            OP_SIN => regs[i] = regs[ai].sin(),
+            OP_COS => regs[i] = regs[ai].cos(),
+            OP_EXP => regs[i] = regs[ai].exp(),
+            OP_LOG => regs[i] = regs[ai].ln(),
+            OP_ABS => regs[i] = regs[ai].abs(),
+            OP_LINEAR => {
+                regs[i] = lin_coeffs[ai] * x[lin_vars[ai] as usize];
+                for k in (ai + 1)..bi {
+                    regs[i] += lin_coeffs[k] * x[lin_vars[k] as usize];
+                }
+            }
+            // Unreachable for a well-formed tape (the builder emits only the
+            // opcodes above).
+            _ => regs[i] = f64::NAN,
+        }
+    }
+    out[0] = regs[n - 1];
+}
+
+fn to_u32(v: usize) -> u32 {
+    u32::try_from(v).expect("index exceeds u32::MAX")
+}
+
+/// Snapshot the arena's current parameter values into a dense vector, the
+/// `params` input of `eval_tape`. Public so value-only consumers can drive [`Tape::value`].
+///
+/// # Panics
+///
+/// Panics if the arena holds more than `u32::MAX` parameters.
+pub fn params_snapshot(arena: &ExprArena) -> Vec<f64> {
+    (0..arena.num_params()).map(|i| arena.param_value(oximo_expr::ParamId(to_u32(i)))).collect()
+}
+
+#[derive(Default)]
+struct Builder {
+    tape: Tape,
+    memo: FxHashMap<ExprId, u32>,
+}
+
+impl Builder {
+    fn push(&mut self, op: u32, a: u32, b: u32) -> u32 {
+        let reg = to_u32(self.tape.ops.len());
+        self.tape.ops.push(op);
+        self.tape.a.push(a);
+        self.tape.b.push(b);
+        reg
+    }
+
+    /// Append a value to the constant pool and return its index, an operand
+    /// for `OP_CONST`/`OP_POWC` (not a register).
+    fn add_const(&mut self, v: f64) -> u32 {
+        let idx = to_u32(self.tape.consts.len());
+        self.tape.consts.push(v);
+        idx
+    }
+
+    fn push_const(&mut self, v: f64) -> u32 {
+        let idx = self.add_const(v);
+        self.push(OP_CONST, idx, 0)
+    }
+
+    // TODO: Can we improve this?
+
+    /// The interpreter returns the last register, so if the root register is
+    /// not last (memo hit on a shared subexpression), append `root * 1.0`.
+    fn finish_root(&mut self, root: u32) {
+        if root as usize != self.tape.ops.len() - 1 {
+            let one = self.push_const(1.0);
+            self.push(OP_MUL, root, one);
+        }
+    }
+
+    fn lower(&mut self, arena: &ExprArena, id: ExprId) -> u32 {
+        if let Some(&reg) = self.memo.get(&id) {
+            return reg;
+        }
+        let reg = match arena.get(id) {
+            ExprNode::Const(c) => self.push_const(*c),
+            ExprNode::Var(v) => self.push(OP_VAR, v.0, 0),
+            ExprNode::Param(p) => self.push(OP_PARAM, p.0, 0),
+            ExprNode::Add(children) => self.lower_nary(arena, children, OP_ADD, 0.0),
+            ExprNode::Mul(children) => self.lower_nary(arena, children, OP_MUL, 1.0),
+            ExprNode::Neg(inner) => {
+                let r = self.lower(arena, *inner);
+                self.push(OP_NEG, r, 0)
+            }
+            ExprNode::Pow(base, exp) => {
+                let base_reg = self.lower(arena, *base);
+                if let ExprNode::Const(e) = arena.get(*exp) {
+                    let idx = self.add_const(*e);
+                    self.push(OP_POWC, base_reg, idx)
+                } else {
+                    let exp_reg = self.lower(arena, *exp);
+                    self.push(OP_POW, base_reg, exp_reg)
+                }
+            }
+            ExprNode::Div(num, den) => {
+                let n = self.lower(arena, *num);
+                let d = self.lower(arena, *den);
+                self.push(OP_DIV, n, d)
+            }
+            ExprNode::Sin(inner) => {
+                let r = self.lower(arena, *inner);
+                self.push(OP_SIN, r, 0)
+            }
+            ExprNode::Cos(inner) => {
+                let r = self.lower(arena, *inner);
+                self.push(OP_COS, r, 0)
+            }
+            ExprNode::Exp(inner) => {
+                let r = self.lower(arena, *inner);
+                self.push(OP_EXP, r, 0)
+            }
+            ExprNode::Log(inner) => {
+                let r = self.lower(arena, *inner);
+                self.push(OP_LOG, r, 0)
+            }
+            ExprNode::Abs(inner) => {
+                let r = self.lower(arena, *inner);
+                self.push(OP_ABS, r, 0)
+            }
+            // OP_LINEAR requires a non-empty range (see `eval_tape`), so a
+            // coefficient-free Linear node lowers to its constant.
+            ExprNode::Linear { coeffs, constant } if coeffs.is_empty() => {
+                self.push_const(*constant)
+            }
+            ExprNode::Linear { coeffs, constant } => {
+                let start = to_u32(self.tape.lin_vars.len());
+                for (v, c) in coeffs {
+                    self.tape.lin_vars.push(v.0);
+                    self.tape.lin_coeffs.push(*c);
+                }
+                let end = to_u32(self.tape.lin_vars.len());
+                let sum = self.push(OP_LINEAR, start, end);
+                if *constant == 0.0 {
+                    sum
+                } else {
+                    let c = self.push_const(*constant);
+                    self.push(OP_ADD, sum, c)
+                }
+            }
+        };
+        self.memo.insert(id, reg);
+        reg
+    }
+
+    fn lower_nary(
+        &mut self,
+        arena: &ExprArena,
+        children: &[ExprId],
+        op: u32,
+        identity: f64,
+    ) -> u32 {
+        let Some((&first, rest)) = children.split_first() else {
+            return self.push_const(identity);
+        };
+        let mut acc = self.lower(arena, first);
+        for &child in rest {
+            let r = self.lower(arena, child);
+            acc = self.push(op, acc, r);
+        }
+        acc
+    }
+}

--- a/crates/oximo-autodiff/tests/derivatives.rs
+++ b/crates/oximo-autodiff/tests/derivatives.rs
@@ -1,0 +1,461 @@
+//! Enzyme-feature tests: gradients, Jacobians, and Hessians of the Lagrangian
+//! against finite differences and exact quadratic extraction.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="-Zautodiff=Enable" cargo +nightly test -p oximo-autodiff --features enzyme --profile enzyme
+//! ```
+#![cfg(feature = "enzyme")]
+#![allow(clippy::cast_precision_loss)]
+
+use oximo_autodiff::{AutodiffError, NlpEvaluator, gradient_at};
+use oximo_core::Model;
+use oximo_core::prelude::*;
+
+fn assert_close(got: f64, want: f64, tol: f64, what: &str) {
+    let denom = want.abs().max(1.0);
+    assert!(((got - want) / denom).abs() < tol, "{what}: got {got}, want {want}");
+}
+
+/// Central finite-difference gradient of the evaluator's objective.
+fn fd_objective_gradient(ev: &NlpEvaluator, x: &[f64]) -> Vec<f64> {
+    let h = 1e-6;
+    (0..x.len())
+        .map(|i| {
+            let mut xp = x.to_vec();
+            let mut xm = x.to_vec();
+            xp[i] += h;
+            xm[i] -= h;
+            (ev.eval_objective(&xp) - ev.eval_objective(&xm)) / (2.0 * h)
+        })
+        .collect()
+}
+
+/// Dense gradient of the Lagrangian function via the evaluator's first-derivative callbacks.
+fn lagrangian_gradient(ev: &NlpEvaluator, x: &[f64], sigma: f64, lambda: &[f64]) -> Vec<f64> {
+    let n = ev.num_variables();
+    let mut g = vec![0.0; n];
+    ev.eval_objective_gradient(x, &mut g);
+    for v in &mut g {
+        *v *= sigma;
+    }
+    let mut jac = vec![0.0; ev.jacobian_structure().len()];
+    ev.eval_constraint_jacobian(x, &mut jac);
+    for (&(row, col), v) in ev.jacobian_structure().iter().zip(&jac) {
+        g[col] += lambda[row] * v;
+    }
+    g
+}
+
+/// Assemble the dense symmetric Hessian from the evaluator's sparse lower
+/// triangle.
+fn dense_hessian(ev: &NlpEvaluator, x: &[f64], sigma: f64, lambda: &[f64]) -> Vec<Vec<f64>> {
+    let n = ev.num_variables();
+    let mut vals = vec![0.0; ev.hessian_lagrangian_structure().len()];
+    ev.eval_hessian_lagrangian(x, sigma, lambda, &mut vals);
+    let mut dense = vec![vec![0.0; n]; n];
+    for (&(r, c), &v) in ev.hessian_lagrangian_structure().iter().zip(&vals) {
+        dense[r][c] += v;
+        if r != c {
+            dense[c][r] += v;
+        }
+    }
+    dense
+}
+
+#[test]
+fn objective_gradient_matches_fd() {
+    let m = Model::new("grad");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    objective!(m, Min, x.sin() * y + x.powi(3) / y + 2.0 * x - 0.5 * y);
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    for point in [[0.8, 1.7], [-1.2, 0.4], [2.5, -3.0]] {
+        let mut grad = vec![0.0; 2];
+        ev.eval_objective_gradient(&point, &mut grad);
+        let fd = fd_objective_gradient(&ev, &point);
+        for i in 0..2 {
+            assert_close(grad[i], fd[i], 1e-6, &format!("grad[{i}] at {point:?}"));
+        }
+    }
+}
+
+#[test]
+fn constraint_jacobian_matches_fd() {
+    let m = Model::new("jac");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    objective!(m, Min, x + y);
+    constraint!(m, lin, 2.0 * x + 3.0 * y <= 10.0);
+    constraint!(m, quad, x.powi(2) + x * y <= 5.0);
+    constraint!(m, nl, x.sin() * y.exp() <= 1.0);
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    let point = [0.7, 1.3];
+    let mut jac = vec![0.0; ev.jacobian_structure().len()];
+    ev.eval_constraint_jacobian(&point, &mut jac);
+
+    let h = 1e-6;
+    let m_con = ev.num_constraints();
+    for (&(row, col), &v) in ev.jacobian_structure().iter().zip(&jac) {
+        let mut xp = point.to_vec();
+        let mut xm = point.to_vec();
+        xp[col] += h;
+        xm[col] -= h;
+        let mut gp = vec![0.0; m_con];
+        let mut gm = vec![0.0; m_con];
+        ev.eval_constraint(&xp, &mut gp);
+        ev.eval_constraint(&xm, &mut gm);
+        let fd = (gp[row] - gm[row]) / (2.0 * h);
+        assert_close(v, fd, 1e-6, &format!("jac[{row},{col}]"));
+    }
+}
+
+#[test]
+fn hessian_exact_on_quadratic() {
+    // f = 3x^2 + xy + y^2 + 2x - y, Hessian [[6, 1], [1, 2]].
+    let m = Model::new("qp");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    objective!(m, Min, 3.0 * x.powi(2) + x * y + y.powi(2) + 2.0 * x - y);
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    assert_eq!(ev.hessian_lagrangian_structure(), &[(0, 0), (1, 0), (1, 1)]);
+    let mut vals = vec![0.0; 3];
+    ev.eval_hessian_lagrangian(&[0.3, -0.4], 2.0, &[], &mut vals);
+    assert_close(vals[0], 12.0, 1e-14, "H[0,0] * sigma");
+    assert_close(vals[1], 2.0, 1e-14, "H[1,0] * sigma");
+    assert_close(vals[2], 4.0, 1e-14, "H[1,1] * sigma");
+}
+
+fn lagrangian_test_model() -> Model {
+    let m = Model::new("lagr");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    objective!(m, Min, x.sin() * y + x.powi(3));
+    constraint!(m, quad, x.powi(2) + y.powi(2) <= 40.0);
+    constraint!(m, nl, x * y.exp() >= 1.0);
+    constraint!(m, lin, x + y <= 10.0);
+    m
+}
+
+#[test]
+fn hessian_lagrangian_matches_fd_of_gradient() {
+    let m = lagrangian_test_model();
+    let ev = NlpEvaluator::new(&m).unwrap();
+    let x = [0.9, -1.1];
+    let sigma = 0.7;
+    let lambda = [1.3, -0.6, 2.0];
+
+    let dense = dense_hessian(&ev, &x, sigma, &lambda);
+    let h = 1e-5;
+    for j in 0..2 {
+        let mut xp = x.to_vec();
+        let mut xm = x.to_vec();
+        xp[j] += h;
+        xm[j] -= h;
+        let gp = lagrangian_gradient(&ev, &xp, sigma, &lambda);
+        let gm = lagrangian_gradient(&ev, &xm, sigma, &lambda);
+        for i in 0..2 {
+            let fd = (gp[i] - gm[i]) / (2.0 * h);
+            assert_close(dense[i][j], fd, 1e-5, &format!("H[{i},{j}]"));
+        }
+    }
+}
+
+#[test]
+fn hessian_is_linear_in_sigma_and_lambda() {
+    let m = lagrangian_test_model();
+    let ev = NlpEvaluator::new(&m).unwrap();
+    let x = [0.9, -1.1];
+    let nnz = ev.hessian_lagrangian_structure().len();
+
+    let eval = |sigma: f64, lambda: [f64; 3]| {
+        let mut vals = vec![0.0; nnz];
+        ev.eval_hessian_lagrangian(&x, sigma, &lambda, &mut vals);
+        vals
+    };
+
+    let sigma = 0.7;
+    let lambda = [1.3, -0.6, 2.0];
+    let combined = eval(sigma, lambda);
+    let obj = eval(1.0, [0.0; 3]);
+    let parts: Vec<Vec<f64>> = (0..3)
+        .map(|i| {
+            let mut l = [0.0; 3];
+            l[i] = 1.0;
+            eval(0.0, l)
+        })
+        .collect();
+    for k in 0..nnz {
+        let want = sigma * obj[k] + lambda.iter().zip(&parts).map(|(l, p)| l * p[k]).sum::<f64>();
+        assert_close(combined[k], want, 1e-10, &format!("linearity at nnz {k}"));
+    }
+}
+
+#[test]
+fn repeated_evaluations_are_deterministic() {
+    let m = lagrangian_test_model();
+    let ev = NlpEvaluator::new(&m).unwrap();
+    let x = [0.9, -1.1];
+    let lambda = [1.3, -0.6, 2.0];
+
+    let mut g1 = vec![0.0; 2];
+    let mut g2 = vec![0.0; 2];
+    ev.eval_objective_gradient(&x, &mut g1);
+    ev.eval_objective_gradient(&x, &mut g2);
+    assert_eq!(g1, g2, "gradient must not accumulate across calls");
+
+    let nnz = ev.hessian_lagrangian_structure().len();
+    let mut h1 = vec![0.0; nnz];
+    let mut h2 = vec![0.0; nnz];
+    ev.eval_hessian_lagrangian(&x, 0.7, &lambda, &mut h1);
+    ev.eval_hessian_lagrangian(&x, 0.7, &lambda, &mut h2);
+    assert_eq!(h1, h2, "hessian must not accumulate across calls");
+}
+
+#[test]
+fn params_refresh_without_retaping() {
+    let m = Model::new("params");
+    variable!(m, -5.0 <= x <= 5.0);
+    param!(m, p = 2.0);
+    objective!(m, Min, p * x.sin());
+
+    let mut ev = NlpEvaluator::new(&m).unwrap();
+    let point = [0.8];
+    let mut grad = vec![0.0; 1];
+    ev.eval_objective_gradient(&point, &mut grad);
+    assert_close(grad[0], 2.0 * point[0].cos(), 1e-12, "grad with p=2");
+
+    m.set_param(p, 3.0);
+    ev.refresh_params(&m);
+    ev.eval_objective_gradient(&point, &mut grad);
+    assert_close(grad[0], 3.0 * point[0].cos(), 1e-12, "grad with p=3");
+}
+
+#[test]
+fn gradient_at_matches_fd() {
+    let m = Model::new("gat");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    let g = x.powi(2) * y + y.exp();
+
+    let point = [1.5, 0.5];
+    let grad = gradient_at(&m, g, &point).unwrap();
+    assert_close(grad[0], 2.0 * point[0] * point[1], 1e-12, "d/dx");
+    assert_close(grad[1], point[0].powi(2) + point[1].exp(), 1e-12, "d/dy");
+}
+
+#[test]
+fn feasibility_model_has_zero_objective() {
+    let m = Model::new("feas");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    constraint!(m, c, x.sin() + y.powi(2) <= 4.0);
+    objective!(m, Feasibility);
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    let point = [1.0, -2.0];
+    assert_close(ev.eval_objective(&point), 0.0, 1e-12, "objective");
+
+    let mut grad = vec![0.0; 2];
+    ev.eval_objective_gradient(&point, &mut grad);
+    for (i, &g) in grad.iter().enumerate() {
+        assert_close(g, 0.0, 1e-12, &format!("objective grad[{i}]"));
+    }
+
+    let mut g = vec![0.0; 1];
+    ev.eval_constraint(&point, &mut g);
+    assert_close(g[0], point[0].sin() + point[1].powi(2), 1e-12, "constraint value");
+}
+
+/// Mostly-separable objective.
+#[test]
+fn separable_hessian_is_sparse_and_compressed() {
+    let m = Model::new("separable");
+    variable!(m, -5.0 <= x0 <= 5.0);
+    variable!(m, -5.0 <= x1 <= 5.0);
+    variable!(m, -5.0 <= x2 <= 5.0);
+    variable!(m, -5.0 <= x3 <= 5.0);
+    variable!(m, -5.0 <= x4 <= 5.0);
+    variable!(m, -5.0 <= x5 <= 5.0);
+    let xs = [x0, x1, x2, x3, x4, x5];
+    // sum sin(x_i) + x0*x1, true Hessian is diagonal plus one cross entry.
+    let mut obj = xs[0] * xs[1];
+    for x in &xs {
+        obj = obj + x.sin();
+    }
+    objective!(m, Min, obj);
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    // 7 entries, not the 21 a support clique would produce.
+    assert_eq!(
+        ev.hessian_lagrangian_structure(),
+        &[(0, 0), (1, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
+    );
+    // Columns {0, 2..5} share one seed while column 1 conflicts with 0.
+    assert_eq!(ev.num_hessian_seeds(), 2);
+
+    let x = [0.4, -1.3, 2.1, 0.9, -0.2, 1.7];
+    let dense = dense_hessian(&ev, &x, 1.0, &[]);
+    let h = 1e-5;
+    for j in 0..6 {
+        let mut xp = x.to_vec();
+        let mut xm = x.to_vec();
+        xp[j] += h;
+        xm[j] -= h;
+        let gp = lagrangian_gradient(&ev, &xp, 1.0, &[]);
+        let gm = lagrangian_gradient(&ev, &xm, 1.0, &[]);
+        for i in 0..6 {
+            let fd = (gp[i] - gm[i]) / (2.0 * h);
+            assert_close(dense[i][j], fd, 1e-5, &format!("H[{i},{j}]"));
+        }
+    }
+}
+
+#[test]
+fn try_refresh_reuses_tapes_when_structure_preserved() {
+    let m = Model::new("refresh_ok");
+    variable!(m, -5.0 <= x <= 5.0);
+    param!(m, p = 2.0);
+    objective!(m, Min, p * x.sin());
+
+    let mut ev = NlpEvaluator::new(&m).unwrap();
+    let point = [0.8];
+    let mut grad = vec![0.0; 1];
+    ev.eval_objective_gradient(&point, &mut grad);
+    assert_close(grad[0], 2.0 * point[0].cos(), 1e-12, "grad with p=2");
+
+    m.set_param(p, 3.0);
+    assert!(ev.try_refresh(&m), "structure preserved -> refreshed in place");
+    ev.eval_objective_gradient(&point, &mut grad);
+    assert_close(grad[0], 3.0 * point[0].cos(), 1e-12, "grad after try_refresh with p=3");
+}
+
+#[test]
+fn try_refresh_declines_when_model_structure_differs() {
+    let base = Model::new("base");
+    variable!(base, -5.0 <= x <= 5.0);
+    variable!(base, -5.0 <= y <= 5.0);
+    objective!(base, Min, x.sin() * y);
+    constraint!(base, c0, x.powi(2) + y.powi(2) <= 4.0);
+
+    let mut ev = NlpEvaluator::new(&base).unwrap();
+    let jac_before = ev.jacobian_structure().to_vec();
+
+    let other = Model::new("other");
+    variable!(other, -5.0 <= x <= 5.0);
+    variable!(other, -5.0 <= y <= 5.0);
+    objective!(other, Min, x.sin() * y);
+    constraint!(other, c0, x.powi(2) + y.powi(2) <= 4.0);
+    constraint!(other, c1, x * y.exp() >= 1.0);
+
+    assert!(!ev.try_refresh(&other), "different constraint set -> caller must rebuild");
+    assert_eq!(ev.jacobian_structure(), jac_before.as_slice(), "declined refresh is a no-op");
+    assert_eq!(ev.num_constraints(), 1, "evaluator still describes the base model");
+}
+
+#[test]
+fn gradient_at_rejects_wrong_dimension() {
+    let m = Model::new("gat_dim");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    let g = x.powi(2) + y.exp();
+
+    let err = gradient_at(&m, g, &[1.0]).unwrap_err();
+    assert!(
+        matches!(err, AutodiffError::DimensionMismatch { expected: 2, got: 1 }),
+        "unexpected error: {err:?}"
+    );
+}
+
+/// A dense Hessian yields one seed per column, crossing the parallel-HVP
+/// threshold, so this tests the rayon Hessian path and checks it
+/// against finite differences.
+#[test]
+fn parallel_hessian_matches_fd() {
+    let n = 20usize;
+    let m = Model::new("par_hess");
+    variable!(m, -1.0 <= x[i in 0..n] <= 1.0);
+    objective!(m, Min, sum!(x[i] for i in 0..n).sin());
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    assert_eq!(ev.num_hessian_seeds(), n, "dense Hessian -> one seed per column");
+
+    let x: Vec<f64> = (0..n).map(|i| 0.05 + 0.01 * i as f64).collect();
+    let dense = dense_hessian(&ev, &x, 1.0, &[]);
+    let h = 1e-5;
+    for j in 0..n {
+        let mut xp = x.clone();
+        let mut xm = x.clone();
+        xp[j] += h;
+        xm[j] -= h;
+        let gp = lagrangian_gradient(&ev, &xp, 1.0, &[]);
+        let gm = lagrangian_gradient(&ev, &xm, 1.0, &[]);
+        for i in 0..n {
+            let fd = (gp[i] - gm[i]) / (2.0 * h);
+            assert_close(dense[i][j], fd, 1e-5, &format!("H[{i},{j}]"));
+        }
+    }
+}
+
+/// Enough constraints to cross the parallel threshold, testing the rayon
+/// constraint-value and Jacobian paths against closed-form derivatives.
+#[test]
+fn parallel_constraints_and_jacobian_match_analytic() {
+    let n = 70usize;
+    let m = Model::new("par_con");
+    variable!(m, -2.0 <= x[i in 0..n] <= 2.0);
+    constraint!(m, c[i in 0..n], x[i].sin() <= 0.5);
+    objective!(m, Min, sum!(x[i] for i in 0..n));
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    assert_eq!(ev.num_constraints(), n);
+
+    let point: Vec<f64> = (0..n).map(|i| 0.1 + 0.01 * i as f64).collect();
+
+    let mut g = vec![0.0; n];
+    ev.eval_constraint(&point, &mut g);
+    for i in 0..n {
+        assert_close(g[i], point[i].sin(), 1e-12, &format!("constraint[{i}] value"));
+    }
+
+    // Row i is sin(x_i), so its only Jacobian entry is at column i with value
+    // cos(x_i).
+    let mut jac = vec![0.0; ev.jacobian_structure().len()];
+    ev.eval_constraint_jacobian(&point, &mut jac);
+    for (&(row, col), &v) in ev.jacobian_structure().iter().zip(&jac) {
+        assert_eq!(row, col, "each constraint touches exactly its own variable");
+        assert_close(v, point[col].cos(), 1e-9, &format!("jac[{row},{col}]"));
+    }
+}
+
+#[test]
+fn hub_objective_star_compresses_seeds() {
+    let n = 7usize;
+    let m = Model::new("hub");
+    variable!(m, -1.0 <= x[i in 0..n] <= 1.0);
+    objective!(m, Min, x[0] * sum!(x[i].sin() for i in 1..n));
+
+    let ev = NlpEvaluator::new(&m).unwrap();
+    // 2 * (n-1) + 0 entries: (i,0) and (i,i) for each spoke, no (0,0).
+    assert_eq!(ev.hessian_lagrangian_structure().len(), 2 * (n - 1));
+    assert_eq!(ev.num_hessian_seeds(), 2, "arrow Hessian compresses to two seeds");
+
+    let x: Vec<f64> = (0..n).map(|i| 0.2 + 0.1 * i as f64).collect();
+    let dense = dense_hessian(&ev, &x, 1.0, &[]);
+    let h = 1e-5;
+    for j in 0..n {
+        let mut xp = x.clone();
+        let mut xm = x.clone();
+        xp[j] += h;
+        xm[j] -= h;
+        let gp = lagrangian_gradient(&ev, &xp, 1.0, &[]);
+        let gm = lagrangian_gradient(&ev, &xm, 1.0, &[]);
+        for i in 0..n {
+            let fd = (gp[i] - gm[i]) / (2.0 * h);
+            assert_close(dense[i][j], fd, 1e-5, &format!("H[{i},{j}]"));
+        }
+    }
+}

--- a/crates/oximo-autodiff/tests/sparsity.rs
+++ b/crates/oximo-autodiff/tests/sparsity.rs
@@ -1,0 +1,192 @@
+//! Stable tests for the exact structural Hessian pattern and the star-coloring
+//! compression of the Hessian into Hessian-vector-product seeds.
+#![allow(clippy::unreadable_literal, clippy::cast_precision_loss)]
+
+use oximo_autodiff::sparsity::{HessianColoring, hessian_pattern, star_hessian_coloring};
+use oximo_expr::{ExprArena, ExprNode, VarId, extract_quadratic};
+use rustc_hash::FxHashSet;
+
+fn var(arena: &mut ExprArena, i: u32) -> oximo_expr::ExprId {
+    arena.var(VarId(i))
+}
+
+#[test]
+fn separable_sum_of_sins_is_diagonal() {
+    let mut arena = ExprArena::new();
+    let sins: Vec<_> = (0..5)
+        .map(|i| {
+            let x = var(&mut arena, i);
+            arena.push(ExprNode::Sin(x))
+        })
+        .collect();
+    let root = arena.push(ExprNode::Add(sins.into_iter().collect()));
+    assert_eq!(hessian_pattern(&arena, root), vec![(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)]);
+}
+
+#[test]
+fn product_and_unary_patterns() {
+    let mut arena = ExprArena::new();
+    let x0 = var(&mut arena, 0);
+    let x1 = var(&mut arena, 1);
+    let x2 = var(&mut arena, 2);
+
+    let mul = arena.push(ExprNode::Mul([x0, x1].into_iter().collect()));
+    let sin = arena.push(ExprNode::Sin(x2));
+    let root = arena.push(ExprNode::Add([mul, sin].into_iter().collect()));
+    assert_eq!(hessian_pattern(&arena, root), vec![(1, 0), (2, 2)]);
+
+    let add = arena.push(ExprNode::Add([x0, x1].into_iter().collect()));
+    let two = arena.constant(2.0);
+    let sq = arena.push(ExprNode::Pow(add, two));
+    assert_eq!(hessian_pattern(&arena, sq), vec![(0, 0), (1, 0), (1, 1)]);
+
+    let div = arena.push(ExprNode::Div(x0, x1));
+    assert_eq!(hessian_pattern(&arena, div), vec![(1, 0), (1, 1)]);
+
+    let pow = arena.push(ExprNode::Pow(x0, x1));
+    assert_eq!(hessian_pattern(&arena, pow), vec![(0, 0), (1, 0), (1, 1)]);
+}
+
+#[test]
+fn abs_passes_through_its_argument_pattern() {
+    let mut arena = ExprArena::new();
+    let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), -1.0)], 0.0);
+    let abs_lin = arena.push(ExprNode::Abs(lin));
+    assert_eq!(hessian_pattern(&arena, abs_lin), vec![]);
+
+    let x0 = var(&mut arena, 0);
+    let three = arena.constant(3.0);
+    let cube = arena.push(ExprNode::Pow(x0, three));
+    let abs_cube = arena.push(ExprNode::Abs(cube));
+    assert_eq!(hessian_pattern(&arena, abs_cube), vec![(0, 0)]);
+}
+
+#[test]
+fn dag_shared_subexpression() {
+    let mut arena = ExprArena::new();
+    let x0 = var(&mut arena, 0);
+    let s = arena.push(ExprNode::Sin(x0));
+    let mul = arena.push(ExprNode::Mul([s, s].into_iter().collect()));
+    let root = arena.push(ExprNode::Add([mul, s].into_iter().collect()));
+    assert_eq!(hessian_pattern(&arena, root), vec![(0, 0)]);
+}
+
+#[test]
+fn pattern_of_quadratic_matches_extract_quadratic() {
+    let mut arena = ExprArena::new();
+    let x0 = var(&mut arena, 0);
+    let x1 = var(&mut arena, 1);
+    let c3 = arena.constant(3.0);
+    let sq0 = arena.push(ExprNode::Mul([c3, x0, x0].into_iter().collect()));
+    let cross = arena.push(ExprNode::Mul([x0, x1].into_iter().collect()));
+    let sq1 = arena.push(ExprNode::Mul([x1, x1].into_iter().collect()));
+    let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), -1.0)], 0.0);
+    let root = arena.push(ExprNode::Add([sq0, cross, sq1, lin].into_iter().collect()));
+
+    let mut from_extract: Vec<(u32, u32)> = extract_quadratic(&arena, root)
+        .expect("degree 2")
+        .hessian
+        .iter()
+        .map(|&(r, c, _)| (r.0, c.0))
+        .collect();
+    from_extract.sort_unstable();
+    assert_eq!(hessian_pattern(&arena, root), from_extract);
+}
+
+/// Exact recovery check, fill a deterministic (pseudo-random, collision-free)
+/// symmetric matrix on `pattern`, simulate one HVP per group
+/// (`b[g][row] = sum_{col in group} H[row][col]`), and confirm the coloring's
+/// recovery plan reproduces every entry.
+fn assert_recovers(pattern: &[(usize, usize)]) -> HessianColoring {
+    let coloring = star_hessian_coloring(pattern);
+    let n = pattern.iter().flat_map(|&(r, c)| [r, c]).max().map_or(0, |m| m + 1);
+
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut rng = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 11) as f64 / (1u64 << 53) as f64 + 0.5
+    };
+    let mut h = vec![vec![0.0f64; n]; n];
+    for &(r, c) in pattern {
+        let v = rng();
+        h[r][c] = v;
+        h[c][r] = v;
+    }
+
+    let b: Vec<Vec<f64>> = coloring
+        .groups
+        .iter()
+        .map(|cols| (0..n).map(|row| cols.iter().map(|&col| h[row][col]).sum()).collect())
+        .collect();
+
+    for (i, &(r, c)) in pattern.iter().enumerate() {
+        let (g, row) = coloring.recover[i];
+        assert!(
+            (b[g][row] - h[r][c]).abs() < 1e-12,
+            "entry {:?}: recovered {}, want {}",
+            (r, c),
+            b[g][row],
+            h[r][c]
+        );
+    }
+    coloring
+}
+
+#[test]
+fn diagonal_pattern_needs_one_group() {
+    let pattern: Vec<(usize, usize)> = (0..6).map(|i| (i, i)).collect();
+    let coloring = assert_recovers(&pattern);
+    assert_eq!(coloring.groups.len(), 1);
+    assert_eq!(coloring.groups[0], vec![0, 1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn tridiagonal_pattern_needs_at_most_three_groups() {
+    let mut pattern: Vec<(usize, usize)> = (0..6).map(|i| (i, i)).collect();
+    pattern.extend((1..6).map(|i| (i, i - 1)));
+    pattern.sort_unstable();
+    let coloring = assert_recovers(&pattern);
+    assert!(coloring.groups.len() <= 3, "tridiagonal needs <= 3 groups, got {:?}", coloring.groups);
+}
+
+/// The pattern {(1,0),(2,1),(2,2)} is the classic case where treating columns 0
+/// and 2 as independent corrupts entry (1,0) via `H[1,2] = H[2,1]`. The
+/// star-coloring recovery plan must reproduce every entry exactly.
+#[test]
+fn adjacent_columns_recover_exactly() {
+    assert_recovers(&[(1, 0), (2, 1), (2, 2)]);
+}
+
+#[test]
+fn arrow_pattern_collapses_to_two_seeds() {
+    // Hub column 0 couples to every spoke. Distance-2 grouping needed one seed
+    // per column (n); star coloring recovers the whole arrow in two HVPs.
+    let n = 5;
+    let mut pattern: Vec<(usize, usize)> = (0..n).map(|i| (i, i)).collect();
+    pattern.extend((1..n).map(|i| (i, 0)));
+    pattern.sort_unstable();
+    let coloring = assert_recovers(&pattern);
+    assert_eq!(coloring.groups.len(), 2, "star coloring compresses the hub");
+}
+
+#[test]
+fn randomized_patterns_recover_exactly() {
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    let mut next = move |bound: usize| {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((state >> 33) as usize) % bound
+    };
+    for _ in 0..50 {
+        let n = 4 + next(12);
+        let nnz = 1 + next(2 * n);
+        let mut pattern: FxHashSet<(usize, usize)> = FxHashSet::default();
+        for _ in 0..nnz {
+            let i = next(n);
+            let j = next(n);
+            pattern.insert((i.max(j), i.min(j)));
+        }
+        let mut pattern: Vec<(usize, usize)> = pattern.into_iter().collect();
+        pattern.sort_unstable();
+        assert_recovers(&pattern);
+    }
+}

--- a/crates/oximo-autodiff/tests/sparsity.rs
+++ b/crates/oximo-autodiff/tests/sparsity.rs
@@ -93,6 +93,54 @@ fn pattern_of_quadratic_matches_extract_quadratic() {
     assert_eq!(hessian_pattern(&arena, root), from_extract);
 }
 
+#[test]
+fn triple_product_has_no_diagonal() {
+    let mut arena = ExprArena::new();
+    let x = var(&mut arena, 0);
+    let y = var(&mut arena, 1);
+    let z = var(&mut arena, 2);
+    let prod = arena.push(ExprNode::Mul([x, y, z].into_iter().collect()));
+    assert_eq!(hessian_pattern(&arena, prod), vec![(1, 0), (2, 0), (2, 1)]);
+}
+
+#[test]
+fn sum_of_variables_has_empty_hessian() {
+    let mut arena = ExprArena::new();
+    let x = var(&mut arena, 0);
+    let y = var(&mut arena, 1);
+    let sum = arena.push(ExprNode::Add([x, y].into_iter().collect()));
+    assert_eq!(hessian_pattern(&arena, sum), vec![]);
+}
+
+#[test]
+fn sin_of_sum_is_a_full_clique() {
+    let mut arena = ExprArena::new();
+    let x = var(&mut arena, 0);
+    let y = var(&mut arena, 1);
+    let sum = arena.push(ExprNode::Add([x, y].into_iter().collect()));
+    let s = arena.push(ExprNode::Sin(sum));
+    assert_eq!(hessian_pattern(&arena, s), vec![(0, 0), (1, 0), (1, 1)]);
+}
+
+#[test]
+fn square_of_sum_matches_the_smooth_unary_clique() {
+    let mut arena = ExprArena::new();
+    let x = var(&mut arena, 0);
+    let y = var(&mut arena, 1);
+    let sum = arena.push(ExprNode::Add([x, y].into_iter().collect()));
+    let two = arena.constant(2.0);
+    let sq = arena.push(ExprNode::Pow(sum, two));
+    assert_eq!(hessian_pattern(&arena, sq), vec![(0, 0), (1, 0), (1, 1)]);
+}
+
+#[test]
+fn self_division_keeps_its_structural_entry() {
+    let mut arena = ExprArena::new();
+    let x = var(&mut arena, 0);
+    let div = arena.push(ExprNode::Div(x, x));
+    assert_eq!(hessian_pattern(&arena, div), vec![(0, 0)]);
+}
+
 /// Exact recovery check, fill a deterministic (pseudo-random, collision-free)
 /// symmetric matrix on `pattern`, simulate one HVP per group
 /// (`b[g][row] = sum_{col in group} H[row][col]`), and confirm the coloring's
@@ -189,4 +237,48 @@ fn randomized_patterns_recover_exactly() {
         pattern.sort_unstable();
         assert_recovers(&pattern);
     }
+}
+
+/// Build a normalized lower-triangle Hessian pattern for an `n`-vertex graph.
+fn graph_pattern(n: usize, edges: &[(usize, usize)]) -> Vec<(usize, usize)> {
+    let mut set: FxHashSet<(usize, usize)> = (0..n).map(|i| (i, i)).collect();
+    for &(a, b) in edges {
+        set.insert((a.max(b), a.min(b)));
+    }
+    let mut pattern: Vec<(usize, usize)> = set.into_iter().collect();
+    pattern.sort_unstable();
+    pattern
+}
+
+#[test]
+fn path_graph_recovers_exactly() {
+    let edges: Vec<(usize, usize)> = (1..6).map(|i| (i, i - 1)).collect();
+    let coloring = assert_recovers(&graph_pattern(6, &edges));
+    assert!(coloring.groups.len() <= 3, "path needs <= 3 groups, got {}", coloring.groups.len());
+}
+
+#[test]
+fn cycle_graph_recovers_exactly() {
+    let mut edges: Vec<(usize, usize)> = (1..6).map(|i| (i, i - 1)).collect();
+    edges.push((5, 0));
+    assert_recovers(&graph_pattern(6, &edges));
+}
+
+#[test]
+fn complete_graph_recovers_exactly() {
+    let n = 5;
+    let mut edges = Vec::new();
+    for i in 0..n {
+        for j in 0..i {
+            edges.push((i, j));
+        }
+    }
+    let coloring = assert_recovers(&graph_pattern(n, &edges));
+    assert_eq!(coloring.groups.len(), n, "dense block needs one seed per column");
+}
+
+#[test]
+fn disconnected_graph_recovers_exactly() {
+    let edges = [(1, 0), (2, 0), (2, 1), (4, 3), (5, 3), (5, 4)];
+    assert_recovers(&graph_pattern(6, &edges));
 }

--- a/crates/oximo-autodiff/tests/tape.rs
+++ b/crates/oximo-autodiff/tests/tape.rs
@@ -1,0 +1,217 @@
+//! Stable tests: tape compilation/evaluation against `oximo_expr::evaluate`,
+//! slot classification, and sparsity patterns.
+#![allow(clippy::unreadable_literal, clippy::cast_precision_loss, clippy::float_cmp)]
+
+use oximo_autodiff::slot::{
+    FunctionSlot, SlotKind, linear_gradient_add, linear_value, quadratic_gradient_add,
+    quadratic_value,
+};
+use oximo_autodiff::sparsity::{
+    hessian_lagrangian_structure, jacobian_structure, variable_support,
+};
+use oximo_autodiff::tape::Tape;
+use oximo_expr::{ExprArena, ExprId, ExprNode, VarId, evaluate};
+
+fn assert_close(got: f64, want: f64, tol: f64, what: &str) {
+    let denom = want.abs().max(1.0);
+    assert!(((got - want) / denom).abs() < tol, "{what}: got {got}, want {want}");
+}
+
+/// Tape and recursive evaluator must agree to within a couple of ULPs (the
+/// tape may associate sums differently, e.g. a Linear node's constant is
+/// added last instead of first).
+fn check_matches_evaluate(arena: &ExprArena, root: ExprId, points: &[Vec<f64>]) {
+    let tape = Tape::compile(arena, root);
+    let params: Vec<f64> = (0..arena.num_params())
+        .map(|i| arena.param_value(oximo_expr::ParamId(u32::try_from(i).unwrap())))
+        .collect();
+    let mut regs = vec![0.0; tape.n_regs()];
+    for x in points {
+        let want = evaluate(arena, root, &x.as_slice()).unwrap();
+        let got = tape.value(x, &params, &[], &mut regs);
+        if got.is_nan() && want.is_nan() {
+            continue;
+        }
+        assert_close(got, want, 1e-14, &format!("tape vs evaluate at {x:?}"));
+    }
+}
+
+fn points(n_vars: usize, n_points: usize) -> Vec<Vec<f64>> {
+    // Small deterministic LCG; values in roughly [-2, 2], kept away from 0.
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next = move || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let unit = (state >> 11) as f64 / (1u64 << 53) as f64;
+        let v = 4.0 * unit - 2.0;
+        if v.abs() < 0.1 { v + 0.5 } else { v }
+    };
+    (0..n_points).map(|_| (0..n_vars).map(|_| next()).collect()).collect()
+}
+
+#[test]
+fn every_node_kind_matches_evaluate() {
+    let mut arena = ExprArena::new();
+    let x0 = arena.var(VarId(0));
+    let x1 = arena.var(VarId(1));
+    let p = arena.new_param(0.7);
+    let p0 = arena.param(p);
+    let c2 = arena.constant(2.0);
+    let c3 = arena.constant(3.0);
+
+    let add = arena.push(ExprNode::Add([x0, x1, c2].into_iter().collect()));
+    let mul = arena.push(ExprNode::Mul([x0, x1, p0].into_iter().collect()));
+    let neg = arena.push(ExprNode::Neg(mul));
+    let powc = arena.push(ExprNode::Pow(x0, c3));
+    let pow = arena.push(ExprNode::Pow(add, x1)); // expression exponent
+    let div = arena.push(ExprNode::Div(powc, x1));
+    let sin = arena.push(ExprNode::Sin(x0));
+    let cos = arena.push(ExprNode::Cos(x1));
+    let exp = arena.push(ExprNode::Exp(sin));
+    let log = arena.push(ExprNode::Log(exp));
+    let abs = arena.push(ExprNode::Abs(neg));
+    let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), -0.5)], 4.0);
+    let root =
+        arena.push(ExprNode::Add([add, neg, pow, div, cos, log, abs, lin].into_iter().collect()));
+
+    // `pow` with an expression exponent needs a positive base: shift points.
+    let pts: Vec<Vec<f64>> = points(2, 20)
+        .into_iter()
+        .map(|p| p.into_iter().map(f64::abs).map(|v| v + 0.2).collect())
+        .collect();
+    check_matches_evaluate(&arena, root, &pts);
+}
+
+#[test]
+fn shared_subexpressions_lower_once() {
+    let mut arena = ExprArena::new();
+    let x0 = arena.var(VarId(0));
+    let sin = arena.push(ExprNode::Sin(x0));
+    // sin(x0) used three times: as a DAG the tape must reuse the register.
+    let mul = arena.push(ExprNode::Mul([sin, sin].into_iter().collect()));
+    let root = arena.push(ExprNode::Add([mul, sin].into_iter().collect()));
+
+    let tape = Tape::compile(&arena, root);
+    // x0, sin, mul, add, sharing means 4 instructions
+    assert_eq!(tape.n_regs(), 4);
+    check_matches_evaluate(&arena, root, &points(1, 10));
+}
+
+#[test]
+fn weighted_tape_matches_manual_sum() {
+    let mut arena = ExprArena::new();
+    let x0 = arena.var(VarId(0));
+    let x1 = arena.var(VarId(1));
+    let sin = arena.push(ExprNode::Sin(x0));
+    let f0 = arena.push(ExprNode::Mul([sin, x1].into_iter().collect()));
+    let f1 = arena.push(ExprNode::Exp(x1));
+    let f2 = arena.push(ExprNode::Mul([sin, sin].into_iter().collect())); // shares sin
+
+    let tape = Tape::compile_weighted(&arena, &[f0, f1, f2]);
+    assert_eq!(tape.n_mults(), 3);
+    let mut regs = vec![0.0; tape.n_regs()];
+    let mults = [1.5, -2.0, 0.25];
+    for x in points(2, 10) {
+        let want: f64 = [f0, f1, f2]
+            .iter()
+            .zip(mults)
+            .map(|(&f, m)| m * evaluate(&arena, f, &x.as_slice()).unwrap())
+            .sum();
+        let got = tape.value(&x, &[], &mults, &mut regs);
+        assert_close(got, want, 1e-14, "weighted tape");
+    }
+}
+
+#[test]
+fn empty_weighted_tape_is_zero() {
+    let arena = ExprArena::new();
+    let tape = Tape::compile_weighted(&arena, &[]);
+    let mut regs = vec![0.0; tape.n_regs()];
+    assert_eq!(tape.value(&[], &[], &[], &mut regs), 0.0);
+}
+
+#[test]
+fn classification_fast_paths() {
+    let mut arena = ExprArena::new();
+    let x0 = arena.var(VarId(0));
+    let x1 = arena.var(VarId(1));
+
+    let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), 3.0)], 1.0);
+    let slot = FunctionSlot::classify(&arena, lin);
+    assert!(matches!(slot.kind, SlotKind::Linear(_)), "linear slot");
+    assert_eq!(slot.support, vec![0, 1]);
+
+    let sq = arena.push(ExprNode::Mul([x0, x0].into_iter().collect()));
+    let cross = arena.push(ExprNode::Mul([x0, x1].into_iter().collect()));
+    let quad = arena.push(ExprNode::Add([sq, cross, lin].into_iter().collect()));
+    let slot = FunctionSlot::classify(&arena, quad);
+    assert!(matches!(slot.kind, SlotKind::Quadratic(_)), "quadratic slot");
+    assert_eq!(slot.support, vec![0, 1]);
+
+    let sin = arena.push(ExprNode::Sin(x0));
+    let slot = FunctionSlot::classify(&arena, sin);
+    assert!(slot.is_nonlinear(), "nonlinear slot");
+    assert_eq!(slot.support, vec![0]);
+}
+
+#[test]
+fn linear_and_quadratic_closed_forms() {
+    let mut arena = ExprArena::new();
+    let x0 = arena.var(VarId(0));
+    let x1 = arena.var(VarId(1));
+    let sq = arena.push(ExprNode::Mul([x0, x0].into_iter().collect()));
+    let cross = arena.push(ExprNode::Mul([x0, x1].into_iter().collect()));
+    let c3 = arena.constant(3.0);
+    let scaled = arena.push(ExprNode::Mul([c3, sq].into_iter().collect()));
+    let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), -1.0)], 5.0);
+    let quad = arena.push(ExprNode::Add([scaled, cross, lin].into_iter().collect()));
+
+    let SlotKind::Quadratic(q) = FunctionSlot::classify(&arena, quad).kind else {
+        panic!("expected quadratic");
+    };
+    let SlotKind::Linear(l) = FunctionSlot::classify(&arena, lin).kind else {
+        panic!("expected linear");
+    };
+
+    for x in points(2, 10) {
+        let want_q = evaluate(&arena, quad, &x.as_slice()).unwrap();
+        assert_close(quadratic_value(&q, &x), want_q, 1e-13, "quadratic value");
+        let want_l = evaluate(&arena, lin, &x.as_slice()).unwrap();
+        assert_close(linear_value(&l, &x), want_l, 1e-13, "linear value");
+
+        // Gradient of 3 x0^2 + x0 x1 + 2 x0 - x1 + 5 is (6 x0 + x1 + 2, x0 - 1).
+        let mut g = vec![0.0; 2];
+        quadratic_gradient_add(&q, &x, 1.0, &mut g);
+        assert_close(g[0], 6.0 * x[0] + x[1] + 2.0, 1e-13, "quad grad x0");
+        assert_close(g[1], x[0] - 1.0, 1e-13, "quad grad x1");
+
+        let mut g = vec![0.0; 2];
+        linear_gradient_add(&l, 2.0, &mut g);
+        assert_close(g[0], 4.0, 1e-15, "lin grad x0 (scaled)");
+        assert_close(g[1], -2.0, 1e-15, "lin grad x1 (scaled)");
+    }
+}
+
+#[test]
+fn sparsity_patterns() {
+    let mut arena = ExprArena::new();
+    let x0 = arena.var(VarId(0));
+    let x2 = arena.var(VarId(2));
+    let sin = arena.push(ExprNode::Sin(x2));
+    let mul = arena.push(ExprNode::Mul([x0, sin].into_iter().collect()));
+    let lin = arena.linear(vec![(VarId(1), 1.0), (VarId(3), 2.0)], 0.0);
+    let root = arena.push(ExprNode::Add([mul, lin].into_iter().collect()));
+    assert_eq!(variable_support(&arena, root), vec![0, 1, 2, 3]);
+
+    let sq1 = arena.push(ExprNode::Mul([x2, x2].into_iter().collect()));
+    let slots = vec![
+        FunctionSlot::classify(&arena, lin), // linear in x1, x3
+        FunctionSlot::classify(&arena, sq1), // quadratic in x2
+        FunctionSlot::classify(&arena, mul), // nonlinear in x0, x2
+    ];
+
+    assert_eq!(jacobian_structure(&slots), vec![(0, 1), (0, 3), (1, 2), (2, 0), (2, 2)]);
+    // Hessian: the quadratic contributes (2,2), and the nonlinear x0*sin(x2)
+    // has the exact pattern {(2,0), (2,2)} with no (0,0) since d²/dx0² ≡ 0.
+    // Linear contributes nothing.
+    assert_eq!(hessian_lagrangian_structure(&slots), vec![(2, 0), (2, 2)]);
+}


### PR DESCRIPTION
## Description

This PR adds support for automatic differentiation of oximo models through `std::autodiff` (nightly only).

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/12