### PR TITLE
Model and Equation pretty-printing

### DIFF
--- a/crates/oximo-core/src/display.rs
+++ b/crates/oximo-core/src/display.rs
@@ -1,0 +1,356 @@
+//! Human-readable rendering of models, constraints, objectives, and expressions.
+//!
+//! Everything here is a lazy adapter holding `&Model`. The model's `RefCell`s
+//! are borrowed at format time, so do not format one while holding a mutable
+//! borrow of the arena or registries.
+
+use std::fmt;
+
+use oximo_expr::{Expr, ExprId, render_expr};
+
+use crate::constraint::{ConstraintId, Sense};
+use crate::domain::Domain;
+use crate::model::Model;
+use crate::objective::ObjectiveSense;
+use crate::soc::SocConstraintId;
+use crate::var::{Variable, var_name};
+
+/// Compact `f64` rendering (shortest round-trip).
+fn fmt_num(v: f64) -> String {
+    if v == 0.0 { "0".to_string() } else { format!("{v}") }
+}
+
+/// Displays one expression as infix algebra, e.g. `3 x + 4 y - z`.
+/// Built by [`Model::display_expr`]/[`Model::display_expr_id`].
+#[derive(Debug)]
+pub struct ExprDisplay<'a> {
+    model: &'a Model,
+    id: ExprId,
+}
+
+impl fmt::Display for ExprDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let arena = self.model.arena.borrow();
+        let vars = self.model.variables.borrow();
+        f.write_str(&render_expr(&arena, self.id, &|v| var_name(&vars, v)))
+    }
+}
+
+/// Displays one constraint as `name: lhs <= rhs` (or a range / equality).
+/// Built by [`Model::display_constraint`].
+#[derive(Debug)]
+pub struct ConstraintDisplay<'a> {
+    model: &'a Model,
+    id: ConstraintId,
+}
+
+impl fmt::Display for ConstraintDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let arena = self.model.arena.borrow();
+        let vars = self.model.variables.borrow();
+        let constraints = self.model.constraints.borrow();
+        let c = &constraints[self.id.index()];
+        let resolve = |v| var_name(&vars, v);
+        let expr = render_expr(&arena, c.lhs, &resolve);
+        write!(f, "{}: ", c.name)?;
+        match c.as_single() {
+            Some((Sense::Le, rhs)) => write!(f, "{expr} <= {}", fmt_num(rhs))?,
+            Some((Sense::Ge, rhs)) => write!(f, "{expr} >= {}", fmt_num(rhs))?,
+            Some((Sense::Eq, rhs)) => write!(f, "{expr} = {}", fmt_num(rhs))?,
+            None if c.is_range() => {
+                write!(f, "{} <= {expr} <= {}", fmt_num(c.lower), fmt_num(c.upper))?;
+            }
+            None => write!(f, "{expr} free")?,
+        }
+        if !c.active {
+            f.write_str(" (inactive)")?;
+        }
+        Ok(())
+    }
+}
+
+/// Displays the objective as `min <expr>`/`max <expr>`/`feasibility`.
+/// Built by [`Model::display_objective`].
+#[derive(Debug)]
+pub struct ObjectiveDisplay<'a> {
+    model: &'a Model,
+}
+
+impl fmt::Display for ObjectiveDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.model.is_feasibility() {
+            return f.write_str("feasibility");
+        }
+        // Copy `(sense, expr)` out so the objective borrow ends before the
+        // expression rendering takes its own borrows.
+        let obj = self.model.objective.borrow().as_ref().map(|o| (o.sense, o.expr));
+        let Some((sense, expr)) = obj else {
+            return f.write_str("(no objective)");
+        };
+        let word = match sense {
+            ObjectiveSense::Minimize => "min",
+            ObjectiveSense::Maximize => "max",
+        };
+        write!(f, "{word} {}", ExprDisplay { model: self.model, id: expr })
+    }
+}
+
+/// Displays one second-order cone constraint as `name: ||t1, t2|| <= bound`.
+/// Built by [`Model::display_soc`].
+#[derive(Debug)]
+pub struct SocDisplay<'a> {
+    model: &'a Model,
+    id: SocConstraintId,
+}
+
+impl fmt::Display for SocDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let arena = self.model.arena.borrow();
+        let vars = self.model.variables.borrow();
+        let socs = self.model.soc_constraints.borrow();
+        let c = &socs[self.id.index()];
+        let resolve = |v| var_name(&vars, v);
+        write!(f, "{}: ||", c.name)?;
+        for (i, t) in c.terms.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            f.write_str(&render_expr(&arena, *t, &resolve))?;
+        }
+        write!(f, "|| <= {}", render_expr(&arena, c.bound, &resolve))?;
+        if !c.active {
+            f.write_str(" (inactive)")?;
+        }
+        Ok(())
+    }
+}
+
+/// One `vars` section line: bounds relation plus a domain suffix,
+/// e.g. `0 <= y <= 1, binary`.
+fn write_var_line(f: &mut fmt::Formatter<'_>, v: &Variable) -> fmt::Result {
+    match (v.lb.is_finite(), v.ub.is_finite()) {
+        (true, true) if v.lb.total_cmp(&v.ub).is_eq() => {
+            write!(f, "{} = {}", v.name, fmt_num(v.lb))?;
+        }
+        (true, true) => write!(f, "{} <= {} <= {}", fmt_num(v.lb), v.name, fmt_num(v.ub))?,
+        (true, false) => write!(f, "{} >= {}", v.name, fmt_num(v.lb))?,
+        (false, true) => write!(f, "{} <= {}", v.name, fmt_num(v.ub))?,
+        (false, false) => write!(f, "{} free", v.name)?,
+    }
+    match v.domain {
+        Domain::Real => Ok(()),
+        Domain::Integer => f.write_str(", integer"),
+        Domain::Binary => f.write_str(", binary"),
+        Domain::SemiContinuous { threshold } => {
+            write!(f, ", semicontinuous(threshold={})", fmt_num(threshold))
+        }
+        Domain::SemiInteger { threshold } => {
+            write!(f, ", semiinteger(threshold={})", fmt_num(threshold))
+        }
+    }
+}
+
+impl Model {
+    /// Display adapter for an expression handle, resolving variable names
+    /// against this model.
+    #[must_use]
+    pub fn display_expr(&self, e: Expr<'_>) -> ExprDisplay<'_> {
+        self.display_expr_id(e.id)
+    }
+
+    /// Display adapter for a raw [`ExprId`] (as stored in constraints and the
+    /// objective).
+    #[must_use]
+    pub fn display_expr_id(&self, id: ExprId) -> ExprDisplay<'_> {
+        ExprDisplay { model: self, id }
+    }
+
+    /// Display adapter for one algebraic constraint.
+    #[must_use]
+    pub fn display_constraint(&self, id: ConstraintId) -> ConstraintDisplay<'_> {
+        ConstraintDisplay { model: self, id }
+    }
+
+    /// Display adapter for the objective (`min <expr>`/`max <expr>`/
+    /// `feasibility`/`(no objective)`).
+    #[must_use]
+    pub fn display_objective(&self) -> ObjectiveDisplay<'_> {
+        ObjectiveDisplay { model: self }
+    }
+
+    /// Display adapter for one second-order cone constraint.
+    #[must_use]
+    pub fn display_soc(&self, id: SocConstraintId) -> SocDisplay<'_> {
+        SocDisplay { model: self, id }
+    }
+}
+
+/// Pretty-print the whole model as readable algebra:
+///
+/// ```text
+/// Model 'diet' (LP)
+/// min 3 x + 4 y
+/// s.t.
+///   c1: x + 2 y <= 14
+///   c2: 3 x - y >= 0
+/// vars
+///   x >= 0
+///   y >= 0
+/// ```
+///
+/// Sections (`s.t.`, `vars`, `params`) are omitted when empty. The objective
+/// line is omitted when no objective was declared.
+impl fmt::Display for Model {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Model '{}' ({:?})", self.name, self.kind())?;
+        if self.is_feasibility() || self.objective.borrow().is_some() {
+            writeln!(f, "{}", self.display_objective())?;
+        }
+        let n_constraints = self.constraints.borrow().len();
+        let n_socs = self.soc_constraints.borrow().len();
+        if n_constraints + n_socs > 0 {
+            let n_constraints = u32::try_from(n_constraints).expect("constraint count fits u32");
+            let n_socs = u32::try_from(n_socs).expect("soc count fits u32");
+            writeln!(f, "s.t.")?;
+            for i in 0..n_constraints {
+                writeln!(f, "  {}", self.display_constraint(ConstraintId(i)))?;
+            }
+            for i in 0..n_socs {
+                writeln!(f, "  {}", self.display_soc(SocConstraintId(i)))?;
+            }
+        }
+        {
+            let vars = self.variables.borrow();
+            if !vars.is_empty() {
+                writeln!(f, "vars")?;
+                for v in vars.iter() {
+                    f.write_str("  ")?;
+                    write_var_line(f, v)?;
+                    writeln!(f)?;
+                }
+            }
+        }
+        let params = self.parameters.borrow();
+        if !params.is_empty() {
+            let arena = self.arena.borrow();
+            writeln!(f, "params")?;
+            for p in params.iter() {
+                writeln!(f, "  {} = {}", p.name, fmt_num(arena.param_value(p.id)))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constraint::Relate;
+
+    #[test]
+    fn full_model_snapshot() {
+        let m = Model::new("diet");
+        let x = m.__var("x").lb(0.0).build();
+        let y = m.__var("y").lb(0.0).build();
+        m.__add_constraint("c1", (x + 2.0 * y).le(14.0));
+        m.__add_constraint("c2", (3.0 * x - y).ge(0.0));
+        m.__minimize(3.0 * x + 4.0 * y);
+
+        let expected = "Model 'diet' (LP)\n\
+                        min 3 x + 4 y\n\
+                        s.t.\n\
+                        \x20 c1: x + 2 y <= 14\n\
+                        \x20 c2: 3 x - y >= 0\n\
+                        vars\n\
+                        \x20 x >= 0\n\
+                        \x20 y >= 0\n";
+        assert_eq!(format!("{m}"), expected);
+    }
+
+    #[test]
+    fn constraint_variants_render() {
+        let m = Model::new("t");
+        let x = m.__var("x").build();
+        let eq = m.__add_constraint("e", x.eq(5.0));
+        assert_eq!(m.display_constraint(eq).to_string(), "e: x = 5");
+
+        m.__add_range("r", x, 2.0, 10.0);
+        let r = m.constraint_id("r").unwrap();
+        assert_eq!(m.display_constraint(r).to_string(), "r: 2 <= x <= 10");
+
+        let ge = m.__add_constraint("g", x.ge(1.0));
+        m.constraints.borrow_mut()[ge.index()].active = false;
+        assert_eq!(m.display_constraint(ge).to_string(), "g: x >= 1 (inactive)");
+    }
+
+    #[test]
+    fn objective_and_feasibility() {
+        let m = Model::new("t");
+        let x = m.__var("x").build();
+        assert_eq!(m.display_objective().to_string(), "(no objective)");
+        m.__maximize(x);
+        assert_eq!(m.display_objective().to_string(), "max x");
+
+        let f = Model::new("f");
+        f.__feasibility();
+        assert_eq!(f.display_objective().to_string(), "feasibility");
+        assert!(format!("{f}").contains("feasibility\n"));
+    }
+
+    #[test]
+    fn var_lines_cover_domains_and_bounds() {
+        let m = Model::new("t");
+        m.__var("a").bounds(0.0, 5.0).build();
+        m.__var("b").binary().build();
+        m.__var("c").integer().build();
+        m.__var("d").build();
+        m.__var("e").ub(3.0).build();
+        m.__var("g").fix(2.0).build();
+        m.__var("h").lb(0.0).domain(crate::Domain::SemiContinuous { threshold: 2.0 }).build();
+
+        let out = format!("{m}");
+        assert!(out.contains("  0 <= a <= 5\n"), "{out}");
+        assert!(out.contains("  0 <= b <= 1, binary\n"), "{out}");
+        assert!(out.contains("  c free, integer\n"), "{out}");
+        assert!(out.contains("  d free\n"), "{out}");
+        assert!(out.contains("  e <= 3\n"), "{out}");
+        assert!(out.contains("  g = 2\n"), "{out}");
+        assert!(out.contains("  h >= 0, semicontinuous(threshold=2)\n"), "{out}");
+    }
+
+    #[test]
+    fn params_section_shows_current_values() {
+        let m = Model::new("t");
+        let x = m.__var("x").build();
+        let price = m.__param("price", 4.0);
+        m.__minimize(price * x);
+        let out = format!("{m}");
+        assert!(out.contains("min 4 x\n"), "{out}");
+        assert!(out.contains("params\n  price = 4\n"), "{out}");
+
+        price.set_param_value(7.5);
+        let out = format!("{m}");
+        assert!(out.contains("min 7.5 x\n"), "{out}");
+        assert!(out.contains("params\n  price = 7.5\n"), "{out}");
+    }
+
+    #[test]
+    fn soc_row_renders_in_model_display() {
+        let m = Model::new("t");
+        let x = m.__var("x").build();
+        let y = m.__var("y").build();
+        let t = m.__var("t").lb(0.0).build();
+        let id = m.add_soc_constraint("q1", [x, y], t);
+        assert_eq!(m.display_soc(id).to_string(), "q1: ||x, y|| <= t");
+        assert!(format!("{m}").contains("  q1: ||x, y|| <= t\n"));
+    }
+
+    #[test]
+    fn display_expr_renders_nonlinear() {
+        let m = Model::new("t");
+        let x = m.__var("x").build();
+        let y = m.__var("y").build();
+        let e = x * y - y;
+        assert_eq!(m.display_expr(e).to_string(), "-y + x * y");
+    }
+}

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -7,6 +7,7 @@ extern crate self as oximo_core;
 #[path = "macro_support.rs"]
 pub mod __macro_support;
 pub mod constraint;
+pub mod display;
 pub mod domain;
 pub mod error;
 pub mod indexed;
@@ -20,6 +21,7 @@ pub mod sum;
 pub mod var;
 
 pub use constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
+pub use display::{ConstraintDisplay, ExprDisplay, ObjectiveDisplay, SocDisplay};
 pub use domain::Domain;
 pub use error::{Error, Result};
 pub use indexed::{IndexedParam, IndexedVar};
@@ -35,6 +37,7 @@ pub use var::{VarBuilder, Variable, var_name};
 // `oximo-expr` import.
 pub use oximo_expr::{
     EvalError, Expr, ExprArena, ExprId, ExprNode, ParamId, VarId, describe_nonlinear_term, dot,
+    render_expr, render_linear_terms,
 };
 
 pub use oximo_macros::{constraint, objective, param, set, soc_constraint, sum, variable};

--- a/crates/oximo-expr/src/lib.rs
+++ b/crates/oximo-expr/src/lib.rs
@@ -8,6 +8,7 @@ mod handle;
 mod linear;
 mod ops;
 mod quadratic;
+mod render;
 mod simplify;
 mod visit;
 
@@ -18,5 +19,6 @@ pub use handle::Expr;
 pub use linear::{LinearTerms, SignedExpr, describe_nonlinear_term, extract_linear, split_linear};
 pub use ops::dot;
 pub use quadratic::{QuadraticTerms, extract_quadratic};
+pub use render::{render_expr, render_linear_terms};
 pub use simplify::simplify;
 pub use visit::{Visitor, walk};

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -273,6 +273,7 @@ pub fn describe_nonlinear_term(
     id: ExprId,
     resolve: &impl Fn(VarId) -> String,
 ) -> Option<String> {
+    use crate::render::{PREC_ADD, PREC_UNARY, render_node};
     let (_, residual) = split_linear(arena, id);
     residual.first().map(|s| {
         if s.neg {
@@ -281,86 +282,6 @@ pub fn describe_nonlinear_term(
             render_node(arena, s.id, resolve, PREC_ADD)
         }
     })
-}
-
-// Precedence levels for parenthesizing `render_node` output.
-const PREC_ADD: u8 = 1;
-const PREC_MUL: u8 = 2;
-const PREC_UNARY: u8 = 3;
-
-/// Render an arena node as an infix string. `parent_prec` is the precedence of
-/// the surrounding context.
-fn render_node(
-    arena: &ExprArena,
-    id: ExprId,
-    resolve: &impl Fn(VarId) -> String,
-    parent_prec: u8,
-) -> String {
-    let (text, prec) = match arena.get(id) {
-        ExprNode::Const(c) => (fmt_num(*c), PREC_UNARY),
-        ExprNode::Var(v) => (resolve(*v), PREC_UNARY),
-        ExprNode::Param(p) => (fmt_num(arena.param_value(*p)), PREC_UNARY),
-        ExprNode::Neg(x) => {
-            (format!("-{}", render_node(arena, *x, resolve, PREC_UNARY)), PREC_UNARY)
-        }
-        ExprNode::Add(children) => {
-            let parts: Vec<String> =
-                children.iter().map(|c| render_node(arena, *c, resolve, PREC_ADD)).collect();
-            (parts.join(" + "), PREC_ADD)
-        }
-        ExprNode::Mul(children) => {
-            let parts: Vec<String> =
-                children.iter().map(|c| render_node(arena, *c, resolve, PREC_MUL)).collect();
-            (parts.join(" * "), PREC_MUL)
-        }
-        ExprNode::Pow(b, e) => {
-            let base = render_node(arena, *b, resolve, PREC_UNARY);
-            let exp = render_node(arena, *e, resolve, PREC_UNARY);
-            (format!("{base}^{exp}"), PREC_UNARY)
-        }
-        ExprNode::Div(num, den) => {
-            let n = render_node(arena, *num, resolve, PREC_MUL);
-            let d = render_node(arena, *den, resolve, PREC_MUL);
-            (format!("{n} / {d}"), PREC_MUL)
-        }
-        ExprNode::Sin(x) => (fmt_call("sin", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Cos(x) => (fmt_call("cos", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Exp(x) => (fmt_call("exp", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Log(x) => (fmt_call("log", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Abs(x) => (fmt_call("abs", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Linear { coeffs, constant } => {
-            let mut parts: Vec<String> = coeffs
-                .iter()
-                .map(|(v, c)| {
-                    if (*c - 1.0).abs() < f64::EPSILON {
-                        resolve(*v)
-                    } else {
-                        format!("{} * {}", fmt_num(*c), resolve(*v))
-                    }
-                })
-                .collect();
-            if *constant != 0.0 || parts.is_empty() {
-                parts.push(fmt_num(*constant));
-            }
-            (parts.join(" + "), if parts.len() > 1 { PREC_ADD } else { PREC_MUL })
-        }
-    };
-    if prec < parent_prec { format!("({text})") } else { text }
-}
-
-/// Format a call-like node `name(arg)`.
-fn fmt_call(
-    name: &str,
-    arena: &ExprArena,
-    arg: ExprId,
-    resolve: &impl Fn(VarId) -> String,
-) -> String {
-    format!("{name}({})", render_node(arena, arg, resolve, PREC_ADD))
-}
-
-/// Render an `f64` compactly, used inside term descriptions.
-fn fmt_num(v: f64) -> String {
-    format!("{v}")
 }
 
 #[cfg(test)]

--- a/crates/oximo-expr/src/render.rs
+++ b/crates/oximo-expr/src/render.rs
@@ -35,6 +35,7 @@ pub fn render_expr(arena: &ExprArena, id: ExprId, resolve: &impl Fn(VarId) -> St
 /// - unit magnitudes omitted,
 /// - multiplication implicit,
 /// - the constant last.
+///
 /// An empty expression renders as `0`.
 pub fn render_linear_terms(t: &LinearTerms, resolve: &impl Fn(VarId) -> String) -> String {
     join_parts(&linear_parts(t, resolve))

--- a/crates/oximo-expr/src/render.rs
+++ b/crates/oximo-expr/src/render.rs
@@ -1,0 +1,288 @@
+//! Shared infix rendering of arena expressions.
+//! Used by the public display adapters in `oximo-core` and by
+//! the nonlinear-term error messages ([`describe_nonlinear_term`](crate::describe_nonlinear_term)).
+
+use crate::arena::{ExprArena, ExprId, ExprNode, VarId};
+use crate::linear::{LinearTerms, split_linear};
+
+// Precedence levels for parenthesizing `render_node` output.
+pub(crate) const PREC_ADD: u8 = 1;
+pub(crate) const PREC_MUL: u8 = 2;
+pub(crate) const PREC_UNARY: u8 = 3;
+
+/// One additive summand composed by the sign flag and the unsigned rendering.
+type Part = (bool, String);
+
+/// Render `id` as a canonical infix string, resolving each [`VarId`] to a
+/// display name via `resolve`.
+/// The linear part first, then any nonlinear residual summands.
+/// Signs are folded into the joins, and a value-less expression
+/// is rendered as `0`.
+///
+/// Parameters render as their current arena value.
+pub fn render_expr(arena: &ExprArena, id: ExprId, resolve: &impl Fn(VarId) -> String) -> String {
+    let (lin, residual) = split_linear(arena, id);
+    let mut parts = linear_parts(&lin, resolve);
+    for s in &residual {
+        let prec = if s.neg { PREC_UNARY } else { PREC_ADD };
+        parts.push((s.neg, render_node(arena, s.id, resolve, prec)));
+    }
+    join_parts(&parts)
+}
+
+/// Render a [`LinearTerms`] snapshot by:
+/// - zero coefficients skipped,
+/// - unit magnitudes omitted,
+/// - multiplication implicit,
+/// - the constant last.
+/// An empty expression renders as `0`.
+pub fn render_linear_terms(t: &LinearTerms, resolve: &impl Fn(VarId) -> String) -> String {
+    join_parts(&linear_parts(t, resolve))
+}
+
+/// Split a linear expression into signed summands, ready for [`join_parts`].
+fn linear_parts(t: &LinearTerms, resolve: &impl Fn(VarId) -> String) -> Vec<Part> {
+    let mut parts = Vec::with_capacity(t.coeffs.len() + 1);
+    for (v, c) in &t.coeffs {
+        if *c == 0.0 {
+            continue;
+        }
+        let mag = c.abs();
+        let text = if (mag - 1.0).abs() < f64::EPSILON {
+            resolve(*v)
+        } else {
+            format!("{} {}", fmt_num(mag), resolve(*v))
+        };
+        parts.push((*c < 0.0, text));
+    }
+    if t.constant != 0.0 {
+        parts.push((t.constant < 0.0, fmt_num(t.constant.abs())));
+    }
+    parts
+}
+
+/// Join signed summands sign-aware.
+fn join_parts(parts: &[Part]) -> String {
+    let Some(((first_neg, first), rest)) = parts.split_first() else {
+        return "0".to_string();
+    };
+    let mut out = String::new();
+    if *first_neg {
+        out.push('-');
+    }
+    out.push_str(first);
+    for (neg, text) in rest {
+        out.push_str(if *neg { " - " } else { " + " });
+        out.push_str(text);
+    }
+    out
+}
+
+/// Render an arena node as an infix string. `parent_prec` is the precedence of
+/// the surrounding context.
+pub(crate) fn render_node(
+    arena: &ExprArena,
+    id: ExprId,
+    resolve: &impl Fn(VarId) -> String,
+    parent_prec: u8,
+) -> String {
+    let (text, prec) = match arena.get(id) {
+        ExprNode::Const(c) => (fmt_num(*c), PREC_UNARY),
+        ExprNode::Var(v) => (resolve(*v), PREC_UNARY),
+        ExprNode::Param(p) => (fmt_num(arena.param_value(*p)), PREC_UNARY),
+        ExprNode::Neg(x) => {
+            (format!("-{}", render_node(arena, *x, resolve, PREC_UNARY)), PREC_UNARY)
+        }
+        ExprNode::Add(children) => {
+            let mut parts: Vec<Part> = Vec::with_capacity(children.len());
+            for c in children.iter().copied() {
+                match arena.get(c) {
+                    ExprNode::Neg(inner) => {
+                        parts.push((true, render_node(arena, *inner, resolve, PREC_UNARY)));
+                    }
+                    ExprNode::Const(v) if *v < 0.0 => parts.push((true, fmt_num(-v))),
+                    ExprNode::Linear { coeffs, constant } => parts.extend(linear_parts(
+                        &LinearTerms { coeffs: coeffs.clone(), constant: *constant },
+                        resolve,
+                    )),
+                    _ => parts.push((false, render_node(arena, c, resolve, PREC_ADD))),
+                }
+            }
+            (join_parts(&parts), PREC_ADD)
+        }
+        ExprNode::Mul(children) => {
+            let parts: Vec<String> =
+                children.iter().map(|c| render_node(arena, *c, resolve, PREC_MUL)).collect();
+            (parts.join(" * "), PREC_MUL)
+        }
+        ExprNode::Pow(b, e) => {
+            let base = render_node(arena, *b, resolve, PREC_UNARY);
+            let exp = render_node(arena, *e, resolve, PREC_UNARY);
+            (format!("{base}^{exp}"), PREC_UNARY)
+        }
+        ExprNode::Div(num, den) => {
+            let n = render_node(arena, *num, resolve, PREC_MUL);
+            let d = render_node(arena, *den, resolve, PREC_MUL);
+            (format!("{n} / {d}"), PREC_MUL)
+        }
+        ExprNode::Sin(x) => (fmt_call("sin", arena, *x, resolve), PREC_UNARY),
+        ExprNode::Cos(x) => (fmt_call("cos", arena, *x, resolve), PREC_UNARY),
+        ExprNode::Exp(x) => (fmt_call("exp", arena, *x, resolve), PREC_UNARY),
+        ExprNode::Log(x) => (fmt_call("log", arena, *x, resolve), PREC_UNARY),
+        ExprNode::Abs(x) => (fmt_call("abs", arena, *x, resolve), PREC_UNARY),
+        ExprNode::Linear { coeffs, constant } => {
+            let parts =
+                linear_parts(&LinearTerms { coeffs: coeffs.clone(), constant: *constant }, resolve);
+            // A multi-term or negative-leading sum needs parens inside a product.
+            let prec = match parts.as_slice() {
+                [(false, _)] => PREC_MUL,
+                [] => PREC_UNARY,
+                _ => PREC_ADD,
+            };
+            (join_parts(&parts), prec)
+        }
+    };
+    if prec < parent_prec { format!("({text})") } else { text }
+}
+
+/// Format a call-like node `name(arg)`.
+fn fmt_call(
+    name: &str,
+    arena: &ExprArena,
+    arg: ExprId,
+    resolve: &impl Fn(VarId) -> String,
+) -> String {
+    format!("{name}({})", render_node(arena, arg, resolve, PREC_ADD))
+}
+
+/// Render an `f64` compactly (shortest round-trip).
+pub(crate) fn fmt_num(v: f64) -> String {
+    if v == 0.0 { "0".to_string() } else { format!("{v}") }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arena::{ExprArena, ExprNode, VarId};
+
+    fn names(v: VarId) -> String {
+        match v.0 {
+            0 => "x".to_string(),
+            1 => "y".to_string(),
+            2 => "z".to_string(),
+            n => format!("v{n}"),
+        }
+    }
+
+    fn lt(coeffs: Vec<(u32, f64)>, constant: f64) -> LinearTerms {
+        LinearTerms { coeffs: coeffs.into_iter().map(|(v, c)| (VarId(v), c)).collect(), constant }
+    }
+
+    #[test]
+    fn linear_terms_are_sign_aware() {
+        let t = lt(vec![(0, 1.0), (1, 2.0), (2, -3.0)], 0.0);
+        assert_eq!(render_linear_terms(&t, &names), "x + 2 y - 3 z");
+    }
+
+    #[test]
+    fn leading_negative_and_constant() {
+        let t = lt(vec![(0, -1.0)], 2.0);
+        assert_eq!(render_linear_terms(&t, &names), "-x + 2");
+        let t = lt(vec![(0, 1.0)], -2.5);
+        assert_eq!(render_linear_terms(&t, &names), "x - 2.5");
+    }
+
+    #[test]
+    fn zero_coeffs_skipped_and_empty_is_zero() {
+        let t = lt(vec![(0, 0.0), (1, 1.0)], 0.0);
+        assert_eq!(render_linear_terms(&t, &names), "y");
+        assert_eq!(render_linear_terms(&lt(vec![], 0.0), &names), "0");
+        assert_eq!(render_linear_terms(&lt(vec![], -0.0), &names), "0");
+    }
+
+    #[test]
+    fn constant_only() {
+        assert_eq!(render_linear_terms(&lt(vec![], 5.0), &names), "5");
+        assert_eq!(render_linear_terms(&lt(vec![], -5.0), &names), "-5");
+    }
+
+    #[test]
+    fn expr_linear_and_nonlinear_mix() {
+        let mut arena = ExprArena::new();
+        let x = arena.push(ExprNode::Var(VarId(0)));
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let z = arena.push(ExprNode::Var(VarId(2)));
+        let two = arena.constant(2.0);
+        let two_z = arena.push(ExprNode::Mul(smallvec::smallvec![two, z]));
+        let prod = arena.push(ExprNode::Mul(smallvec::smallvec![x, y]));
+        let sum = arena.push(ExprNode::Add(smallvec::smallvec![two_z, prod]));
+        assert_eq!(render_expr(&arena, sum, &names), "2 z + x * y");
+    }
+
+    #[test]
+    fn expr_negated_residual() {
+        let mut arena = ExprArena::new();
+        let x = arena.push(ExprNode::Var(VarId(0)));
+        let s = arena.push(ExprNode::Sin(x));
+        let neg = arena.push(ExprNode::Neg(s));
+        assert_eq!(render_expr(&arena, neg, &names), "-sin(x)");
+
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let sum = arena.push(ExprNode::Add(smallvec::smallvec![y, neg]));
+        assert_eq!(render_expr(&arena, sum, &names), "y - sin(x)");
+    }
+
+    #[test]
+    fn expr_pure_linear_uses_split() {
+        let mut arena = ExprArena::new();
+        let e = arena.push(ExprNode::Linear {
+            coeffs: vec![(VarId(0), 3.0), (VarId(1), -1.0)],
+            constant: 1.5,
+        });
+        assert_eq!(render_expr(&arena, e, &names), "3 x - y + 1.5");
+    }
+
+    #[test]
+    fn precedence_parenthesizes_sums_in_products() {
+        let mut arena = ExprArena::new();
+        let x = arena.push(ExprNode::Var(VarId(0)));
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let one = arena.constant(1.0);
+        let sum = arena.push(ExprNode::Add(smallvec::smallvec![x, one]));
+        let prod = arena.push(ExprNode::Mul(smallvec::smallvec![sum, y]));
+        assert_eq!(render_expr(&arena, prod, &names), "(x + 1) * y");
+    }
+
+    #[test]
+    fn nested_add_is_sign_aware() {
+        let mut arena = ExprArena::new();
+        let x = arena.push(ExprNode::Var(VarId(0)));
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let prod = arena.push(ExprNode::Mul(smallvec::smallvec![x, y]));
+        let neg_z = arena.push(ExprNode::Linear { coeffs: vec![(VarId(2), -1.0)], constant: 0.0 });
+        let sum = arena.push(ExprNode::Add(smallvec::smallvec![prod, neg_z]));
+        let s = arena.push(ExprNode::Sin(sum));
+        assert_eq!(render_expr(&arena, s, &names), "sin(x * y - z)");
+    }
+
+    #[test]
+    fn linear_node_inside_product_parenthesizes_when_needed() {
+        let mut arena = ExprArena::new();
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let two_x = arena.push(ExprNode::Linear { coeffs: vec![(VarId(0), 2.0)], constant: 0.0 });
+        let prod = arena.push(ExprNode::Mul(smallvec::smallvec![two_x, y]));
+        assert_eq!(render_expr(&arena, prod, &names), "2 x * y");
+
+        let sum = arena.push(ExprNode::Linear { coeffs: vec![(VarId(0), 1.0)], constant: 1.0 });
+        let prod2 = arena.push(ExprNode::Mul(smallvec::smallvec![sum, y]));
+        assert_eq!(render_expr(&arena, prod2, &names), "(x + 1) * y");
+    }
+
+    #[test]
+    fn negative_zero_constant_renders_as_zero() {
+        assert_eq!(fmt_num(-0.0), "0");
+        let mut arena = ExprArena::new();
+        let c = arena.constant(-0.0);
+        assert_eq!(render_expr(&arena, c, &names), "0");
+    }
+}

--- a/crates/oximo-expr/src/render.rs
+++ b/crates/oximo-expr/src/render.rs
@@ -102,6 +102,9 @@ pub(crate) fn render_node(
                         parts.push((true, render_node(arena, *inner, resolve, PREC_UNARY)));
                     }
                     ExprNode::Const(v) if *v < 0.0 => parts.push((true, fmt_num(-v))),
+                    ExprNode::Param(p) if arena.param_value(*p) < 0.0 => {
+                        parts.push((true, fmt_num(-arena.param_value(*p))));
+                    }
                     ExprNode::Linear { coeffs, constant } => parts.extend(linear_parts(
                         &LinearTerms { coeffs: coeffs.clone(), constant: *constant },
                         resolve,
@@ -264,6 +267,20 @@ mod tests {
         let sum = arena.push(ExprNode::Add(smallvec::smallvec![prod, neg_z]));
         let s = arena.push(ExprNode::Sin(sum));
         assert_eq!(render_expr(&arena, s, &names), "sin(x * y - z)");
+    }
+
+    #[test]
+    fn negative_param_in_nonlinear_add_is_sign_aware() {
+        let mut arena = ExprArena::new();
+        let x = arena.push(ExprNode::Var(VarId(0)));
+        let pid = arena.new_param(-3.0);
+        let p = arena.param(pid);
+        let sum = arena.push(ExprNode::Add(smallvec::smallvec![x, p]));
+        let s = arena.push(ExprNode::Sin(sum));
+        assert_eq!(render_expr(&arena, s, &names), "sin(x - 3)");
+
+        arena.set_param_value(pid, 3.0);
+        assert_eq!(render_expr(&arena, s, &names), "sin(x + 3)");
     }
 
     #[test]

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -304,6 +304,32 @@ for i in 0..result.result_count() {
 }
 ```
 
+## Inspecting a model
+
+`Model` implements `Display`, printing the whole model as readable algebra. Adapters give the same rendering for single pieces: `display_constraint`, `display_objective`, `display_expr`, `display_soc`.
+
+```rust
+use oximo::prelude::*;
+
+let m = Model::new("diet");
+variable!(m, x >= 0.0);
+variable!(m, y >= 0.0);
+constraint!(m, c1, x + 2.0 * y <= 14.0);
+objective!(m, Min, 3.0 * x + 4.0 * y);
+
+println!("{m}");
+// Model 'diet' (LP)
+// min 3 x + 4 y
+// s.t.
+//   c1: x + 2 y <= 14
+// vars
+//   x >= 0
+//   y >= 0
+
+let c1 = m.constraint_id("c1").unwrap();
+assert_eq!(m.display_constraint(c1).to_string(), "c1: x + 2 y <= 14");
+```
+
 ## Model export
 
 With the `io` feature (default), you can export models to MPS, LP and NL format for inspection or use with external solvers.

--- a/crates/oximo/tests/display.rs
+++ b/crates/oximo/tests/display.rs
@@ -1,0 +1,69 @@
+//! End-to-end checks of the human-readable model display built through the
+//! macro API.
+
+use oximo::prelude::*;
+
+#[test]
+fn model_display_matches_grammar() {
+    let m = Model::new("diet");
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    constraint!(m, c1, x + 2.0 * y <= 14.0);
+    constraint!(m, c2, 3.0 * x - y >= 0.0);
+    objective!(m, Min, 3.0 * x + 4.0 * y);
+
+    let expected = "Model 'diet' (LP)\n\
+                    min 3 x + 4 y\n\
+                    s.t.\n\
+                    \x20 c1: x + 2 y <= 14\n\
+                    \x20 c2: 3 x - y >= 0\n\
+                    vars\n\
+                    \x20 x >= 0\n\
+                    \x20 y >= 0\n";
+    assert_eq!(m.to_string(), expected);
+}
+
+#[test]
+fn display_covers_range_soc_and_domains() {
+    let m = Model::new("mix");
+    variable!(m, x >= 0.0);
+    variable!(m, y, Bin);
+    variable!(m, t >= 0.0);
+    constraint!(m, band, 1.0 <= x + t <= 4.0);
+    soc_constraint!(m, disk, [x, t] <= x + 1.0);
+    objective!(m, Max, x + y);
+
+    let out = m.to_string();
+    assert!(out.contains("max x + y\n"), "{out}");
+    assert!(out.contains("  band: 1 <= x + t <= 4\n"), "{out}");
+    assert!(out.contains("  disk: ||x, t|| <= x + 1\n"), "{out}");
+    assert!(out.contains("  0 <= y <= 1, binary\n"), "{out}");
+}
+
+#[test]
+fn display_expr_and_constraint_adapters() {
+    let m = Model::new("adapters");
+    variable!(m, x);
+    variable!(m, y);
+    constraint!(m, c, x * y - y <= 3.0);
+    let c = m.constraint_id("c").unwrap();
+    assert_eq!(m.display_constraint(c).to_string(), "c: -y + x * y <= 3");
+    assert_eq!(m.display_expr(2.0 * x - y).to_string(), "2 x - y");
+}
+
+#[test]
+fn params_render_current_binding() {
+    let m = Model::new("params");
+    variable!(m, x >= 0.0);
+    param!(m, price = 4.0);
+    objective!(m, Min, price * x);
+
+    let out = m.to_string();
+    assert!(out.contains("min 4 x\n"), "{out}");
+    assert!(out.contains("params\n  price = 4\n"), "{out}");
+
+    m.set_param(price, 7.5);
+    let out = m.to_string();
+    assert!(out.contains("min 7.5 x\n"), "{out}");
+    assert!(out.contains("params\n  price = 7.5\n"), "{out}");
+}


### PR DESCRIPTION
## Description

This PR implements `Display` for `Model`, printing readable algebra.
We also add adapters `display_expr`/`display_constraint`/`display_objective`/`display_soc` to render single pieces.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)