### PR TITLE
Support Irreducible infeasibility system (IIS) in oximo

### DIFF
--- a/crates/oximo-baron/src/lib.rs
+++ b/crates/oximo-baron/src/lib.rs
@@ -12,7 +12,7 @@ pub use options::BaronOptions;
 pub use translate::solve;
 
 use oximo_core::{Model, ModelKind};
-use oximo_solver::{Solver, SolverError, SolverResult};
+use oximo_solver::{Iis, InfeasibilityDiagnosis, Solver, SolverError, SolverResult};
 
 /// BARON backend. Writes an oximo [`Model`] to a temporary `.bar` file, invokes
 /// the `baron` executable, and parses the result.
@@ -71,5 +71,11 @@ impl Solver for Baron {
 
     fn solve(&mut self, model: &Model, opts: &BaronOptions) -> Result<SolverResult, SolverError> {
         translate::solve(model, opts, self.exec.as_deref())
+    }
+}
+
+impl InfeasibilityDiagnosis for Baron {
+    fn compute_iis(&mut self, model: &Model, opts: &BaronOptions) -> Result<Iis, SolverError> {
+        translate::compute_iis(model, opts, self.exec.as_deref())
     }
 }

--- a/crates/oximo-baron/src/options.rs
+++ b/crates/oximo-baron/src/options.rs
@@ -3,9 +3,6 @@ use std::path::PathBuf;
 
 use oximo_solver::{HasUniversal, UniversalOptions};
 
-// TODO: CompIIS writes IIS to the summary file.
-// oximo emits the option but doesn't parse/return the IIS (temp dir deleted).
-
 /// BARON-specific solver options.
 ///
 /// Universal options (`time_limit`, `threads`, `verbose`) come from the embedded
@@ -265,6 +262,14 @@ impl BaronOptions {
     pub fn raw(mut self, keyword: impl Into<String>, value: impl Into<String>) -> Self {
         self.raw.push((keyword.into(), value.into()));
         self
+    }
+
+    /// Whether `CompIIS` has been set (to any value) via [`comp_iis`](Self::comp_iis)
+    /// or [`raw`](Self::raw). The IIS backend uses this to avoid overriding a
+    /// user-chosen algorithm when it enables IIS search.
+    pub(crate) fn has_comp_iis(&self) -> bool {
+        self.int_opts.iter().any(|(k, _)| *k == "CompIIS")
+            || self.raw.iter().any(|(k, _)| k.eq_ignore_ascii_case("CompIIS"))
     }
 }
 

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -9,8 +9,10 @@ use oximo_core::{
     SocConstraintId, VarId, Variable,
 };
 use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
-use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
-use rustc_hash::FxHashMap;
+use oximo_solver::{
+    Iis, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus, VarBoundKind,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::BaronOptions;
 use crate::options::write_options;
@@ -44,7 +46,83 @@ pub fn solve(
 ) -> Result<SolverResult, SolverError> {
     let sense = model.objective().as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
     let (bar, var_order, con_order, soc_bounds) = build_bar(model, opts)?;
+    let run = run_baron(&bar, opts, exec)?;
+    Ok(parse_solution(
+        &run.tim,
+        &run.res,
+        sense,
+        run.elapsed,
+        run.raw_log,
+        &var_order,
+        &con_order,
+        &soc_bounds,
+    ))
+}
 
+/// Build `model`, run BARON with IIS search enabled, and when BARON reports the
+/// model infeasible, parse the irreducible infeasible subsystem it prints in the
+/// results file.
+///
+/// If the caller has not set `CompIIS`, it is enabled (`CompIIS: 1`). A user-chosen
+/// `CompIIS` algorithm is left untouched.
+///
+/// # Errors
+///
+/// Returns a [`SolverError`] on the same conditions as [`solve`], or when the model is
+/// not infeasible (there is nothing to diagnose).
+///
+/// # Panics
+///
+/// Panics if variable indices overflow `u32`.
+pub fn compute_iis(
+    model: &Model,
+    opts: &BaronOptions,
+    exec: Option<&str>,
+) -> Result<Iis, SolverError> {
+    let iis_opts = if opts.has_comp_iis() { opts.clone() } else { opts.clone().comp_iis(1) };
+    let (bar, _var_order, _con_order, _soc_bounds) = build_bar(model, &iis_opts)?;
+    let run = run_baron(&bar, &iis_opts, exec)?;
+
+    let termination = map_status(&run.res, tim_model_status(&run.tim));
+    if !termination.is_infeasible() {
+        return Err(SolverError::Backend(format!(
+            "cannot compute an IIS: model is not infeasible ({termination:?})"
+        )));
+    }
+
+    let iis = parse_iis(&run.res);
+    if iis.is_empty() {
+        return Err(SolverError::Backend(
+            "BARON reported the model infeasible but emitted no IIS block \
+             (CompIIS may have failed or been unable to isolate a subsystem)"
+                .to_string(),
+        ));
+    }
+    Ok(iis)
+}
+
+/// The text files BARON leaves in its working directory after a run.
+struct BaronRun {
+    /// Contents of the times file (`tim.lst`): the single status line.
+    tim: String,
+    /// Contents of the results file (`res.lst`): the primal/dual blocks and, when
+    /// `CompIIS` is on, the IIS listing.
+    res: String,
+    elapsed: std::time::Duration,
+    /// Captured stdout/stderr, surfaced on failure (`None` when the run succeeded or
+    /// output was streamed in verbose mode).
+    raw_log: Option<String>,
+}
+
+/// Write `bar` to a fresh temp directory, execute BARON, read back its times and
+/// results files, then remove the directory. Shared by [`solve`] and [`compute_iis`].
+///
+/// # Errors
+///
+/// Returns a [`SolverError`] if the temp directory or `.bar` file cannot be written,
+/// the `baron` executable is missing, or BARON produced no times file (a syntax or
+/// license error that never reached the solve).
+fn run_baron(bar: &str, opts: &BaronOptions, exec: Option<&str>) -> Result<BaronRun, SolverError> {
     // - Temp directory. Combine a timestamp with a per-process atomic counter so
     //   concurrent invocations never share a directory.
     let ts = std::time::SystemTime::now()
@@ -56,7 +134,7 @@ pub fn solve(
         .map_err(|e| SolverError::Backend(format!("cannot create temp dir: {e}")))?;
 
     let bar_path = tmp_dir.join(BAR_NAME);
-    fs::write(&bar_path, &bar)
+    fs::write(&bar_path, bar)
         .map_err(|e| SolverError::Backend(format!("cannot write .bar file: {e}")))?;
 
     // - Execute BARON.
@@ -121,11 +199,9 @@ pub fn solve(
     let tim = fs::read_to_string(&tim_path)
         .map_err(|e| SolverError::Backend(format!("cannot read times file: {e}")))?;
     let res = fs::read_to_string(tmp_dir.join(RES_NAME)).unwrap_or_default();
-    let result =
-        parse_solution(&tim, &res, sense, elapsed, raw_log, &var_order, &con_order, &soc_bounds);
 
     let _ = fs::remove_dir_all(&tmp_dir);
-    Ok(result)
+    Ok(BaronRun { tim, res, elapsed, raw_log })
 }
 
 /// Everything `solve` needs from the `.bar` writer: the file text, the
@@ -583,6 +659,13 @@ fn fmt(v: f64) -> String {
 
 /// Parse BARON's times file (`tim.lst`) and results file (`res.lst`).
 ///
+/// Read BARON's model status from the times file (`tim.lst`). The 9th whitespace
+/// token of its single status line. Defaults to `5` (a BARON status oximo maps to an
+/// `Other` termination) when the field is absent or unparseable.
+fn tim_model_status(tim: &str) -> i64 {
+    tim.split_whitespace().nth(8).and_then(|s| s.parse::<i64>().ok()).unwrap_or(5)
+}
+
 /// The times file is a single whitespace-separated line. Field positions follow
 /// the BARON convention (0-indexed here):
 /// `[5]` lower bound, `[6]` upper bound, `[8]` model status, `[10]`
@@ -604,7 +687,7 @@ fn parse_solution(
     let int_at = |i: usize| tokens.get(i).and_then(|s| s.parse::<i64>().ok());
     let float_at = |i: usize| tokens.get(i).and_then(|s| parse_baron_float(s));
 
-    let model_status = int_at(8).unwrap_or(5);
+    let model_status = tim_model_status(tim);
     let lower = float_at(5);
     let upper = float_at(6);
     let iterations = int_at(10).and_then(|n| u64::try_from(n).ok()).unwrap_or(0);
@@ -944,6 +1027,86 @@ fn parse_best_table(res: &str) -> Option<SolutionPoint> {
         }
     }
     (!primal.is_empty() || objective.is_some()).then_some(SolutionPoint { primal, objective })
+}
+
+/// Parse BARON's IIS listing from the results file (`res.lst`).
+///
+/// For an infeasible model solved with `CompIIS`, BARON prints:
+///
+/// ```text
+///  IIS contains 1 row and 2 columns as follows:
+///   c0   Upper
+///   x0   Lower
+///   x1   Lower
+/// ```
+///
+/// Each entry is `<name>   <side>`. Names follow the writer's convention
+/// ([`write_equations`]/[`write_var_section`]). `c{n}`/`c{n}_lo`/`c{n}_hi` are
+/// constraint rows, `soc{n}`/`soc{n}_sign` are SOC rows, and `x{n}` are variable
+/// columns whose `side` (`Lower`/`Upper`) selects the bound. Row entries carry a side
+/// too, but it is informational. Returns an empty [`Iis`] when no IIS block is present.
+///
+/// The banner is matched on `"IS contains"` so both `"IIS contains ..."` (a proven
+/// irreducible set) and `"(I)IS contains ..."` (BARON's label when irreducibility
+/// cannot be guaranteed) are handled.
+fn parse_iis(res: &str) -> Iis {
+    let mut iis = Iis::default();
+    let Some(pos) = res.find("IS contains") else {
+        return iis;
+    };
+    let start = res[pos..].find("as follows:").map_or(res.len(), |a| pos + a + "as follows:".len());
+
+    let mut seen_con: FxHashSet<u32> = FxHashSet::default();
+    let mut seen_soc: FxHashSet<u32> = FxHashSet::default();
+    let mut started = false;
+    for line in res[start..].lines() {
+        let t = line.trim();
+        if t.is_empty() {
+            if started {
+                break;
+            }
+            continue;
+        }
+        if t.starts_with("***") {
+            break;
+        }
+        let mut parts = t.split_whitespace();
+        let Some(name) = parts.next() else { continue };
+        let side = parts.next();
+        // Classify by name prefix (check `x` and `soc` before the bare `c`).
+        if name.starts_with('x') {
+            if let Some(i) = extract_index(name) {
+                iis.var_bounds.push((VarId(i), side_kind(side)));
+                started = true;
+            }
+        } else if name.starts_with("soc") {
+            if let Some(i) = extract_index(name) {
+                if seen_soc.insert(i) {
+                    iis.soc_constraints.push(SocConstraintId(i));
+                }
+                started = true;
+            }
+        } else if name.starts_with('c') {
+            if let Some(i) = extract_index(name) {
+                if seen_con.insert(i) {
+                    iis.constraints.push(ConstraintId(i));
+                }
+                started = true;
+            }
+        } else if started {
+            break;
+        }
+    }
+    iis
+}
+
+/// Map BARON's IIS bound-side label (`Lower`/`Upper`) to a [`VarBoundKind`],
+/// defaulting to the lower bound for anything unrecognized.
+fn side_kind(side: Option<&str>) -> VarBoundKind {
+    match side {
+        Some(s) if s.eq_ignore_ascii_case("upper") => VarBoundKind::Upper,
+        _ => VarBoundKind::Lower,
+    }
 }
 
 /// Recover the variable index from a synthetic `x{i}` name by reading its digits.
@@ -1491,6 +1654,69 @@ The above solution has an objective value of:  0.0
         assert_eq!(r.reduced_costs.get(&VarId(1)), Some(&1.5));
         assert_eq!(r.dual.get(&ConstraintId(0)), Some(&-3.0));
         assert_eq!(r.dual.len(), 1);
+    }
+
+    #[test]
+    fn parse_iis_extracts_rows_and_columns() {
+        // Captured from a real BARON run (CompIIS: 1) on an infeasible model.
+        let res = "\
+ >>> Problem solved during preprocessing
+ Lower bound is   infinity
+ IIS contains 1 row and 2 columns as follows:
+  c0   Upper
+  x0   Lower
+  x1   Lower
+
+
+                         *** Normal completion ***
+";
+        let iis = parse_iis(res);
+        assert_eq!(iis.constraints, vec![ConstraintId(0)]);
+        assert!(iis.soc_constraints.is_empty());
+        assert_eq!(
+            iis.var_bounds,
+            vec![(VarId(0), VarBoundKind::Lower), (VarId(1), VarBoundKind::Lower)]
+        );
+    }
+
+    #[test]
+    fn parse_iis_maps_ranges_and_socs_and_dedups() {
+        let res = "\
+ IIS contains 3 rows and 1 column as follows:
+  c2_lo   Lower
+  c2_hi   Upper
+  soc0   Upper
+  soc0_sign   Lower
+  x5   Upper
+";
+        let iis = parse_iis(res);
+        assert_eq!(iis.constraints, vec![ConstraintId(2)]);
+        assert_eq!(iis.soc_constraints, vec![SocConstraintId(0)]);
+        assert_eq!(iis.var_bounds, vec![(VarId(5), VarBoundKind::Upper)]);
+    }
+
+    #[test]
+    fn parse_iis_handles_non_guaranteed_banner() {
+        let res = "\
+ >>> Problem solved during preprocessing
+ Lower bound is   infinity
+ Irreducibility of the IS provided cannot be guaranteed
+ (I)IS contains 2 rows and 0 columns as follows:
+  c0   Lower
+  c1   Upper
+
+
+                         *** Normal completion ***
+";
+        let iis = parse_iis(res);
+        assert_eq!(iis.constraints, vec![ConstraintId(0), ConstraintId(1)]);
+        assert!(iis.var_bounds.is_empty());
+    }
+
+    #[test]
+    fn parse_iis_absent_block_is_empty() {
+        let res = "*** Normal completion ***\nThe best solution found is:\n";
+        assert!(parse_iis(res).is_empty());
     }
 
     #[test]

--- a/crates/oximo-gurobi/src/lib.rs
+++ b/crates/oximo-gurobi/src/lib.rs
@@ -11,7 +11,9 @@ pub use persistent::GurobiPersistent;
 pub use translate::solve;
 
 use oximo_core::{Model, ModelKind};
-use oximo_solver::{PersistentSolver, Solver, SolverError, SolverResult};
+use oximo_solver::{
+    Iis, InfeasibilityDiagnosis, PersistentSolver, Solver, SolverError, SolverResult,
+};
 
 /// Gurobi solver handle.
 ///
@@ -65,5 +67,11 @@ impl PersistentSolver for Gurobi {
 
     fn persistent(&self) -> GurobiPersistent {
         GurobiPersistent::new()
+    }
+}
+
+impl InfeasibilityDiagnosis for Gurobi {
+    fn compute_iis(&mut self, model: &Model, opts: &GurobiOptions) -> Result<Iis, SolverError> {
+        translate::compute_iis(model, opts)
     }
 }

--- a/crates/oximo-gurobi/src/persistent.rs
+++ b/crates/oximo-gurobi/src/persistent.rs
@@ -1,10 +1,10 @@
 use grb::prelude::*;
 use oximo_core::{Model, ModelKind};
-use oximo_solver::{Snapshot, Solver, SolverError, SolverResult, snapshot};
+use oximo_solver::{Iis, Snapshot, Solver, SolverError, SolverResult, snapshot};
 
 use crate::GurobiOptions;
 use crate::options::apply as apply_options;
-use crate::translate::{Built, build, default_env, map_grb_err, run_and_collect};
+use crate::translate::{Built, build, compute_iis_resident, default_env, map_grb_err, run_and_collect};
 
 /// The resident Gurobi model plus the baseline snapshot the fast path diffs against
 /// (`None` when the fast path is ineligible).
@@ -51,6 +51,32 @@ impl GurobiPersistent {
     /// scratch, clearing any solver options carried on the Gurobi instance.
     pub fn reset(&mut self) {
         self.state = None;
+    }
+
+    /// Compute an irreducible infeasible subsystem for the resident model, reusing the
+    /// build and solve from the previous [`solve`](Solver::solve).
+    ///
+    /// Call this after a [`solve`](Solver::solve) that returned an infeasible status
+    /// (see [`TerminationStatus::is_infeasible`](oximo_solver::TerminationStatus::is_infeasible)).
+    /// It runs Gurobi's `computeIIS` directly on the resident instance. If the prior
+    /// solve left the ambiguous `INF_OR_UNBD` status, it re-optimizes with dual
+    /// reductions off to get a definite verdict first.
+    ///
+    /// For a one-shot diagnosis that builds and solves in a single call, use
+    /// [`Gurobi::compute_iis`](oximo_solver::InfeasibilityDiagnosis::compute_iis) instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SolverError`] if there is no resident model (never solved, or a
+    /// prior solve failed and cleared it), the resident model is not infeasible, or
+    /// Gurobi errors during the IIS computation.
+    pub fn compute_iis(&mut self) -> Result<Iis, SolverError> {
+        let st = self.state.as_mut().ok_or_else(|| {
+            SolverError::Backend(
+                "no resident model to diagnose; call solve first (it must be infeasible)".into(),
+            )
+        })?;
+        compute_iis_resident(&mut st.built)
     }
 
     /// Discard any resident instance and rebuild from the current model state.

--- a/crates/oximo-gurobi/src/persistent.rs
+++ b/crates/oximo-gurobi/src/persistent.rs
@@ -4,7 +4,9 @@ use oximo_solver::{Iis, Snapshot, Solver, SolverError, SolverResult, snapshot};
 
 use crate::GurobiOptions;
 use crate::options::apply as apply_options;
-use crate::translate::{Built, build, compute_iis_resident, default_env, map_grb_err, run_and_collect};
+use crate::translate::{
+    Built, build, compute_iis_resident, default_env, map_grb_err, run_and_collect,
+};
 
 /// The resident Gurobi model plus the baseline snapshot the fast path diffs against
 /// (`None` when the fast path is ineligible).

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -186,8 +186,34 @@ pub fn compute_iis(model: &Model, opts: &GurobiOptions) -> Result<Iis, SolverErr
     // unbounded model.
     built.model.set_param(grb::param::DualReductions, 0).map_err(map_grb_err)?;
     built.model.optimize().map_err(map_grb_err)?;
+    compute_iis_resident(&mut built)
+}
 
-    let termination = map_status(&built.model)?;
+/// Run Gurobi's `computeIIS` on an already-optimized [`Built`] and read the IIS
+/// membership back. Shared by the one-shot [`compute_iis`] and the persistent handle.
+///
+/// If the last optimize left the ambiguous `INF_OR_UNBD` status (the standalone path
+/// forces `DualReductions` off up front, but a persistent handle's prior `solve` may
+/// not have), this turns `DualReductions` off and re-optimizes to get a definite
+/// verdict first, since Gurobi's `computeIIS` requires a proven-infeasible model.
+///
+/// # Errors
+///
+/// Returns a [`SolverError`] if the model is not infeasible or Gurobi errors
+/// during IIS computation.
+///
+/// # Panics
+///
+/// Panics if a constraint, SOC, or variable index overflows `u32`.
+pub(crate) fn compute_iis_resident(built: &mut Built) -> Result<Iis, SolverError> {
+    let mut termination = map_status(&built.model)?;
+    if matches!(termination, TerminationStatus::InfeasibleOrUnbounded) {
+        // Dual reductions can leave "infeasible or unbounded".
+        // Turn them off and re-optimize so we know it is genuinely infeasible.
+        built.model.set_param(grb::param::DualReductions, 0).map_err(map_grb_err)?;
+        built.model.optimize().map_err(map_grb_err)?;
+        termination = map_status(&built.model)?;
+    }
     if !termination.is_infeasible() {
         return Err(SolverError::Backend(format!(
             "cannot compute an IIS: model is not infeasible ({termination:?})"
@@ -195,7 +221,7 @@ pub fn compute_iis(model: &Model, opts: &GurobiOptions) -> Result<Iis, SolverErr
     }
 
     built.model.compute_iis().map_err(map_grb_err)?;
-    read_iis(&built)
+    read_iis(built)
 }
 
 /// Read the IIS membership attributes off a model on which `computeIIS` has already

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -7,7 +7,9 @@ use oximo_core::{
     SocConstraintId, VarId, Variable, var_name,
 };
 use oximo_expr::{ExprArena, ExprId, LinearTerms, describe_nonlinear_term, extract_linear};
-use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
+use oximo_solver::{
+    Iis, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus, VarBoundKind,
+};
 use rustc_hash::FxHashMap;
 
 use crate::GurobiOptions;
@@ -161,6 +163,79 @@ pub(crate) fn run_and_collect(
         raw_log: None,
         solver_name: Some(crate::NAME.into()),
     })
+}
+
+/// Build `model`, solve it, and when Gurobi finds it infeasible compute an
+/// irreducible infeasible subsystem via Gurobi's `computeIIS`.
+///
+/// `DualReductions` is turned off so an ambiguous "infeasible or unbounded" presolve
+/// outcome is resolved to a definite status before the IIS is requested.
+///
+/// # Errors
+///
+/// Returns a [`SolverError`] if the model is unsupported, Gurobi errors during setup
+/// or optimization, or the model is not infeasible.
+///
+/// # Panics
+///
+/// Panics if a constraint, SOC, or variable index overflows `u32`.
+pub fn compute_iis(model: &Model, opts: &GurobiOptions) -> Result<Iis, SolverError> {
+    let env = default_env()?;
+    let mut built = build(model, opts, &env)?;
+    // Force a definite Infeasible/Unbounded verdict so we don't ask for an IIS on an
+    // unbounded model.
+    built.model.set_param(grb::param::DualReductions, 0).map_err(map_grb_err)?;
+    built.model.optimize().map_err(map_grb_err)?;
+
+    let termination = map_status(&built.model)?;
+    if !termination.is_infeasible() {
+        return Err(SolverError::Backend(format!(
+            "cannot compute an IIS: model is not infeasible ({termination:?})"
+        )));
+    }
+
+    built.model.compute_iis().map_err(map_grb_err)?;
+    read_iis(&built)
+}
+
+/// Read the IIS membership attributes off a model on which `computeIIS` has already
+/// run, mapping Gurobi's per-row and per-column flags back to oximo ids through the
+/// 1:1 handle vectors on [`Built`].
+fn read_iis(built: &Built) -> Result<Iis, SolverError> {
+    let model = &built.model;
+    let mut iis = Iis::default();
+
+    for (i, row) in built.constrs.iter().enumerate() {
+        let in_iis = match row {
+            GrbRow::Lin(c) => model.get_obj_attr(attr::IISConstr, c),
+            GrbRow::Quad(q) => model.get_obj_attr(attr::IISQConstr, q),
+        }
+        .map_err(map_grb_err)?;
+        if in_iis != 0 {
+            iis.constraints
+                .push(ConstraintId(u32::try_from(i).expect("constraint index fits u32")));
+        }
+    }
+
+    for (i, (qrow, _)) in built.soc_rows.iter().enumerate() {
+        if model.get_obj_attr(attr::IISQConstr, qrow).map_err(map_grb_err)? != 0 {
+            iis.soc_constraints
+                .push(SocConstraintId(u32::try_from(i).expect("soc index fits u32")));
+        }
+    }
+
+    // Only model variables are scanned.
+    for (i, v) in built.vars.iter().enumerate() {
+        let id = VarId(u32::try_from(i).expect("var index fits u32"));
+        if model.get_obj_attr(attr::IISLB, v).map_err(map_grb_err)? != 0 {
+            iis.var_bounds.push((id, VarBoundKind::Lower));
+        }
+        if model.get_obj_attr(attr::IISUB, v).map_err(map_grb_err)? != 0 {
+            iis.var_bounds.push((id, VarBoundKind::Upper));
+        }
+    }
+
+    Ok(iis)
 }
 
 /// Add one Gurobi variable per model variable, in `VarId` order, applying its

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -208,11 +208,17 @@ pub fn compute_iis(model: &Model, opts: &GurobiOptions) -> Result<Iis, SolverErr
 pub(crate) fn compute_iis_resident(built: &mut Built) -> Result<Iis, SolverError> {
     let mut termination = map_status(&built.model)?;
     if matches!(termination, TerminationStatus::InfeasibleOrUnbounded) {
-        // Dual reductions can leave "infeasible or unbounded".
-        // Turn them off and re-optimize so we know it is genuinely infeasible.
+        // Dual reductions can leave "infeasible or unbounded". Turn them off just
+        // for a disambiguating re-optimize, then restore the saved value so the
+        // resident model's parameter state is unchanged for later solves.
+        let saved = built.model.get_param(grb::param::DualReductions).map_err(map_grb_err)?;
         built.model.set_param(grb::param::DualReductions, 0).map_err(map_grb_err)?;
-        built.model.optimize().map_err(map_grb_err)?;
-        termination = map_status(&built.model)?;
+        let outcome = (|| {
+            built.model.optimize().map_err(map_grb_err)?;
+            map_status(&built.model)
+        })();
+        built.model.set_param(grb::param::DualReductions, saved).map_err(map_grb_err)?;
+        termination = outcome?;
     }
     if !termination.is_infeasible() {
         return Err(SolverError::Backend(format!(

--- a/crates/oximo-solver/src/infeasibility.rs
+++ b/crates/oximo-solver/src/infeasibility.rs
@@ -1,0 +1,179 @@
+use oximo_core::{ConstraintId, Model, SocConstraintId, VarId};
+
+use crate::result::SolverResult;
+use crate::solver::Solver;
+use crate::status::SolverError;
+
+/// Which side of a variable's bound participates in an infeasibility.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum VarBoundKind {
+    /// The variable's lower bound.
+    Lower,
+    /// The variable's upper bound.
+    Upper,
+}
+
+/// An irreducible infeasible subsystem (IIS).
+///
+/// A minimal set of constraints and variable bounds that together make the model
+/// infeasible. Removing any single member makes the remaining subsystem feasible.
+///
+/// Backends that can diagnose infeasibility return one via
+/// [`InfeasibilityDiagnosis::compute_iis`]. The members are keyed by the same ids the
+/// model assigns ([`ConstraintId`], [`SocConstraintId`], [`VarId`]), so
+/// [`Iis::report`] can name them against the [`Model`].
+#[derive(Clone, Debug, Default)]
+pub struct Iis {
+    /// Algebraic constraints in the IIS.
+    pub constraints: Vec<ConstraintId>,
+    /// Second-order-cone constraints in the IIS.
+    pub soc_constraints: Vec<SocConstraintId>,
+    /// Variable bounds in the IIS, each `(variable, which bound)`.
+    pub var_bounds: Vec<(VarId, VarBoundKind)>,
+}
+
+impl Iis {
+    /// Whether the IIS carries no members.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.constraints.is_empty() && self.soc_constraints.is_empty() && self.var_bounds.is_empty()
+    }
+
+    /// The total number of members (constraints, SOC constraints, and variable
+    /// bounds) in the IIS.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.constraints.len() + self.soc_constraints.len() + self.var_bounds.len()
+    }
+
+    /// A human-readable, model-aware listing of this IIS.
+    ///
+    /// It names every constraint and variable bound in the subsystem using the
+    /// model's own names. Render with [`ToString::to_string`] or by printing.
+    #[must_use]
+    pub fn report<'a>(&'a self, model: &'a Model) -> IisReport<'a> {
+        IisReport { iis: self, model }
+    }
+}
+
+/// A printable, model-aware listing of an [`Iis`]. Created by [`Iis::report`].
+#[derive(Debug)]
+pub struct IisReport<'a> {
+    iis: &'a Iis,
+    model: &'a Model,
+}
+
+impl std::fmt::Display for IisReport<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let iis = self.iis;
+        let m = self.model;
+
+        writeln!(f, "irreducible infeasible subsystem ({} members)", iis.len())?;
+
+        if !iis.constraints.is_empty() {
+            let cons = m.constraints();
+            writeln!(f, "\nconstraints ({})", iis.constraints.len())?;
+            for id in &iis.constraints {
+                match cons.get(id.index()) {
+                    Some(c) => writeln!(f, "  {}", c.name)?,
+                    None => writeln!(f, "  <constraint #{}>", id.index())?,
+                }
+            }
+        }
+
+        if !iis.soc_constraints.is_empty() {
+            let socs = m.soc_constraints();
+            writeln!(f, "\nsoc constraints ({})", iis.soc_constraints.len())?;
+            for id in &iis.soc_constraints {
+                match socs.get(id.index()) {
+                    Some(s) => writeln!(f, "  {}", s.name)?,
+                    None => writeln!(f, "  <soc #{}>", id.index())?,
+                }
+            }
+        }
+
+        if !iis.var_bounds.is_empty() {
+            let vars = m.variables();
+            writeln!(f, "\nvariable bounds ({})", iis.var_bounds.len())?;
+            for (id, kind) in &iis.var_bounds {
+                let side = match kind {
+                    VarBoundKind::Lower => "lower",
+                    VarBoundKind::Upper => "upper",
+                };
+                match vars.get(id.index()) {
+                    Some(v) => writeln!(f, "  {} ({side} bound)", v.name)?,
+                    None => writeln!(f, "  <var #{}> ({side} bound)", id.index())?,
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A [`Solver`] that can diagnose why a model is infeasible by computing an
+/// irreducible infeasible subsystem ([`Iis`]).
+///
+/// Implemented only by backends whose underlying solver exposes a native IIS/
+/// conflict-refiner options. Solve the model and if infeasible call
+/// [`compute_iis`](InfeasibilityDiagnosis::compute_iis) to get
+/// the minimal conflicting set.
+pub trait InfeasibilityDiagnosis: Solver {
+    /// Compute an irreducible infeasible subsystem for `model`.
+    ///
+    /// The backend solves `model` (with `opts`) and, if it is infeasible, returns the
+    /// minimal set of constraints and variable bounds responsible.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SolverError`] if the solve fails, the backend cannot represent the
+    /// model, or the model is not actually infeasible.
+    fn compute_iis(&mut self, model: &Model, opts: &Self::Options) -> Result<Iis, SolverError>;
+}
+
+/// Helper for backends, whether a [`SolverResult`] indicates the model is infeasible.
+/// Treats the ambiguous `InfeasibleOrUnbounded` as infeasible.
+#[must_use]
+pub fn is_infeasible(result: &SolverResult) -> bool {
+    result.termination.is_infeasible()
+}
+
+#[cfg(test)]
+mod tests {
+    use oximo_core::{constraint, variable};
+
+    use super::*;
+
+    #[test]
+    fn report_names_members() {
+        let m = Model::new("infeas");
+        variable!(m, x >= 0.0);
+        let lo = constraint!(m, floor, x >= 2.0);
+        let hi = constraint!(m, ceil, x <= 1.0);
+
+        let iis = Iis {
+            constraints: vec![lo, hi],
+            soc_constraints: Vec::new(),
+            var_bounds: vec![(x.var_id().unwrap(), VarBoundKind::Lower)],
+        };
+
+        assert_eq!(iis.len(), 3);
+        assert!(!iis.is_empty());
+
+        let out = iis.report(&m).to_string();
+        assert!(out.contains("irreducible infeasible subsystem (3 members)"), "{out}");
+        assert!(out.contains("floor"), "{out}");
+        assert!(out.contains("ceil"), "{out}");
+        assert!(out.contains("x (lower bound)"), "{out}");
+    }
+
+    #[test]
+    fn empty_iis_reports_zero() {
+        let m = Model::new("ok");
+        let iis = Iis::default();
+        assert!(iis.is_empty());
+        assert_eq!(iis.len(), 0);
+        let out = iis.report(&m).to_string();
+        assert!(out.contains("(0 members)"), "{out}");
+    }
+}

--- a/crates/oximo-solver/src/lib.rs
+++ b/crates/oximo-solver/src/lib.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 
 pub mod incremental;
+pub mod infeasibility;
 pub mod options;
 pub mod persistent;
 pub mod result;
@@ -9,6 +10,7 @@ pub mod solver;
 pub mod status;
 
 pub use incremental::{Snapshot, snapshot};
+pub use infeasibility::{Iis, IisReport, InfeasibilityDiagnosis, VarBoundKind, is_infeasible};
 pub use options::{HasUniversal, UniversalOptions, UniversalOptionsExt};
 pub use persistent::PersistentSolver;
 pub use result::{ModelReport, SolutionPoint, SolverResult};

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -48,6 +48,16 @@ impl TerminationStatus {
                 | Self::Interrupted
         )
     }
+
+    /// Whether this status proves the model infeasible, so a conflict/IIS
+    /// diagnosis is meaningful. Treats the ambiguous [`InfeasibleOrUnbounded`]
+    /// as infeasible.
+    ///
+    /// [`InfeasibleOrUnbounded`]: Self::InfeasibleOrUnbounded
+    #[must_use]
+    pub fn is_infeasible(&self) -> bool {
+        matches!(self, Self::Infeasible | Self::InfeasibleOrUnbounded)
+    }
 }
 
 /// The status of the primal point held in a [`crate::SolverResult`].
@@ -185,6 +195,15 @@ mod tests {
                 (true, _) => PrimalStatus::FeasiblePoint,
             };
             assert_eq!(primal, expected, "inferred primal for {t:?}");
+        }
+    }
+
+    #[test]
+    fn is_infeasible_covers_infeasible_and_ambiguous() {
+        use TerminationStatus as T;
+        for t in all_terminations() {
+            let expected = matches!(t, T::Infeasible | T::InfeasibleOrUnbounded);
+            assert_eq!(t.is_infeasible(), expected, "is_infeasible for {t:?}");
         }
     }
 

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -57,8 +57,9 @@ pub mod prelude {
     //! Glob-import target. Brings the modeling and solver surface into scope.
     pub use oximo_core::prelude::*;
     pub use oximo_solver::{
-        HasUniversal, ModelReport, PersistentSolver, PrimalStatus, SolutionPoint, Solver,
-        SolverError, SolverResult, TerminationStatus, UniversalOptions, UniversalOptionsExt,
+        HasUniversal, Iis, IisReport, InfeasibilityDiagnosis, ModelReport, PersistentSolver,
+        PrimalStatus, SolutionPoint, Solver, SolverError, SolverResult, TerminationStatus,
+        UniversalOptions, UniversalOptionsExt, VarBoundKind,
     };
 
     #[cfg(feature = "highs")]

--- a/crates/oximo/tests/solve_baron.rs
+++ b/crates/oximo/tests/solve_baron.rs
@@ -103,3 +103,38 @@ fn baron_soc_dual_matches_norm_form_multiplier() {
     let z0 = r.soc_dual_of(disk).expect("SOC dual missing");
     assert!((z0 - std::f64::consts::SQRT_2).abs() < 1e-3, "z0 = {z0}");
 }
+
+#[test]
+fn baron_iis_pinpoints_conflicting_constraints() {
+    // Infeasible: x >= 2 and x <= 1 cannot both hold. BARON's CompIIS reports the two
+    // conflicting rows. The backend maps them back to their ConstraintIds.
+    let m = Model::new("iis");
+    variable!(m, x >= 0.0);
+    let floor = constraint!(m, floor, x >= 2.0);
+    let ceil = constraint!(m, ceil, x <= 1.0);
+    objective!(m, Min, x);
+
+    let opts = BaronOptions::default().time_limit(Duration::from_secs(30));
+    let iis = Baron::new().compute_iis(&m, &opts).expect("compute_iis");
+    assert!(!iis.is_empty());
+    assert!(iis.constraints.contains(&floor), "floor missing from IIS: {iis:?}");
+    assert!(iis.constraints.contains(&ceil), "ceil missing from IIS: {iis:?}");
+
+    let report = iis.report(&m).to_string();
+    assert!(report.contains("floor") && report.contains("ceil"), "{report}");
+}
+
+#[test]
+fn baron_iis_errors_on_feasible_model() {
+    let m = Model::new("feasible");
+    variable!(m, 0.0 <= x <= 10.0);
+    constraint!(m, c, x <= 5.0);
+    objective!(m, Min, x);
+
+    let opts = BaronOptions::default().time_limit(Duration::from_secs(30));
+    let err = Baron::new().compute_iis(&m, &opts).unwrap_err();
+    match err {
+        SolverError::Backend(msg) => assert!(msg.contains("not infeasible"), "{msg}"),
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+}

--- a/crates/oximo/tests/solve_gurobi.rs
+++ b/crates/oximo/tests/solve_gurobi.rs
@@ -115,3 +115,63 @@ fn gurobi_qcp_duals_skipped_by_default() {
     assert!((result.objective().unwrap() + 2.0).abs() < 1e-5);
     assert!(result.dual.is_empty(), "QCP duals must be empty without .qcp_dual(1)");
 }
+
+#[test]
+fn gurobi_iis_pinpoints_conflicting_constraints() {
+    // Infeasible: x >= 2 and x <= 1 cannot both hold. The unique minimal IIS is the
+    // two conflicting constraints (the x >= 0 bound is not needed).
+    let m = Model::new("iis");
+    variable!(m, x >= 0.0);
+    let floor = constraint!(m, floor, x >= 2.0);
+    let ceil = constraint!(m, ceil, x <= 1.0);
+    objective!(m, Min, x);
+
+    let iis = Gurobi.compute_iis(&m, &GurobiOptions::default()).expect("compute_iis");
+    assert!(!iis.is_empty());
+    assert!(iis.constraints.contains(&floor), "floor missing from IIS: {iis:?}");
+    assert!(iis.constraints.contains(&ceil), "ceil missing from IIS: {iis:?}");
+
+    let report = iis.report(&m).to_string();
+    assert!(report.contains("floor") && report.contains("ceil"), "{report}");
+}
+
+#[test]
+fn gurobi_iis_errors_on_feasible_model() {
+    let m = Model::new("feasible");
+    variable!(m, 0.0 <= x <= 10.0);
+    constraint!(m, c, x <= 5.0);
+    objective!(m, Min, x);
+
+    let err = Gurobi.compute_iis(&m, &GurobiOptions::default()).unwrap_err();
+    match err {
+        SolverError::Backend(msg) => assert!(msg.contains("not infeasible"), "{msg}"),
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+}
+
+#[test]
+fn gurobi_persistent_iis_reuses_resident_model() {
+    let m = Model::new("iis_persist");
+    variable!(m, x >= 0.0);
+    let floor = constraint!(m, floor, x >= 2.0);
+    let ceil = constraint!(m, ceil, x <= 1.0);
+    objective!(m, Min, x);
+
+    let mut h = Gurobi.persistent();
+    let r = h.solve(&m, &GurobiOptions::default()).unwrap();
+    assert!(r.termination.is_infeasible(), "expected infeasible, got {:?}", r.termination);
+
+    let iis = h.compute_iis().expect("compute_iis on resident model");
+    assert!(iis.constraints.contains(&floor), "floor missing from IIS: {iis:?}");
+    assert!(iis.constraints.contains(&ceil), "ceil missing from IIS: {iis:?}");
+}
+
+#[test]
+fn gurobi_persistent_iis_without_solve_errors() {
+    let mut h = Gurobi.persistent();
+    let err = h.compute_iis().unwrap_err();
+    match err {
+        SolverError::Backend(msg) => assert!(msg.contains("no resident model"), "{msg}"),
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for Irreducible Infeasibility System (IIS) in oximo.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)