### PR TITLE
oximo-mosek

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ If you don't have the required setup, you can skip these tests, but they should 
 A reviewer will run these tests manually. -->
 - [ ] `cargo test --features gams` passes (requires GAMS)
 - [ ] `cargo test --features gurobi` passes (requires Gurobi)
+- [ ] `cargo test --features mosek` passes (requires MOSEK)
 - [ ] `cargo test --features baron` passes (requires BARON)
 
 ## Changes Made

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --exclude oximo-gurobi --all-targets -- -D warnings
+      - run: cargo clippy --workspace --exclude oximo-gurobi --exclude oximo-mosek --all-targets -- -D warnings
 
   test:
     name: Cargo test
@@ -45,4 +45,4 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --exclude oximo-gurobi
+      - run: cargo test --workspace --exclude oximo-gurobi --exclude oximo-mosek

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -1139,9 +1148,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -1201,6 +1210,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mosek"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90447bbb12bd401e76c8ee36c6b7ece0de373141ea0156b2eae610b23074ec84"
+dependencies = [
+ "itertools 0.10.5",
+ "libc",
+]
 
 [[package]]
 name = "nano-gemm"
@@ -1461,6 +1480,7 @@ dependencies = [
  "oximo-gurobi",
  "oximo-highs",
  "oximo-io",
+ "oximo-mosek",
  "oximo-pounce",
  "oximo-solver",
 ]
@@ -1578,6 +1598,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.0",
+]
+
+[[package]]
+name = "oximo-mosek"
+version = "0.5.0"
+dependencies = [
+ "mosek",
+ "oximo-core",
+ "oximo-expr",
+ "oximo-solver",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/oximo-highs",
     "crates/oximo-io",
     "crates/oximo-gurobi",
+    "crates/oximo-mosek",
     "crates/oximo-gams",
     "crates/oximo-baron",
     "crates/oximo-clarabel",
@@ -36,6 +37,7 @@ oximo-solver = { path = "crates/oximo-solver", version = "0.5.0" }
 oximo-highs  = { path = "crates/oximo-highs",  version = "0.5.0" }
 oximo-io     = { path = "crates/oximo-io",     version = "0.5.0" }
 oximo-gurobi = { path = "crates/oximo-gurobi", version = "0.5.0" }
+oximo-mosek  = { path = "crates/oximo-mosek",  version = "0.5.0" }
 oximo-gams   = { path = "crates/oximo-gams",   version = "0.5.0" }
 oximo-baron  = { path = "crates/oximo-baron",  version = "0.5.0" }
 oximo-clarabel = { path = "crates/oximo-clarabel", version = "0.5.0" }
@@ -55,6 +57,7 @@ thiserror        = "2.0"
 num-traits       = "0.2"
 highs            = "2.4"
 grb              = "3.0"    
+mosek            = "11.2"
 clarabel         = "0.11"
 pounce-rs        = "0.8"
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ pub trait Solver {
 | `highs`         | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
 | `io`            | NL, MPS, and LP file writers                                 | yes     |
 | `gurobi`        | Gurobi solver (requires licensed install)                    | no      |
+| `mosek`         | MOSEK 11.2 - convex LP/MIP/QP/QCP/SOCP solver                | no      |
 | `gams`          | GAMS bridge - solve type depends on the selected sub-solver  | no      |
 | `baron`         | BARON - Global non-convex solver (requires licensed install) | no      |
 | `clarabel`      | Clarabel - LP/QP/SOCP conic solver (pure Rust, no install)   | no      |
@@ -261,6 +262,7 @@ for i in 0..result.result_count() {
 | `oximo-io`       | MPS, LP and NL writers                                    |
 | `oximo-highs`    | HiGHS backend                                             |
 | `oximo-gurobi`   | Gurobi backend                                            |
+| `oximo-mosek`    | MOSEK 11.2 backend                                       |
 | `oximo-gams`     | GAMS writer and backend                                   |
 | `oximo-baron`    | BARON writer and backend                                  |
 | `oximo-clarabel` | Clarabel backend                                          |
@@ -269,6 +271,7 @@ for i in 0..result.result_count() {
 ## Requirements
 
 - Gurobi feature: Gurobi, `GUROBI_HOME` set, valid license
+- MOSEK feature: MOSEK 11.2, `MOSEK_BINDIR_112` if needed, valid license
 - GAMS feature: GAMS on `PATH`, valid license
 - BARON feature: BARON on `PATH`, valid license
 

--- a/crates/oximo-mosek/Cargo.toml
+++ b/crates/oximo-mosek/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "MOSEK backend for oximo"
+readme = "README.md"
 
 [dependencies]
 mosek.workspace = true

--- a/crates/oximo-mosek/Cargo.toml
+++ b/crates/oximo-mosek/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "oximo-mosek"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "MOSEK backend for oximo"
+
+[dependencies]
+mosek.workspace = true
+oximo-expr.workspace = true
+oximo-core.workspace = true
+oximo-solver.workspace = true
+rustc-hash.workspace = true
+
+[lints]
+workspace = true

--- a/crates/oximo-mosek/README.md
+++ b/crates/oximo-mosek/README.md
@@ -1,0 +1,68 @@
+# oximo-mosek
+
+[MOSEK](https://www.mosek.com/) 11.2 backend for [oximo](https://crates.io/crates/oximo).
+
+This backend supports LP, MILP, convex QP/MIQP, convex QCP/MIQCP, and
+SOCP/MISOCP models. MOSEK validates convexity.
+
+Install [MOSEK 11.2](https://www.mosek.com/downloads/), configure a valid license, and point `MOSEK_BINDIR_112` at
+the platform `bin` directory when it is not in MOSEK's default location.
+
+## Supported model kinds
+
+| Kind             | Support                                                                       |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `LP`, `MILP`     | Yes                                                                           |
+| `QP`, `MIQP`     | Yes when the objective is convex for minimization or concave for maximization |
+| `QCP`, `MIQCP`   | Yes when the quadratic rows and objective satisfy MOSEK's convexity rules     |
+| `SOCP`, `MISOCP` | Yes, for explicit oximo cones and detected diagonal quadratic cones           |
+
+Quadratic expressions use MOSEK's lower-triangular `0.5 x'Qx` convention.
+Indefinite and otherwise nonconvex data is sent to MOSEK and its native
+validation message is returned as a backend error.
+
+```toml
+[dependencies]
+oximo = { version = "0.5", features = ["mosek"] }
+
+# Optional when using MOSEK enumeration constants in option builders:
+mosek = "11.2"
+```
+
+```rust,ignore
+use oximo::prelude::*;
+use oximo::solvers::Mosek;
+
+let model = Model::new("example");
+variable!(model, x >= 0.0);
+objective!(model, Min, x);
+
+let options = MosekOptions::default()
+    .mio_tol_rel_gap(1e-4)
+    .presolve_use(mosek::Presolvemode::ON)
+    .optimizer(mosek::Optimizertype::FREE)
+    .remote_optserver_host("server.example.com");
+let result = Mosek.solve(&model, &options)?;
+# Ok::<(), SolverError>(())
+```
+
+Universal `time_limit`, `threads`, and `verbose` options are applied first.
+MOSEK-specific parameter builders are applied afterward in call order, so the
+last backend-specific write wins. Results include a primal point and objective,
+continuous duals and reduced costs, explicit SOC bound duals, MIP bound and
+relative gap, iteration counts, solve time, and the solver name when available.
+`raw_log` and solution pools are not populated.
+
+`Mosek` also implements `PersistentSolver`. Its persistent handle updates linear
+objective coefficients, objective constants, and variable bounds in place for
+LP/MILP models, allowing MOSEK to reuse warm-start information. Other model
+changes, and all quadratic or conic models for now, rebuild transparently.
+
+Every MOSEK 11.2 `Dparam`, `Iparam`, and `Sparam` has a snake-case builder.
+Double builders accept `f64`, integer builders accept `i32`, and string builders
+accept `impl Into<String>`. MOSEK enumeration constants can be passed directly
+to integer builders. Repeated calls are preserved and applied in order.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/oximo-mosek/src/lib.rs
+++ b/crates/oximo-mosek/src/lib.rs
@@ -1,0 +1,47 @@
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+
+mod options;
+mod translate;
+
+pub use options::MosekOptions;
+pub use translate::solve;
+
+use oximo_core::{Model, ModelKind};
+use oximo_solver::{Solver, SolverError, SolverResult};
+
+/// MOSEK solver backend.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Mosek;
+
+pub(crate) const NAME: &str = "MOSEK";
+
+pub(crate) const fn supported(kind: ModelKind) -> bool {
+    matches!(
+        kind,
+        ModelKind::LP
+            | ModelKind::MILP
+            | ModelKind::QP
+            | ModelKind::MIQP
+            | ModelKind::QCP
+            | ModelKind::MIQCP
+            | ModelKind::SOCP
+            | ModelKind::MISOCP
+    )
+}
+
+impl Solver for Mosek {
+    type Options = MosekOptions;
+
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn supports(&self, kind: ModelKind) -> bool {
+        supported(kind)
+    }
+
+    fn solve(&mut self, model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
+        translate::solve(model, opts)
+    }
+}

--- a/crates/oximo-mosek/src/lib.rs
+++ b/crates/oximo-mosek/src/lib.rs
@@ -2,13 +2,15 @@
 #![forbid(unsafe_code)]
 
 mod options;
+mod persistent;
 mod translate;
 
 pub use options::MosekOptions;
+pub use persistent::MosekPersistent;
 pub use translate::solve;
 
 use oximo_core::{Model, ModelKind};
-use oximo_solver::{Solver, SolverError, SolverResult};
+use oximo_solver::{PersistentSolver, Solver, SolverError, SolverResult};
 
 /// MOSEK solver backend.
 #[derive(Debug, Default, Clone, Copy)]
@@ -43,5 +45,13 @@ impl Solver for Mosek {
 
     fn solve(&mut self, model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
         translate::solve(model, opts)
+    }
+}
+
+impl PersistentSolver for Mosek {
+    type Handle = MosekPersistent;
+
+    fn persistent(&self) -> MosekPersistent {
+        MosekPersistent::new()
     }
 }

--- a/crates/oximo-mosek/src/options.rs
+++ b/crates/oximo-mosek/src/options.rs
@@ -414,18 +414,34 @@ mod tests {
         assert_eq!(ids, (0..expected).collect::<Vec<_>>());
     }
 
+    fn integer_parameter_count(linked_count: i32) -> Result<i32, String> {
+        match linked_count {
+            189 => Ok(linked_count),
+            // MOSEK 11.2.2 returns 64 for `INT_TYPE`, equal to its
+            // double-parameter count, even though the binding exposes 189
+            // contiguous `Iparam` values.
+            64 => Ok(189),
+            other => Err(format!("unexpected MOSEK integer parameter count: {other}")),
+        }
+    }
+
+    #[test]
+    fn integer_parameter_count_handles_native_and_compatibility_reports() {
+        assert_eq!(integer_parameter_count(189), Ok(189));
+        assert_eq!(integer_parameter_count(64), Ok(189));
+        assert!(integer_parameter_count(188).is_err());
+    }
+
     #[test]
     fn complete_parameter_catalog_matches_linked_library() {
         let task = Task::new().expect("create MOSEK task");
         let nd = task.get_num_param(Parametertype::DOU_TYPE).unwrap();
         let linked_ni = task.get_num_param(Parametertype::INT_TYPE).unwrap();
         let ns = task.get_num_param(Parametertype::STR_TYPE).unwrap();
-        assert!(matches!(linked_ni, 64 | 189));
-        let ni = 189;
+        let ni = integer_parameter_count(linked_ni).unwrap();
         assert_catalog(MosekOptions::DOUBLE_PARAM_IDS, nd);
         assert_catalog(MosekOptions::INT_PARAM_IDS, ni);
         assert_catalog(MosekOptions::STRING_PARAM_IDS, ns);
-        assert_eq!(nd + ni + ns, 277);
     }
 
     #[test]

--- a/crates/oximo-mosek/src/options.rs
+++ b/crates/oximo-mosek/src/options.rs
@@ -1,4 +1,4 @@
-use mosek::{Dparam, Iparam, Sparam, Task};
+use mosek::{Dparam, Iparam, Sparam, TaskCB};
 use oximo_solver::{HasUniversal, SolverError, UniversalOptions};
 
 /// MOSEK-specific solver options.
@@ -369,7 +369,8 @@ impl MosekOptions {
         (str, stat_name, STAT_NAME),
     );
 
-    pub(crate) fn apply(&self, task: &mut Task) -> Result<(), SolverError> {
+    /// Apply options to a callback-capable MOSEK task.
+    pub(crate) fn apply_cb(&self, task: &mut TaskCB) -> Result<(), SolverError> {
         if let Some(limit) = self.universal.time_limit {
             task.put_dou_param(Dparam::OPTIMIZER_MAX_TIME, limit.as_secs_f64()).map_err(backend)?;
         }
@@ -402,7 +403,7 @@ fn backend(message: String) -> SolverError {
 mod tests {
     use std::collections::HashSet;
 
-    use mosek::Parametertype;
+    use mosek::{Parametertype, Task};
 
     use super::*;
 
@@ -442,8 +443,8 @@ mod tests {
             .log(0)
             .mio_tol_rel_gap(1e-4)
             .remote_optserver_host("example.invalid");
-        let mut task = Task::new().expect("create MOSEK task");
-        opts.apply(&mut task).unwrap();
+        let mut task = Task::new().expect("create MOSEK task").with_callbacks();
+        opts.apply_cb(&mut task).unwrap();
         assert!(
             (task.get_dou_param(Dparam::OPTIMIZER_MAX_TIME).unwrap() - 3.5).abs() < f64::EPSILON
         );

--- a/crates/oximo-mosek/src/options.rs
+++ b/crates/oximo-mosek/src/options.rs
@@ -1,0 +1,473 @@
+use mosek::{Dparam, Iparam, Sparam, Task};
+use oximo_solver::{HasUniversal, SolverError, UniversalOptions};
+
+/// MOSEK-specific solver options.
+///
+/// Universal options are available through
+/// [`UniversalOptionsExt`](oximo_solver::UniversalOptionsExt).
+/// The typed methods below cover every parameter in the MOSEK 11.2
+/// Rust binding.
+#[derive(Clone, Debug, Default)]
+pub struct MosekOptions {
+    pub universal: UniversalOptions,
+    double_params: Vec<(i32, f64)>,
+    int_params: Vec<(i32, i32)>,
+    string_params: Vec<(i32, String)>,
+}
+
+impl HasUniversal for MosekOptions {
+    fn universal(&self) -> &UniversalOptions {
+        &self.universal
+    }
+
+    fn universal_mut(&mut self) -> &mut UniversalOptions {
+        &mut self.universal
+    }
+}
+
+macro_rules! mosek_params {
+    ($(($kind:ident, $method:ident, $variant:ident)),* $(,)?) => {
+        $(mosek_params!(@method $kind, $method, $variant);)*
+        #[cfg(test)]
+        pub(crate) const DOUBLE_PARAM_IDS: &[Option<i32>] =
+            &[$(mosek_params!(@id dbl, $kind, $variant)),*];
+        #[cfg(test)]
+        pub(crate) const INT_PARAM_IDS: &[Option<i32>] =
+            &[$(mosek_params!(@id int, $kind, $variant)),*];
+        #[cfg(test)]
+        pub(crate) const STRING_PARAM_IDS: &[Option<i32>] =
+            &[$(mosek_params!(@id str, $kind, $variant)),*];
+    };
+    (@method dbl, $method:ident, $variant:ident) => {
+        #[doc = concat!(
+            "Sets MOSEK double parameter [`",
+            stringify!($variant),
+            "`](mosek::Dparam::",
+            stringify!($variant),
+            "). The linked constant carries MOSEK's upstream parameter description."
+        )]
+        #[must_use]
+        pub fn $method(mut self, value: f64) -> Self {
+            self.double_params.push((Dparam::$variant, value));
+            self
+        }
+    };
+    (@method int, $method:ident, $variant:ident) => {
+        #[doc = concat!(
+            "Sets MOSEK integer parameter [`",
+            stringify!($variant),
+            "`](mosek::Iparam::",
+            stringify!($variant),
+            "). The linked constant carries MOSEK's upstream parameter description."
+        )]
+        #[must_use]
+        pub fn $method(mut self, value: i32) -> Self {
+            self.int_params.push((Iparam::$variant, value));
+            self
+        }
+    };
+    (@method str, $method:ident, $variant:ident) => {
+        #[doc = concat!(
+            "Sets MOSEK string parameter [`",
+            stringify!($variant),
+            "`](mosek::Sparam::",
+            stringify!($variant),
+            "). The linked constant carries MOSEK's upstream parameter description."
+        )]
+        #[must_use]
+        pub fn $method(mut self, value: impl Into<String>) -> Self {
+            self.string_params.push((Sparam::$variant, value.into()));
+            self
+        }
+    };
+    (@id dbl, dbl, $variant:ident) => { Some(Dparam::$variant) };
+    (@id dbl, $other:ident, $variant:ident) => { None };
+    (@id int, int, $variant:ident) => { Some(Iparam::$variant) };
+    (@id int, $other:ident, $variant:ident) => { None };
+    (@id str, str, $variant:ident) => { Some(Sparam::$variant) };
+    (@id str, $other:ident, $variant:ident) => { None };
+}
+
+impl MosekOptions {
+    mosek_params!(
+        (dbl, ana_sol_infeas_tol, ANA_SOL_INFEAS_TOL),
+        (dbl, basis_rel_tol_s, BASIS_REL_TOL_S),
+        (dbl, basis_tol_s, BASIS_TOL_S),
+        (dbl, basis_tol_x, BASIS_TOL_X),
+        (dbl, data_sym_mat_tol, DATA_SYM_MAT_TOL),
+        (dbl, data_sym_mat_tol_huge, DATA_SYM_MAT_TOL_HUGE),
+        (dbl, data_sym_mat_tol_large, DATA_SYM_MAT_TOL_LARGE),
+        (dbl, data_tol_aij_huge, DATA_TOL_AIJ_HUGE),
+        (dbl, data_tol_aij_large, DATA_TOL_AIJ_LARGE),
+        (dbl, data_tol_bound_inf, DATA_TOL_BOUND_INF),
+        (dbl, data_tol_bound_wrn, DATA_TOL_BOUND_WRN),
+        (dbl, data_tol_c_huge, DATA_TOL_C_HUGE),
+        (dbl, data_tol_cj_large, DATA_TOL_CJ_LARGE),
+        (dbl, data_tol_qij, DATA_TOL_QIJ),
+        (dbl, data_tol_x, DATA_TOL_X),
+        (dbl, folding_tol_eq, FOLDING_TOL_EQ),
+        (dbl, intpnt_co_tol_dfeas, INTPNT_CO_TOL_DFEAS),
+        (dbl, intpnt_co_tol_infeas, INTPNT_CO_TOL_INFEAS),
+        (dbl, intpnt_co_tol_mu_red, INTPNT_CO_TOL_MU_RED),
+        (dbl, intpnt_co_tol_near_rel, INTPNT_CO_TOL_NEAR_REL),
+        (dbl, intpnt_co_tol_pfeas, INTPNT_CO_TOL_PFEAS),
+        (dbl, intpnt_co_tol_rel_gap, INTPNT_CO_TOL_REL_GAP),
+        (dbl, intpnt_qo_tol_dfeas, INTPNT_QO_TOL_DFEAS),
+        (dbl, intpnt_qo_tol_infeas, INTPNT_QO_TOL_INFEAS),
+        (dbl, intpnt_qo_tol_mu_red, INTPNT_QO_TOL_MU_RED),
+        (dbl, intpnt_qo_tol_near_rel, INTPNT_QO_TOL_NEAR_REL),
+        (dbl, intpnt_qo_tol_pfeas, INTPNT_QO_TOL_PFEAS),
+        (dbl, intpnt_qo_tol_rel_gap, INTPNT_QO_TOL_REL_GAP),
+        (dbl, intpnt_tol_dfeas, INTPNT_TOL_DFEAS),
+        (dbl, intpnt_tol_dsafe, INTPNT_TOL_DSAFE),
+        (dbl, intpnt_tol_infeas, INTPNT_TOL_INFEAS),
+        (dbl, intpnt_tol_mu_red, INTPNT_TOL_MU_RED),
+        (dbl, intpnt_tol_path, INTPNT_TOL_PATH),
+        (dbl, intpnt_tol_pfeas, INTPNT_TOL_PFEAS),
+        (dbl, intpnt_tol_psafe, INTPNT_TOL_PSAFE),
+        (dbl, intpnt_tol_rel_gap, INTPNT_TOL_REL_GAP),
+        (dbl, intpnt_tol_rel_step, INTPNT_TOL_REL_STEP),
+        (dbl, intpnt_tol_step_size, INTPNT_TOL_STEP_SIZE),
+        (dbl, lower_obj_cut, LOWER_OBJ_CUT),
+        (dbl, lower_obj_cut_finite_trh, LOWER_OBJ_CUT_FINITE_TRH),
+        (dbl, mio_clique_table_size_factor, MIO_CLIQUE_TABLE_SIZE_FACTOR),
+        (dbl, mio_djc_max_bigm, MIO_DJC_MAX_BIGM),
+        (dbl, mio_max_time, MIO_MAX_TIME),
+        (dbl, mio_rel_gap_const, MIO_REL_GAP_CONST),
+        (dbl, mio_tol_abs_gap, MIO_TOL_ABS_GAP),
+        (dbl, mio_tol_abs_relax_int, MIO_TOL_ABS_RELAX_INT),
+        (dbl, mio_tol_feas, MIO_TOL_FEAS),
+        (dbl, mio_tol_rel_dual_bound_improvement, MIO_TOL_REL_DUAL_BOUND_IMPROVEMENT),
+        (dbl, mio_tol_rel_gap, MIO_TOL_REL_GAP),
+        (dbl, optimizer_max_ticks, OPTIMIZER_MAX_TICKS),
+        (dbl, optimizer_max_time, OPTIMIZER_MAX_TIME),
+        (dbl, presolve_tol_abs_lindep, PRESOLVE_TOL_ABS_LINDEP),
+        (dbl, presolve_tol_primal_infeas_perturbation, PRESOLVE_TOL_PRIMAL_INFEAS_PERTURBATION),
+        (dbl, presolve_tol_rel_lindep, PRESOLVE_TOL_REL_LINDEP),
+        (dbl, presolve_tol_s, PRESOLVE_TOL_S),
+        (dbl, presolve_tol_x, PRESOLVE_TOL_X),
+        (dbl, qcqo_reformulate_rel_drop_tol, QCQO_REFORMULATE_REL_DROP_TOL),
+        (dbl, semidefinite_tol_approx, SEMIDEFINITE_TOL_APPROX),
+        (dbl, sim_lu_tol_rel_piv, SIM_LU_TOL_REL_PIV),
+        (dbl, sim_precision_scaling_extended, SIM_PRECISION_SCALING_EXTENDED),
+        (dbl, sim_precision_scaling_normal, SIM_PRECISION_SCALING_NORMAL),
+        (dbl, simplex_abs_tol_piv, SIMPLEX_ABS_TOL_PIV),
+        (dbl, upper_obj_cut, UPPER_OBJ_CUT),
+        (dbl, upper_obj_cut_finite_trh, UPPER_OBJ_CUT_FINITE_TRH),
+        (int, ana_sol_basis, ANA_SOL_BASIS),
+        (int, ana_sol_print_violated, ANA_SOL_PRINT_VIOLATED),
+        (int, auto_sort_a_before_opt, AUTO_SORT_A_BEFORE_OPT),
+        (int, auto_update_sol_info, AUTO_UPDATE_SOL_INFO),
+        (int, basis_solve_use_plus_one, BASIS_SOLVE_USE_PLUS_ONE),
+        (int, bi_clean_optimizer, BI_CLEAN_OPTIMIZER),
+        (int, bi_ignore_max_iter, BI_IGNORE_MAX_ITER),
+        (int, bi_ignore_num_error, BI_IGNORE_NUM_ERROR),
+        (int, bi_max_iterations, BI_MAX_ITERATIONS),
+        (int, cache_license, CACHE_LICENSE),
+        (int, compress_statfile, COMPRESS_STATFILE),
+        (int, folding_use, FOLDING_USE),
+        (int, getdual_convert_lmis, GETDUAL_CONVERT_LMIS),
+        (int, heartbeat_sim_freq_ticks, HEARTBEAT_SIM_FREQ_TICKS),
+        (int, infeas_generic_names, INFEAS_GENERIC_NAMES),
+        (int, infeas_report_auto, INFEAS_REPORT_AUTO),
+        (int, infeas_report_level, INFEAS_REPORT_LEVEL),
+        (int, intpnt_basis, INTPNT_BASIS),
+        (int, intpnt_diff_step, INTPNT_DIFF_STEP),
+        (int, intpnt_hotstart, INTPNT_HOTSTART),
+        (int, intpnt_max_iterations, INTPNT_MAX_ITERATIONS),
+        (int, intpnt_max_num_cor, INTPNT_MAX_NUM_COR),
+        (int, intpnt_off_col_trh, INTPNT_OFF_COL_TRH),
+        (int, intpnt_order_gp_num_seeds, INTPNT_ORDER_GP_NUM_SEEDS),
+        (int, intpnt_order_method, INTPNT_ORDER_METHOD),
+        (int, intpnt_regularization_use, INTPNT_REGULARIZATION_USE),
+        (int, intpnt_scaling, INTPNT_SCALING),
+        (int, intpnt_solve_form, INTPNT_SOLVE_FORM),
+        (int, intpnt_starting_point, INTPNT_STARTING_POINT),
+        (int, license_debug, LICENSE_DEBUG),
+        (int, license_pause_time, LICENSE_PAUSE_TIME),
+        (int, license_suppress_expire_wrns, LICENSE_SUPPRESS_EXPIRE_WRNS),
+        (int, license_trh_expiry_wrn, LICENSE_TRH_EXPIRY_WRN),
+        (int, license_wait, LICENSE_WAIT),
+        (int, log, LOG),
+        (int, log_ana_pro, LOG_ANA_PRO),
+        (int, log_bi, LOG_BI),
+        (int, log_bi_freq, LOG_BI_FREQ),
+        (int, log_cut_second_opt, LOG_CUT_SECOND_OPT),
+        (int, log_expand, LOG_EXPAND),
+        (int, log_feas_repair, LOG_FEAS_REPAIR),
+        (int, log_file, LOG_FILE),
+        (int, log_include_summary, LOG_INCLUDE_SUMMARY),
+        (int, log_infeas_ana, LOG_INFEAS_ANA),
+        (int, log_intpnt, LOG_INTPNT),
+        (int, log_local_info, LOG_LOCAL_INFO),
+        (int, log_mio, LOG_MIO),
+        (int, log_mio_freq, LOG_MIO_FREQ),
+        (int, log_order, LOG_ORDER),
+        (int, log_presolve, LOG_PRESOLVE),
+        (int, log_sensitivity, LOG_SENSITIVITY),
+        (int, log_sensitivity_opt, LOG_SENSITIVITY_OPT),
+        (int, log_sim, LOG_SIM),
+        (int, log_sim_freq, LOG_SIM_FREQ),
+        (int, log_sim_freq_giga_ticks, LOG_SIM_FREQ_GIGA_TICKS),
+        (int, log_storage, LOG_STORAGE),
+        (int, max_num_warnings, MAX_NUM_WARNINGS),
+        (int, mio_branch_dir, MIO_BRANCH_DIR),
+        (int, mio_conflict_analysis_level, MIO_CONFLICT_ANALYSIS_LEVEL),
+        (int, mio_conic_outer_approximation, MIO_CONIC_OUTER_APPROXIMATION),
+        (int, mio_construct_sol, MIO_CONSTRUCT_SOL),
+        (int, mio_crossover_max_nodes, MIO_CROSSOVER_MAX_NODES),
+        (int, mio_cut_clique, MIO_CUT_CLIQUE),
+        (int, mio_cut_cmir, MIO_CUT_CMIR),
+        (int, mio_cut_gmi, MIO_CUT_GMI),
+        (int, mio_cut_implied_bound, MIO_CUT_IMPLIED_BOUND),
+        (int, mio_cut_knapsack_cover, MIO_CUT_KNAPSACK_COVER),
+        (int, mio_cut_lipro, MIO_CUT_LIPRO),
+        (int, mio_cut_selection_level, MIO_CUT_SELECTION_LEVEL),
+        (int, mio_data_permutation_method, MIO_DATA_PERMUTATION_METHOD),
+        (int, mio_dual_ray_analysis_level, MIO_DUAL_RAY_ANALYSIS_LEVEL),
+        (int, mio_feaspump_level, MIO_FEASPUMP_LEVEL),
+        (int, mio_heuristic_level, MIO_HEURISTIC_LEVEL),
+        (int, mio_independent_block_level, MIO_INDEPENDENT_BLOCK_LEVEL),
+        (int, mio_max_num_branches, MIO_MAX_NUM_BRANCHES),
+        (int, mio_max_num_relaxs, MIO_MAX_NUM_RELAXS),
+        (int, mio_max_num_restarts, MIO_MAX_NUM_RESTARTS),
+        (int, mio_max_num_root_cut_rounds, MIO_MAX_NUM_ROOT_CUT_ROUNDS),
+        (int, mio_max_num_solutions, MIO_MAX_NUM_SOLUTIONS),
+        (int, mio_memory_emphasis_level, MIO_MEMORY_EMPHASIS_LEVEL),
+        (int, mio_min_rel, MIO_MIN_REL),
+        (int, mio_mode, MIO_MODE),
+        (int, mio_node_optimizer, MIO_NODE_OPTIMIZER),
+        (int, mio_node_selection, MIO_NODE_SELECTION),
+        (int, mio_numerical_emphasis_level, MIO_NUMERICAL_EMPHASIS_LEVEL),
+        (int, mio_opt_face_max_nodes, MIO_OPT_FACE_MAX_NODES),
+        (int, mio_perspective_reformulate, MIO_PERSPECTIVE_REFORMULATE),
+        (int, mio_presolve_aggregator_use, MIO_PRESOLVE_AGGREGATOR_USE),
+        (int, mio_probing_level, MIO_PROBING_LEVEL),
+        (int, mio_propagate_objective_constraint, MIO_PROPAGATE_OBJECTIVE_CONSTRAINT),
+        (int, mio_qcqo_reformulation_method, MIO_QCQO_REFORMULATION_METHOD),
+        (int, mio_rens_max_nodes, MIO_RENS_MAX_NODES),
+        (int, mio_rins_max_nodes, MIO_RINS_MAX_NODES),
+        (int, mio_root_optimizer, MIO_ROOT_OPTIMIZER),
+        (int, mio_seed, MIO_SEED),
+        (int, mio_symmetry_level, MIO_SYMMETRY_LEVEL),
+        (int, mio_var_selection, MIO_VAR_SELECTION),
+        (int, mio_vb_detection_level, MIO_VB_DETECTION_LEVEL),
+        (int, mt_spincount, MT_SPINCOUNT),
+        (int, ng, NG),
+        (int, num_threads, NUM_THREADS),
+        (int, opf_write_header, OPF_WRITE_HEADER),
+        (int, opf_write_hints, OPF_WRITE_HINTS),
+        (int, opf_write_line_length, OPF_WRITE_LINE_LENGTH),
+        (int, opf_write_parameters, OPF_WRITE_PARAMETERS),
+        (int, opf_write_problem, OPF_WRITE_PROBLEM),
+        (int, opf_write_sol_bas, OPF_WRITE_SOL_BAS),
+        (int, opf_write_sol_itg, OPF_WRITE_SOL_ITG),
+        (int, opf_write_sol_itr, OPF_WRITE_SOL_ITR),
+        (int, opf_write_solutions, OPF_WRITE_SOLUTIONS),
+        (int, optimizer, OPTIMIZER),
+        (int, param_read_case_name, PARAM_READ_CASE_NAME),
+        (int, param_read_ign_error, PARAM_READ_IGN_ERROR),
+        (int, presolve_eliminator_max_fill, PRESOLVE_ELIMINATOR_MAX_FILL),
+        (int, presolve_eliminator_max_num_tries, PRESOLVE_ELIMINATOR_MAX_NUM_TRIES),
+        (int, presolve_lindep_abs_work_trh, PRESOLVE_LINDEP_ABS_WORK_TRH),
+        (int, presolve_lindep_new, PRESOLVE_LINDEP_NEW),
+        (int, presolve_lindep_rel_work_trh, PRESOLVE_LINDEP_REL_WORK_TRH),
+        (int, presolve_lindep_use, PRESOLVE_LINDEP_USE),
+        (int, presolve_max_num_pass, PRESOLVE_MAX_NUM_PASS),
+        (int, presolve_max_num_reductions, PRESOLVE_MAX_NUM_REDUCTIONS),
+        (int, presolve_use, PRESOLVE_USE),
+        (int, primal_repair_optimizer, PRIMAL_REPAIR_OPTIMIZER),
+        (int, ptf_write_parameters, PTF_WRITE_PARAMETERS),
+        (int, ptf_write_single_psd_terms, PTF_WRITE_SINGLE_PSD_TERMS),
+        (int, ptf_write_solutions, PTF_WRITE_SOLUTIONS),
+        (int, ptf_write_transform, PTF_WRITE_TRANSFORM),
+        (int, read_async, READ_ASYNC),
+        (int, read_debug, READ_DEBUG),
+        (int, read_keep_free_con, READ_KEEP_FREE_CON),
+        (int, read_mps_format, READ_MPS_FORMAT),
+        (int, read_mps_width, READ_MPS_WIDTH),
+        (int, read_task_ignore_param, READ_TASK_IGNORE_PARAM),
+        (int, remote_use_compression, REMOTE_USE_COMPRESSION),
+        (int, remove_unused_solutions, REMOVE_UNUSED_SOLUTIONS),
+        (int, sensitivity_all, SENSITIVITY_ALL),
+        (int, sensitivity_type, SENSITIVITY_TYPE),
+        (int, sim_basis_factor_use, SIM_BASIS_FACTOR_USE),
+        (int, sim_degen, SIM_DEGEN),
+        (int, sim_detect_pwl, SIM_DETECT_PWL),
+        (int, sim_dual_crash, SIM_DUAL_CRASH),
+        (int, sim_dual_phaseone_method, SIM_DUAL_PHASEONE_METHOD),
+        (int, sim_dual_restrict_selection, SIM_DUAL_RESTRICT_SELECTION),
+        (int, sim_dual_selection, SIM_DUAL_SELECTION),
+        (int, sim_exploit_dupvec, SIM_EXPLOIT_DUPVEC),
+        (int, sim_hotstart, SIM_HOTSTART),
+        (int, sim_hotstart_lu, SIM_HOTSTART_LU),
+        (int, sim_max_iterations, SIM_MAX_ITERATIONS),
+        (int, sim_max_num_setbacks, SIM_MAX_NUM_SETBACKS),
+        (int, sim_non_singular, SIM_NON_SINGULAR),
+        (int, sim_precision, SIM_PRECISION),
+        (int, sim_precision_boost, SIM_PRECISION_BOOST),
+        (int, sim_primal_crash, SIM_PRIMAL_CRASH),
+        (int, sim_primal_phaseone_method, SIM_PRIMAL_PHASEONE_METHOD),
+        (int, sim_primal_restrict_selection, SIM_PRIMAL_RESTRICT_SELECTION),
+        (int, sim_primal_selection, SIM_PRIMAL_SELECTION),
+        (int, sim_refactor_freq, SIM_REFACTOR_FREQ),
+        (int, sim_reformulation, SIM_REFORMULATION),
+        (int, sim_save_lu, SIM_SAVE_LU),
+        (int, sim_scaling, SIM_SCALING),
+        (int, sim_scaling_method, SIM_SCALING_METHOD),
+        (int, sim_seed, SIM_SEED),
+        (int, sim_solve_form, SIM_SOLVE_FORM),
+        (int, sim_switch_optimizer, SIM_SWITCH_OPTIMIZER),
+        (int, sol_filter_keep_basic, SOL_FILTER_KEEP_BASIC),
+        (int, sol_read_name_width, SOL_READ_NAME_WIDTH),
+        (int, sol_read_width, SOL_READ_WIDTH),
+        (int, timing_level, TIMING_LEVEL),
+        (int, write_async, WRITE_ASYNC),
+        (int, write_bas_constraints, WRITE_BAS_CONSTRAINTS),
+        (int, write_bas_head, WRITE_BAS_HEAD),
+        (int, write_bas_variables, WRITE_BAS_VARIABLES),
+        (int, write_compression, WRITE_COMPRESSION),
+        (int, write_free_con, WRITE_FREE_CON),
+        (int, write_generic_names, WRITE_GENERIC_NAMES),
+        (int, write_ignore_incompatible_items, WRITE_IGNORE_INCOMPATIBLE_ITEMS),
+        (int, write_int_constraints, WRITE_INT_CONSTRAINTS),
+        (int, write_int_head, WRITE_INT_HEAD),
+        (int, write_int_variables, WRITE_INT_VARIABLES),
+        (int, write_json_indentation, WRITE_JSON_INDENTATION),
+        (int, write_lp_full_obj, WRITE_LP_FULL_OBJ),
+        (int, write_lp_line_width, WRITE_LP_LINE_WIDTH),
+        (int, write_mps_format, WRITE_MPS_FORMAT),
+        (int, write_mps_int, WRITE_MPS_INT),
+        (int, write_sol_barvariables, WRITE_SOL_BARVARIABLES),
+        (int, write_sol_constraints, WRITE_SOL_CONSTRAINTS),
+        (int, write_sol_head, WRITE_SOL_HEAD),
+        (int, write_sol_ignore_invalid_names, WRITE_SOL_IGNORE_INVALID_NAMES),
+        (int, write_sol_variables, WRITE_SOL_VARIABLES),
+        (str, bas_sol_file_name, BAS_SOL_FILE_NAME),
+        (str, data_file_name, DATA_FILE_NAME),
+        (str, debug_file_name, DEBUG_FILE_NAME),
+        (str, int_sol_file_name, INT_SOL_FILE_NAME),
+        (str, itr_sol_file_name, ITR_SOL_FILE_NAME),
+        (str, mio_debug_string, MIO_DEBUG_STRING),
+        (str, param_comment_sign, PARAM_COMMENT_SIGN),
+        (str, param_read_file_name, PARAM_READ_FILE_NAME),
+        (str, param_write_file_name, PARAM_WRITE_FILE_NAME),
+        (str, read_mps_bou_name, READ_MPS_BOU_NAME),
+        (str, read_mps_obj_name, READ_MPS_OBJ_NAME),
+        (str, read_mps_ran_name, READ_MPS_RAN_NAME),
+        (str, read_mps_rhs_name, READ_MPS_RHS_NAME),
+        (str, remote_optserver_host, REMOTE_OPTSERVER_HOST),
+        (str, remote_tls_cert, REMOTE_TLS_CERT),
+        (str, remote_tls_cert_path, REMOTE_TLS_CERT_PATH),
+        (str, sensitivity_file_name, SENSITIVITY_FILE_NAME),
+        (str, sensitivity_res_file_name, SENSITIVITY_RES_FILE_NAME),
+        (str, sol_filter_xc_low, SOL_FILTER_XC_LOW),
+        (str, sol_filter_xc_upr, SOL_FILTER_XC_UPR),
+        (str, sol_filter_xx_low, SOL_FILTER_XX_LOW),
+        (str, sol_filter_xx_upr, SOL_FILTER_XX_UPR),
+        (str, stat_key, STAT_KEY),
+        (str, stat_name, STAT_NAME),
+    );
+
+    pub(crate) fn apply(&self, task: &mut Task) -> Result<(), SolverError> {
+        if let Some(limit) = self.universal.time_limit {
+            task.put_dou_param(Dparam::OPTIMIZER_MAX_TIME, limit.as_secs_f64()).map_err(backend)?;
+        }
+        if let Some(threads) = self.universal.threads {
+            let threads = i32::try_from(threads)
+                .map_err(|_| SolverError::Backend("MOSEK: thread count exceeds i32".into()))?;
+            task.put_int_param(Iparam::NUM_THREADS, threads).map_err(backend)?;
+        }
+        if let Some(verbose) = self.universal.verbose {
+            task.put_int_param(Iparam::LOG, i32::from(verbose)).map_err(backend)?;
+        }
+        for &(param, value) in &self.double_params {
+            task.put_dou_param(param, value).map_err(backend)?;
+        }
+        for &(param, value) in &self.int_params {
+            task.put_int_param(param, value).map_err(backend)?;
+        }
+        for (param, value) in &self.string_params {
+            task.put_str_param(*param, value).map_err(backend)?;
+        }
+        Ok(())
+    }
+}
+
+fn backend(message: String) -> SolverError {
+    SolverError::Backend(format!("MOSEK: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use mosek::Parametertype;
+
+    use super::*;
+
+    fn assert_catalog(catalog: &[Option<i32>], expected: i32) {
+        let ids: Vec<i32> = catalog.iter().flatten().copied().collect();
+        assert_eq!(i32::try_from(ids.len()).unwrap(), expected);
+        assert_eq!(ids.iter().copied().collect::<HashSet<_>>().len(), ids.len());
+        assert_eq!(ids, (0..expected).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn complete_parameter_catalog_matches_linked_library() {
+        let task = Task::new().expect("create MOSEK task");
+        let nd = task.get_num_param(Parametertype::DOU_TYPE).unwrap();
+        let linked_ni = task.get_num_param(Parametertype::INT_TYPE).unwrap();
+        let ns = task.get_num_param(Parametertype::STR_TYPE).unwrap();
+        assert!(matches!(linked_ni, 64 | 189));
+        let ni = 189;
+        assert_catalog(MosekOptions::DOUBLE_PARAM_IDS, nd);
+        assert_catalog(MosekOptions::INT_PARAM_IDS, ni);
+        assert_catalog(MosekOptions::STRING_PARAM_IDS, ns);
+        assert_eq!(nd + ni + ns, 277);
+    }
+
+    #[test]
+    fn universal_and_backend_parameters_apply_in_precedence_order() {
+        use std::time::Duration;
+
+        use oximo_solver::UniversalOptionsExt;
+
+        let opts = MosekOptions::default()
+            .time_limit(Duration::from_secs(7))
+            .threads(2)
+            .verbose(true)
+            .optimizer_max_time(3.5)
+            .num_threads(4)
+            .log(0)
+            .mio_tol_rel_gap(1e-4)
+            .remote_optserver_host("example.invalid");
+        let mut task = Task::new().expect("create MOSEK task");
+        opts.apply(&mut task).unwrap();
+        assert!(
+            (task.get_dou_param(Dparam::OPTIMIZER_MAX_TIME).unwrap() - 3.5).abs() < f64::EPSILON
+        );
+        assert_eq!(task.get_int_param(Iparam::NUM_THREADS).unwrap(), 4);
+        assert_eq!(task.get_int_param(Iparam::LOG).unwrap(), 0);
+        assert!((task.get_dou_param(Dparam::MIO_TOL_REL_GAP).unwrap() - 1e-4).abs() < f64::EPSILON);
+        let mut len = task.get_str_param_len(Sparam::REMOTE_OPTSERVER_HOST).unwrap();
+        assert_eq!(
+            task.get_str_param(Sparam::REMOTE_OPTSERVER_HOST, &mut len).unwrap(),
+            "example.invalid"
+        );
+    }
+
+    #[test]
+    fn repeated_backend_parameter_calls_are_retained() {
+        let opts = MosekOptions::default()
+            .mio_tol_rel_gap(0.1)
+            .mio_tol_rel_gap(0.01)
+            .presolve_use(mosek::Presolvemode::OFF)
+            .optimizer(mosek::Optimizertype::INTPNT);
+        assert_eq!(
+            opts.double_params,
+            vec![(Dparam::MIO_TOL_REL_GAP, 0.1), (Dparam::MIO_TOL_REL_GAP, 0.01)]
+        );
+        assert_eq!(opts.int_params.len(), 2);
+    }
+}

--- a/crates/oximo-mosek/src/persistent.rs
+++ b/crates/oximo-mosek/src/persistent.rs
@@ -1,0 +1,175 @@
+use mosek::{Streamtype, TaskCB};
+use oximo_core::{Model, ModelKind};
+use oximo_solver::{Snapshot, Solver, SolverError, SolverResult, snapshot};
+
+use crate::translate::{Meta, build_task, solve_task};
+use crate::{MosekOptions, NAME};
+
+/// The persistent MOSEK task and the information needed to update it safely.
+struct State {
+    task: TaskCB,
+    meta: Meta,
+    snapshot: Option<Snapshot>,
+    initial: Vec<Option<f64>>,
+}
+
+/// A stateful MOSEK handle that keeps a translated model resident across solves.
+///
+/// Created by [`Mosek::persistent`](crate::Mosek). For LP and MILP models,
+/// changes limited to objective coefficients, the objective constant, and
+/// variable bounds are pushed directly into the retained MOSEK task. MOSEK can
+/// then reuse its available basis or incumbent information. Changes to rows,
+/// integrality, objective sense, initial values, or model dimensions rebuild the
+/// task transparently. Quadratic and conic models currently rebuild on every
+/// call, retaining the same correctness guarantee while leaving their native
+/// incremental update support for future work.
+///
+/// Options are applied before every optimization and persist on a resident task.
+/// If an option is omitted later it keeps its previous native value. Call
+/// [`reset`](Self::reset), or use a fresh handle, to restore cold-solve option
+/// behavior as well as discard warm-start information.
+#[derive(Default)]
+pub struct MosekPersistent {
+    state: Option<State>,
+}
+
+impl std::fmt::Debug for MosekPersistent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MosekPersistent").field("resident", &self.state.is_some()).finish()
+    }
+}
+
+impl MosekPersistent {
+    /// Create an empty resident handle. The first solve builds its task.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Discard the persistent MOSEK task. The next solve builds a fresh task.
+    pub fn reset(&mut self) {
+        self.state = None;
+    }
+
+    fn rebuild(&mut self, model: &Model, opts: &MosekOptions) -> Result<(), SolverError> {
+        let (task, meta) = build_task(model, opts)?;
+        let snapshot = linear_snapshot(model)?;
+        let initial = initial_values(model);
+        self.state = Some(State { task, meta, snapshot, initial });
+        Ok(())
+    }
+
+    fn solve_resident(
+        &mut self,
+        model: &Model,
+        opts: &MosekOptions,
+    ) -> Result<SolverResult, SolverError> {
+        let fresh = linear_snapshot(model)?;
+        let initial = initial_values(model);
+        let mut updated = false;
+
+        if let (Some(fresh), Some(state)) = (fresh, self.state.as_mut()) {
+            if state.snapshot.as_ref().is_some_and(|base| base.fingerprint == fresh.fingerprint)
+                && state.initial == initial
+            {
+                apply_linear_delta(
+                    &mut state.task,
+                    state.snapshot.as_ref().expect("snapshot"),
+                    &fresh,
+                )?;
+                opts.apply_cb(&mut state.task)?;
+                attach_verbose_stream(&mut state.task, opts)?;
+                state.snapshot = Some(fresh);
+                updated = true;
+            }
+        }
+
+        if !updated {
+            self.rebuild(model, opts)?;
+        }
+
+        let state = self.state.as_mut().expect("resident state after rebuild");
+        solve_task(model, &mut state.task, &state.meta)
+    }
+}
+
+impl Solver for MosekPersistent {
+    type Options = MosekOptions;
+
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn supports(&self, kind: ModelKind) -> bool {
+        crate::supported(kind)
+    }
+
+    fn solve(&mut self, model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
+        match self.solve_resident(model, opts) {
+            Ok(result) => Ok(result),
+            Err(error) => {
+                self.state = None;
+                Err(error)
+            }
+        }
+    }
+}
+
+fn linear_snapshot(model: &Model) -> Result<Option<Snapshot>, SolverError> {
+    if matches!(model.kind(), ModelKind::LP | ModelKind::MILP) {
+        snapshot(model).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+fn initial_values(model: &Model) -> Vec<Option<f64>> {
+    model.variables().iter().map(|variable| variable.initial).collect()
+}
+
+fn apply_linear_delta(
+    task: &mut TaskCB,
+    base: &Snapshot,
+    fresh: &Snapshot,
+) -> Result<(), SolverError> {
+    for index in 0..fresh.obj_costs.len() {
+        let column = i32::try_from(index).map_err(|_| {
+            SolverError::Backend("MOSEK: variable count exceeds the native index range".into())
+        })?;
+        if fresh.obj_costs[index].to_bits() != base.obj_costs[index].to_bits() {
+            task.put_c_j(column, fresh.obj_costs[index]).map_err(backend)?;
+        }
+        if fresh.lb[index].to_bits() != base.lb[index].to_bits()
+            || fresh.ub[index].to_bits() != base.ub[index].to_bits()
+        {
+            let (key, lower, upper) = bounds(fresh.lb[index], fresh.ub[index]);
+            task.put_var_bound(column, key, lower, upper).map_err(backend)?;
+        }
+    }
+    if fresh.obj_constant.to_bits() != base.obj_constant.to_bits() {
+        task.put_cfix(fresh.obj_constant).map_err(backend)?;
+    }
+    Ok(())
+}
+
+fn attach_verbose_stream(task: &mut TaskCB, opts: &MosekOptions) -> Result<(), SolverError> {
+    if opts.universal.verbose.unwrap_or(false) {
+        task.put_stream_callback(Streamtype::LOG, |message| print!("{message}"))
+            .map_err(backend)?;
+    }
+    Ok(())
+}
+
+fn bounds(lower: f64, upper: f64) -> (i32, f64, f64) {
+    match (lower.is_finite(), upper.is_finite()) {
+        (false, false) => (mosek::Boundkey::FR, 0.0, 0.0),
+        (true, false) => (mosek::Boundkey::LO, lower, 0.0),
+        (false, true) => (mosek::Boundkey::UP, 0.0, upper),
+        (true, true) if lower.total_cmp(&upper).is_eq() => (mosek::Boundkey::FX, lower, upper),
+        (true, true) => (mosek::Boundkey::RA, lower, upper),
+    }
+}
+
+fn backend(message: String) -> SolverError {
+    SolverError::Backend(format!("MOSEK: {message}"))
+}

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -1,0 +1,525 @@
+use std::time::{Duration, Instant};
+
+use mosek::{
+    Boundkey, Dinfitem, Iinfitem, Liinfitem, Objsense, Prosta, Rescode, Solsta, Soltype,
+    Streamtype, Task, TaskCB, Variabletype,
+};
+use oximo_core::{
+    ConstraintId, Domain, Model, ModelKind, ObjectiveSense, SocConstraintId, detect_soc,
+    explicit_soc_form,
+};
+use oximo_expr::{LinearTerms, QuadraticTerms, VarId, extract_quadratic};
+use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
+use rustc_hash::FxHashMap;
+
+use crate::MosekOptions;
+
+#[derive(Debug)]
+struct Meta {
+    kind: ModelKind,
+    row_by_constraint: Vec<Option<i32>>,
+    explicit_accs: Vec<(SocConstraintId, i64, usize)>,
+}
+
+/// Translate and solve an oximo model with a fresh MOSEK task.
+///
+/// # Errors
+///
+/// Returns an error for unsupported model kinds or variable domains, invalid
+/// expressions, and native MOSEK setup, optimization, or solution-query errors.
+pub fn solve(model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
+    model.ensure_objective_declared().map_err(SolverError::Core)?;
+    let kind = model.kind();
+    if !crate::supported(kind) {
+        return Err(SolverError::UnsupportedKind(kind));
+    }
+    reject_semi_domains(model)?;
+
+    let mut task =
+        Task::new().ok_or_else(|| SolverError::Backend("MOSEK: failed to create task".into()))?;
+    build_base(model, &mut task)?;
+    opts.apply(&mut task)?;
+
+    let mut task = task.with_callbacks();
+    if opts.universal.verbose.unwrap_or(false) {
+        task.put_stream_callback(Streamtype::LOG, |message| print!("{message}"))
+            .map_err(backend)?;
+    }
+    let meta = build_rows_and_cones(model, kind, &mut task)?;
+
+    let started = Instant::now();
+    let trm = task.optimize().map_err(backend)?;
+    let elapsed = started.elapsed();
+    extract_result(model, &task, &meta, trm, elapsed)
+}
+
+fn reject_semi_domains(model: &Model) -> Result<(), SolverError> {
+    for variable in model.variables().iter() {
+        if matches!(variable.domain, Domain::SemiContinuous { .. } | Domain::SemiInteger { .. }) {
+            return Err(SolverError::Backend(format!(
+                "MOSEK: variable '{}' uses a semi-continuous or semi-integer domain; \
+                 this backend does not reformulate semi-variable domains",
+                variable.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn build_base(model: &Model, task: &mut Task) -> Result<(), SolverError> {
+    let arena = model.arena();
+    let variables = model.variables();
+    let objective = model.objective();
+    let quad = objective.as_ref().map_or_else(
+        || Ok(QuadraticTerms::default()),
+        |obj| {
+            extract_quadratic(&arena, obj.expr).ok_or_else(|| SolverError::Nonlinear {
+                location: "the objective".into(),
+                term: "<nonlinear>".into(),
+            })
+        },
+    )?;
+
+    task.put_task_name(&model.name).map_err(backend)?;
+    task.append_vars(count_i32(variables.len(), "variables")?).map_err(backend)?;
+    for variable in variables.iter() {
+        let j = index_i32(variable.id.index(), "variable")?;
+        task.put_var_name(j, &variable.name).map_err(backend)?;
+        let (key, lower, upper) = bounds(variable.lb, variable.ub);
+        task.put_var_bound(j, key, lower, upper).map_err(backend)?;
+        if variable.domain.is_integer() {
+            task.put_var_type(j, Variabletype::TYPE_INT).map_err(backend)?;
+        }
+    }
+
+    for &(variable, coefficient) in &quad.linear {
+        task.put_c_j(index_i32(variable.index(), "variable")?, coefficient).map_err(backend)?;
+    }
+    task.put_cfix(quad.constant).map_err(backend)?;
+    put_q_objective(task, &quad)?;
+    task.put_obj_sense(objective.as_ref().map_or(Objsense::MINIMIZE, |obj| match obj.sense {
+        ObjectiveSense::Minimize => Objsense::MINIMIZE,
+        ObjectiveSense::Maximize => Objsense::MAXIMIZE,
+    }))
+    .map_err(backend)?;
+
+    let initial_type =
+        if variables.iter().any(|v| v.domain.is_integer()) { Soltype::ITG } else { Soltype::ITR };
+    let mut has_initial = false;
+    for variable in variables.iter() {
+        if let Some(value) = variable.initial {
+            let j = index_i32(variable.id.index(), "variable")?;
+            task.put_xx_slice(initial_type, j, j + 1, &[value]).map_err(backend)?;
+            has_initial = true;
+        }
+    }
+    if has_initial && initial_type == Soltype::ITG {
+        task.put_int_param(mosek::Iparam::MIO_CONSTRUCT_SOL, mosek::Onoffkey::ON)
+            .map_err(backend)?;
+    }
+    Ok(())
+}
+
+fn build_rows_and_cones(
+    model: &Model,
+    kind: ModelKind,
+    task: &mut TaskCB,
+) -> Result<Meta, SolverError> {
+    let arena = model.arena();
+    let variables = model.variables();
+    let constraints = model.constraints();
+    let mut row_by_constraint = vec![None; constraints.len()];
+    let mut detected = Vec::new();
+
+    for (id, constraint) in constraints.iter().enumerate() {
+        if let Some(form) = detect_soc(&arena, &variables, constraint) {
+            detected.push((constraint.name.to_string(), form));
+            continue;
+        }
+        let terms =
+            extract_quadratic(&arena, constraint.lhs).ok_or_else(|| SolverError::Nonlinear {
+                location: format!("constraint {:?}", constraint.name),
+                term: "<nonlinear>".into(),
+            })?;
+        let row = task.get_num_con().map_err(backend)?;
+        task.append_cons(1).map_err(backend)?;
+        task.put_con_name(row, &constraint.name).map_err(backend)?;
+        put_linear_row(task, row, &terms.linear)?;
+        task.put_con_bound(
+            row,
+            bounds(constraint.lower - terms.constant, constraint.upper - terms.constant).0,
+            bounds(constraint.lower - terms.constant, constraint.upper - terms.constant).1,
+            bounds(constraint.lower - terms.constant, constraint.upper - terms.constant).2,
+        )
+        .map_err(backend)?;
+        put_q_constraint(task, row, &terms)?;
+        row_by_constraint[id] = Some(row);
+    }
+
+    let socs = model.soc_constraints();
+    let mut explicit_accs = Vec::with_capacity(socs.len());
+    let mut next_afe = 0_i64;
+    let mut next_acc = 0_i64;
+    for (id, soc) in socs.iter().enumerate() {
+        let form = explicit_soc_form(&arena, soc).ok_or_else(|| {
+            SolverError::Backend(format!(
+                "MOSEK: SOC constraint '{}' contains an expression from another model",
+                soc.name
+            ))
+        })?;
+        let dim = append_soc(task, &form, &mut next_afe)?;
+        task.put_acc_name(next_acc, &soc.name).map_err(backend)?;
+        explicit_accs.push((
+            SocConstraintId(u32::try_from(id).map_err(|_| overflow("SOC constraint"))?),
+            next_acc,
+            dim,
+        ));
+        next_acc += 1;
+    }
+    for (name, form) in detected {
+        append_soc(task, &form, &mut next_afe)?;
+        task.put_acc_name(next_acc, &name).map_err(backend)?;
+        next_acc += 1;
+    }
+
+    Ok(Meta { kind, row_by_constraint, explicit_accs })
+}
+
+fn append_soc(
+    task: &mut TaskCB,
+    form: &oximo_core::SocForm,
+    next_afe: &mut i64,
+) -> Result<usize, SolverError> {
+    let dim = 1 + form.terms.len();
+    task.append_afes(i64::try_from(dim).map_err(|_| overflow("SOC dimension"))?)
+        .map_err(backend)?;
+    let first = *next_afe;
+    put_afe(task, first, &form.bound)?;
+    for (offset, terms) in form.terms.iter().enumerate() {
+        put_afe(
+            task,
+            first + i64::try_from(offset + 1).map_err(|_| overflow("AFE index"))?,
+            terms,
+        )?;
+    }
+    let domain = task
+        .append_quadratic_cone_domain(i64::try_from(dim).map_err(|_| overflow("SOC dimension"))?)
+        .map_err(backend)?;
+    let afes: Vec<i64> =
+        (first..first + i64::try_from(dim).map_err(|_| overflow("SOC dimension"))?).collect();
+    task.append_acc(domain, &afes, &vec![0.0; dim]).map_err(backend)?;
+    *next_afe += i64::try_from(dim).map_err(|_| overflow("AFE count"))?;
+    Ok(dim)
+}
+
+fn put_afe(task: &mut TaskCB, afe: i64, terms: &LinearTerms) -> Result<(), SolverError> {
+    let columns: Vec<i32> = terms
+        .coeffs
+        .iter()
+        .map(|(variable, _)| index_i32(variable.index(), "variable"))
+        .collect::<Result<_, _>>()?;
+    let values: Vec<f64> = terms.coeffs.iter().map(|(_, value)| *value).collect();
+    task.put_afe_f_row(afe, &columns, &values).map_err(backend)?;
+    task.put_afe_g(afe, terms.constant).map_err(backend)
+}
+
+fn put_linear_row(task: &mut TaskCB, row: i32, terms: &[(VarId, f64)]) -> Result<(), SolverError> {
+    let columns: Vec<i32> = terms
+        .iter()
+        .map(|(variable, _)| index_i32(variable.index(), "variable"))
+        .collect::<Result<_, _>>()?;
+    let values: Vec<f64> = terms.iter().map(|(_, value)| *value).collect();
+    task.put_a_row(row, &columns, &values).map_err(backend)
+}
+
+fn put_q_objective(task: &mut Task, terms: &QuadraticTerms) -> Result<(), SolverError> {
+    if terms.hessian.is_empty() {
+        return Ok(());
+    }
+    let (rows, columns, values) = q_triplets(terms)?;
+    task.put_q_obj(&rows, &columns, &values).map_err(backend)
+}
+
+fn put_q_constraint(
+    task: &mut TaskCB,
+    row: i32,
+    terms: &QuadraticTerms,
+) -> Result<(), SolverError> {
+    if terms.hessian.is_empty() {
+        return Ok(());
+    }
+    let (rows, columns, values) = q_triplets(terms)?;
+    task.put_q_con_k(row, &rows, &columns, &values).map_err(backend)
+}
+
+type QTriplets = (Vec<i32>, Vec<i32>, Vec<f64>);
+
+fn q_triplets(terms: &QuadraticTerms) -> Result<QTriplets, SolverError> {
+    let rows = terms
+        .hessian
+        .iter()
+        .map(|(row, _, _)| index_i32(row.index(), "variable"))
+        .collect::<Result<_, _>>()?;
+    let columns = terms
+        .hessian
+        .iter()
+        .map(|(_, column, _)| index_i32(column.index(), "variable"))
+        .collect::<Result<_, _>>()?;
+    let values = terms.hessian.iter().map(|(_, _, value)| *value).collect();
+    Ok((rows, columns, values))
+}
+
+fn extract_result(
+    model: &Model,
+    task: &TaskCB,
+    meta: &Meta,
+    trm: i32,
+    elapsed: Duration,
+) -> Result<SolverResult, SolverError> {
+    let mixed_integer = matches!(
+        meta.kind,
+        ModelKind::MILP | ModelKind::MIQP | ModelKind::MIQCP | ModelKind::MISOCP
+    );
+    let solution_type = select_solution(task, mixed_integer);
+    let solution_status = task.get_sol_sta(solution_type).unwrap_or(Solsta::UNKNOWN);
+    let problem_status = task.get_pro_sta(solution_type).unwrap_or(Prosta::UNKNOWN);
+    let termination = map_status(solution_status, problem_status, trm);
+    let has_point = task.solution_def(solution_type).unwrap_or(false)
+        && matches!(
+            solution_status,
+            Solsta::OPTIMAL
+                | Solsta::INTEGER_OPTIMAL
+                | Solsta::PRIM_FEAS
+                | Solsta::PRIM_AND_DUAL_FEAS
+        );
+
+    let variables = model.variables();
+    let mut solutions = Vec::new();
+    let mut dual = FxHashMap::default();
+    let mut soc_dual = FxHashMap::default();
+    let mut reduced_costs = FxHashMap::default();
+    if has_point {
+        let mut values = vec![0.0; variables.len()];
+        task.get_xx(solution_type, &mut values).map_err(backend)?;
+        let primal = values
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| {
+                Ok((VarId(u32::try_from(index).map_err(|_| overflow("variable"))?), value))
+            })
+            .collect::<Result<FxHashMap<_, _>, SolverError>>()?;
+        let objective = task.get_primal_obj(solution_type).ok().filter(|value| value.is_finite());
+        solutions.push(SolutionPoint { primal, objective });
+
+        if !mixed_integer {
+            collect_continuous_duals(
+                task,
+                solution_type,
+                meta,
+                variables.len(),
+                &mut dual,
+                &mut reduced_costs,
+            )?;
+            for &(id, acc, dim) in &meta.explicit_accs {
+                let mut dot_y = vec![0.0; dim];
+                if task.get_acc_dot_y(solution_type, acc, &mut dot_y).is_ok() {
+                    if let Some(&bound_multiplier) = dot_y.first() {
+                        soc_dual.insert(id, bound_multiplier);
+                    }
+                }
+            }
+        }
+    }
+
+    let best_bound = mixed_integer
+        .then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_BOUND).ok())
+        .flatten()
+        .filter(|value| value.is_finite());
+    let gap = mixed_integer
+        .then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_REL_GAP).ok())
+        .flatten()
+        .filter(|value| value.is_finite());
+    let iterations = iteration_count(task, mixed_integer);
+    let primal_status = PrimalStatus::infer(&termination, has_point);
+    Ok(SolverResult {
+        termination,
+        primal_status,
+        solutions,
+        dual,
+        soc_dual,
+        reduced_costs,
+        best_bound,
+        gap,
+        solve_time: elapsed,
+        iterations,
+        raw_log: None,
+        solver_name: Some(crate::NAME.into()),
+    })
+}
+
+fn collect_continuous_duals(
+    task: &TaskCB,
+    solution_type: i32,
+    meta: &Meta,
+    num_variables: usize,
+    dual: &mut FxHashMap<ConstraintId, f64>,
+    reduced_costs: &mut FxHashMap<VarId, f64>,
+) -> Result<(), SolverError> {
+    let num_rows = usize::try_from(task.get_num_con().map_err(backend)?)
+        .map_err(|_| overflow("constraint"))?;
+    let mut row_duals = vec![0.0; num_rows];
+    task.get_y(solution_type, &mut row_duals).map_err(backend)?;
+    for (id, row) in meta.row_by_constraint.iter().enumerate() {
+        if let Some(row) = row {
+            if let Some(&value) = row_duals.get(usize::try_from(*row).unwrap_or(usize::MAX)) {
+                dual.insert(
+                    ConstraintId(u32::try_from(id).map_err(|_| overflow("constraint"))?),
+                    value,
+                );
+            }
+        }
+    }
+
+    let mut lower = vec![0.0; num_variables];
+    let mut upper = vec![0.0; num_variables];
+    task.get_slx(solution_type, &mut lower).map_err(backend)?;
+    task.get_sux(solution_type, &mut upper).map_err(backend)?;
+    for (index, (lower, upper)) in lower.into_iter().zip(upper).enumerate() {
+        reduced_costs
+            .insert(VarId(u32::try_from(index).map_err(|_| overflow("variable"))?), lower - upper);
+    }
+    Ok(())
+}
+
+fn select_solution(task: &TaskCB, mixed_integer: bool) -> i32 {
+    if mixed_integer {
+        return Soltype::ITG;
+    }
+    if task.solution_def(Soltype::ITR).unwrap_or(false) {
+        Soltype::ITR
+    } else if task.solution_def(Soltype::BAS).unwrap_or(false) {
+        Soltype::BAS
+    } else {
+        Soltype::ITR
+    }
+}
+
+fn iteration_count(task: &TaskCB, mixed_integer: bool) -> u64 {
+    let nonnegative = |value: i64| u64::try_from(value.max(0)).unwrap_or(0);
+    if mixed_integer {
+        return [
+            task.get_lint_inf(Liinfitem::MIO_INTPNT_ITER).unwrap_or(0),
+            task.get_lint_inf(Liinfitem::MIO_SIMPLEX_ITER).unwrap_or(0),
+        ]
+        .into_iter()
+        .map(nonnegative)
+        .sum();
+    }
+    nonnegative(i64::from(task.get_int_inf(Iinfitem::INTPNT_ITER).unwrap_or(0)))
+        + nonnegative(task.get_lint_inf(Liinfitem::SIMPLEX_ITER).unwrap_or(0))
+}
+
+fn map_status(solution: i32, problem: i32, trm: i32) -> TerminationStatus {
+    if matches!(solution, Solsta::OPTIMAL | Solsta::INTEGER_OPTIMAL) {
+        return TerminationStatus::Optimal;
+    }
+    if matches!(solution, Solsta::PRIM_INFEAS_CER)
+        || matches!(problem, Prosta::PRIM_INFEAS | Prosta::PRIM_AND_DUAL_INFEAS)
+    {
+        return TerminationStatus::Infeasible;
+    }
+    if matches!(solution, Solsta::DUAL_INFEAS_CER) || problem == Prosta::DUAL_INFEAS {
+        return TerminationStatus::Unbounded;
+    }
+    if problem == Prosta::PRIM_INFEAS_OR_UNBOUNDED {
+        return TerminationStatus::InfeasibleOrUnbounded;
+    }
+    if matches!(solution, Solsta::PRIM_ILLPOSED_CER | Solsta::DUAL_ILLPOSED_CER)
+        || problem == Prosta::ILL_POSED
+    {
+        return TerminationStatus::NumericError;
+    }
+    match trm {
+        Rescode::TRM_MAX_TIME | Rescode::TRM_SERVER_MAX_TIME => TerminationStatus::TimeLimit,
+        Rescode::TRM_MAX_ITERATIONS => TerminationStatus::IterationLimit,
+        Rescode::TRM_MIO_NUM_BRANCHES => TerminationStatus::NodeLimit,
+        Rescode::TRM_USER_CALLBACK | Rescode::TRM_LOST_RACE => TerminationStatus::Interrupted,
+        Rescode::TRM_NUMERICAL_PROBLEM | Rescode::TRM_STALL => TerminationStatus::NumericError,
+        _ if matches!(solution, Solsta::PRIM_FEAS | Solsta::PRIM_AND_DUAL_FEAS) => {
+            TerminationStatus::Feasible
+        }
+        Rescode::OK => TerminationStatus::NotSolved,
+        _ => TerminationStatus::Other(format!("MOSEK termination code {trm}")),
+    }
+}
+
+fn bounds(lower: f64, upper: f64) -> (i32, f64, f64) {
+    match (lower.is_finite(), upper.is_finite()) {
+        (false, false) => (Boundkey::FR, 0.0, 0.0),
+        (true, false) => (Boundkey::LO, lower, 0.0),
+        (false, true) => (Boundkey::UP, 0.0, upper),
+        (true, true) if lower.total_cmp(&upper).is_eq() => (Boundkey::FX, lower, upper),
+        (true, true) => (Boundkey::RA, lower, upper),
+    }
+}
+
+fn count_i32(count: usize, what: &str) -> Result<i32, SolverError> {
+    i32::try_from(count).map_err(|_| overflow(what))
+}
+
+fn index_i32(index: usize, what: &str) -> Result<i32, SolverError> {
+    i32::try_from(index).map_err(|_| overflow(what))
+}
+
+fn overflow(what: &str) -> SolverError {
+    SolverError::Backend(format!("MOSEK: {what} count exceeds the native index range"))
+}
+
+fn backend(message: String) -> SolverError {
+    SolverError::Backend(format!("MOSEK: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_native_limit_and_failure_codes() {
+        assert_eq!(
+            map_status(Solsta::PRIM_FEAS, Prosta::UNKNOWN, Rescode::TRM_MAX_TIME),
+            TerminationStatus::TimeLimit
+        );
+        assert_eq!(
+            map_status(Solsta::PRIM_FEAS, Prosta::UNKNOWN, Rescode::TRM_MAX_ITERATIONS),
+            TerminationStatus::IterationLimit
+        );
+        assert_eq!(
+            map_status(Solsta::PRIM_FEAS, Prosta::UNKNOWN, Rescode::TRM_MIO_NUM_BRANCHES),
+            TerminationStatus::NodeLimit
+        );
+        assert_eq!(
+            map_status(Solsta::UNKNOWN, Prosta::UNKNOWN, Rescode::TRM_USER_CALLBACK),
+            TerminationStatus::Interrupted
+        );
+        assert_eq!(
+            map_status(Solsta::UNKNOWN, Prosta::ILL_POSED, Rescode::TRM_NUMERICAL_PROBLEM),
+            TerminationStatus::NumericError
+        );
+    }
+
+    #[test]
+    fn maps_problem_certificates() {
+        assert_eq!(
+            map_status(Solsta::UNKNOWN, Prosta::PRIM_INFEAS, Rescode::OK),
+            TerminationStatus::Infeasible
+        );
+        assert_eq!(
+            map_status(Solsta::UNKNOWN, Prosta::DUAL_INFEAS, Rescode::OK),
+            TerminationStatus::Unbounded
+        );
+        assert_eq!(
+            map_status(Solsta::UNKNOWN, Prosta::PRIM_INFEAS_OR_UNBOUNDED, Rescode::OK),
+            TerminationStatus::InfeasibleOrUnbounded
+        );
+    }
+}

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap;
 use crate::MosekOptions;
 
 #[derive(Debug)]
-struct Meta {
+pub(crate) struct Meta {
     kind: ModelKind,
     row_by_constraint: Vec<Option<i32>>,
     explicit_accs: Vec<(SocConstraintId, i64, usize)>,
@@ -28,6 +28,18 @@ struct Meta {
 /// Returns an error for unsupported model kinds or variable domains, invalid
 /// expressions, and native MOSEK setup, optimization, or solution-query errors.
 pub fn solve(model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
+    let (mut task, meta) = build_task(model, opts)?;
+    solve_task(model, &mut task, &meta)
+}
+
+/// Build a callback-capable MOSEK task from an oximo model.
+///
+/// This is shared by one-shot and persistent solves. A persistent handle retains
+/// the returned task only when its model snapshot remains compatible.
+pub(crate) fn build_task(
+    model: &Model,
+    opts: &MosekOptions,
+) -> Result<(TaskCB, Meta), SolverError> {
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if !crate::supported(kind) {
@@ -35,22 +47,31 @@ pub fn solve(model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverE
     }
     reject_semi_domains(model)?;
 
-    let mut task =
+    let task =
         Task::new().ok_or_else(|| SolverError::Backend("MOSEK: failed to create task".into()))?;
-    build_base(model, &mut task)?;
-    opts.apply(&mut task)?;
-
     let mut task = task.with_callbacks();
+    build_base(model, &mut task)?;
+    opts.apply_cb(&mut task)?;
+
     if opts.universal.verbose.unwrap_or(false) {
         task.put_stream_callback(Streamtype::LOG, |message| print!("{message}"))
             .map_err(backend)?;
     }
     let meta = build_rows_and_cones(model, kind, &mut task)?;
 
+    Ok((task, meta))
+}
+
+/// Optimize an already built task and read its result.
+pub(crate) fn solve_task(
+    model: &Model,
+    task: &mut TaskCB,
+    meta: &Meta,
+) -> Result<SolverResult, SolverError> {
     let started = Instant::now();
     let trm = task.optimize().map_err(backend)?;
     let elapsed = started.elapsed();
-    extract_result(model, &task, &meta, trm, elapsed)
+    extract_result(model, task, meta, trm, elapsed)
 }
 
 fn reject_semi_domains(model: &Model) -> Result<(), SolverError> {
@@ -66,7 +87,7 @@ fn reject_semi_domains(model: &Model) -> Result<(), SolverError> {
     Ok(())
 }
 
-fn build_base(model: &Model, task: &mut Task) -> Result<(), SolverError> {
+fn build_base(model: &Model, task: &mut TaskCB) -> Result<(), SolverError> {
     let arena = model.arena();
     let variables = model.variables();
     let objective = model.objective();
@@ -232,7 +253,7 @@ fn put_linear_row(task: &mut TaskCB, row: i32, terms: &[(VarId, f64)]) -> Result
     task.put_a_row(row, &columns, &values).map_err(backend)
 }
 
-fn put_q_objective(task: &mut Task, terms: &QuadraticTerms) -> Result<(), SolverError> {
+fn put_q_objective(task: &mut TaskCB, terms: &QuadraticTerms) -> Result<(), SolverError> {
     if terms.hessian.is_empty() {
         return Ok(());
     }

--- a/crates/oximo-mosek/tests/solve.rs
+++ b/crates/oximo-mosek/tests/solve.rs
@@ -1,6 +1,6 @@
 use oximo_core::prelude::*;
 use oximo_mosek::{Mosek, MosekOptions, solve};
-use oximo_solver::{Solver, SolverError, TerminationStatus};
+use oximo_solver::{PersistentSolver, Solver, SolverError, TerminationStatus};
 
 fn close(actual: f64, expected: f64) {
     assert!((actual - expected).abs() < 1e-6, "actual={actual}, expected={expected}");
@@ -213,4 +213,41 @@ fn branch_limit_keeps_constructed_incumbent() {
     assert!(result.has_solution());
     assert!(result.best_bound.is_some());
     assert!(result.gap.is_some());
+}
+
+#[test]
+fn persistent_updates_linear_objective_and_bounds() {
+    let model = Model::new("persistent_lp");
+    param!(model, price = 1.0);
+    variable!(model, 0.0 <= x <= 10.0);
+    objective!(model, Max, price * x);
+
+    let mut solver = Mosek.persistent();
+    for (coefficient, upper) in [(1.0, 10.0), (3.0, 4.0), (2.0, 7.0)] {
+        price.set_param_value(coefficient);
+        model.unfix_var(x.var_id().unwrap(), 0.0, upper);
+        let resident = solver.solve(&model, &MosekOptions::default()).unwrap();
+        let cold = Mosek.solve(&model, &MosekOptions::default()).unwrap();
+        assert_eq!(resident.termination, TerminationStatus::Optimal);
+        close(resident.value_of(x).unwrap(), cold.value_of(x).unwrap());
+        close(resident.objective().unwrap(), cold.objective().unwrap());
+    }
+}
+
+#[test]
+fn persistent_rebuilds_after_linear_row_change() {
+    let model = Model::new("persistent_rebuild");
+    param!(model, capacity = 5.0);
+    variable!(model, x >= 0.0);
+    constraint!(model, cap, x <= capacity);
+    objective!(model, Max, x);
+
+    let mut solver = Mosek.persistent();
+    for bound in [5.0, 2.0, 9.0] {
+        capacity.set_param_value(bound);
+        let resident = solver.solve(&model, &MosekOptions::default()).unwrap();
+        let cold = Mosek.solve(&model, &MosekOptions::default()).unwrap();
+        close(resident.value_of(x).unwrap(), cold.value_of(x).unwrap());
+        close(resident.objective().unwrap(), cold.objective().unwrap());
+    }
 }

--- a/crates/oximo-mosek/tests/solve.rs
+++ b/crates/oximo-mosek/tests/solve.rs
@@ -1,0 +1,216 @@
+use oximo_core::prelude::*;
+use oximo_mosek::{Mosek, MosekOptions, solve};
+use oximo_solver::{Solver, SolverError, TerminationStatus};
+
+fn close(actual: f64, expected: f64) {
+    assert!((actual - expected).abs() < 1e-6, "actual={actual}, expected={expected}");
+}
+
+#[test]
+fn lp_range_duals_reduced_costs_and_maximization() {
+    let model = Model::new("lp");
+    variable!(model, x >= 0.0);
+    variable!(model, y >= 0.0);
+    constraint!(model, band, 1.0 <= x + y <= 3.0);
+    objective!(model, Max, 3.0 * x + y + 2.0);
+
+    let result = solve(&model, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    close(result.value_of(x).unwrap(), 3.0);
+    close(result.value_of(y).unwrap(), 0.0);
+    close(result.objective().unwrap(), 11.0);
+    close(result.dual_of(model.constraint_id("band").unwrap()).unwrap(), 3.0);
+    close(*result.reduced_costs.get(&y.var_id().unwrap()).unwrap(), -2.0);
+}
+
+#[test]
+fn milp_and_quadratic_model_classes() {
+    let milp = Model::new("milp");
+    variable!(milp, x, Bin);
+    variable!(milp, y, Bin);
+    constraint!(milp, cap, 2.0 * x + 3.0 * y <= 4.0);
+    objective!(milp, Max, 3.0 * x + 4.0 * y);
+    let result = solve(&milp, &MosekOptions::default()).unwrap();
+    close(result.value_of(x).unwrap(), 0.0);
+    close(result.value_of(y).unwrap(), 1.0);
+
+    let qp = Model::new("qp");
+    variable!(qp, qx >= 0.0);
+    variable!(qp, qy >= 0.0);
+    constraint!(qp, sum, qx + qy == 1.0);
+    objective!(qp, Min, qx.powi(2) + qy.powi(2));
+    let result = solve(&qp, &MosekOptions::default()).unwrap();
+    close(result.value_of(qx).unwrap(), 0.5);
+    close(result.value_of(qy).unwrap(), 0.5);
+    close(result.objective().unwrap(), 0.5);
+
+    let miqp = Model::new("miqp");
+    variable!(miqp, 0.0 <= z <= 5.0, Int);
+    objective!(miqp, Min, (z - 2.2).powi(2));
+    let result = solve(&miqp, &MosekOptions::default()).unwrap();
+    close(result.value_of(z).unwrap(), 2.0);
+    close(result.objective().unwrap(), 0.04);
+}
+
+#[test]
+fn qcp_and_miqcp() {
+    let qcp = Model::new("qcp");
+    variable!(qcp, x >= 0.0);
+    constraint!(qcp, ball, (x - 2.0).powi(2) <= 1.0);
+    objective!(qcp, Min, x);
+    let result = solve(&qcp, &MosekOptions::default()).unwrap();
+    close(result.value_of(x).unwrap(), 1.0);
+
+    let miqcp = Model::new("miqcp");
+    variable!(miqcp, 0.0 <= z <= 4.0, Int);
+    constraint!(miqcp, ball, (z - 2.0).powi(2) <= 1.0);
+    objective!(miqcp, Max, z);
+    let result = solve(&miqcp, &MosekOptions::default()).unwrap();
+    close(result.value_of(z).unwrap(), 3.0);
+}
+
+#[test]
+fn explicit_detected_and_mixed_integer_socp() {
+    let explicit = Model::new("explicit");
+    variable!(explicit, x);
+    variable!(explicit, y);
+    variable!(explicit, t >= 0.0);
+    constraint!(explicit, fix_x, x == 3.0);
+    constraint!(explicit, fix_y, y == 4.0);
+    let cone = explicit.add_soc_constraint("cone", [x, y], t);
+    objective!(explicit, Min, t);
+    let result = solve(&explicit, &MosekOptions::default()).unwrap();
+    close(result.value_of(t).unwrap(), 5.0);
+    close(result.soc_dual_of(cone).unwrap(), 1.0);
+
+    let detected = Model::new("detected");
+    variable!(detected, dx);
+    variable!(detected, dy);
+    variable!(detected, dt >= 0.0);
+    constraint!(detected, fix_x, dx == 3.0);
+    constraint!(detected, fix_y, dy == 4.0);
+    constraint!(detected, cone, dx.powi(2) + dy.powi(2) <= dt.powi(2));
+    objective!(detected, Min, dt);
+    let result = solve(&detected, &MosekOptions::default()).unwrap();
+    close(result.value_of(dt).unwrap(), 5.0);
+
+    let mixed = Model::new("mixed_socp");
+    variable!(mixed, 3.0 <= ix <= 3.0, Int);
+    variable!(mixed, iy);
+    variable!(mixed, it >= 0.0);
+    constraint!(mixed, fix_y, iy == 4.0);
+    mixed.add_soc_constraint("cone", [ix, iy], it);
+    objective!(mixed, Min, it);
+    let result = solve(&mixed, &MosekOptions::default()).unwrap();
+    close(result.value_of(it).unwrap(), 5.0);
+}
+
+#[test]
+fn infeasible_unbounded_and_public_solver_trait() {
+    let infeasible = Model::new("infeasible");
+    variable!(infeasible, x);
+    constraint!(infeasible, lo, x >= 1.0);
+    constraint!(infeasible, hi, x <= 0.0);
+    objective!(infeasible, Min, x);
+    let result = solve(&infeasible, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Infeasible);
+    assert!(!result.has_solution());
+
+    let unbounded = Model::new("unbounded");
+    variable!(unbounded, y);
+    objective!(unbounded, Min, y);
+    let result = solve(&unbounded, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Unbounded);
+
+    let mut solver = Mosek;
+    let result = solver.solve(&infeasible, &MosekOptions::default()).unwrap();
+    assert_eq!(solver.name(), "MOSEK");
+    assert_eq!(result.solver_name.as_deref(), Some("MOSEK"));
+}
+
+#[test]
+fn feasibility_model_returns_a_point() {
+    let model = Model::new("feasibility");
+    variable!(model, x);
+    constraint!(model, bounds, 2.0 <= x <= 3.0);
+    objective!(model, Feasibility);
+
+    let result = solve(&model, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert!((2.0..=3.0).contains(&result.value_of(x).unwrap()));
+    close(result.objective().unwrap(), 0.0);
+}
+
+#[test]
+fn unsupported_nonlinear_and_semi_domains() {
+    let nonlinear = Model::new("nonlinear");
+    variable!(nonlinear, x);
+    objective!(nonlinear, Min, x.sin());
+    assert!(matches!(
+        solve(&nonlinear, &MosekOptions::default()),
+        Err(SolverError::UnsupportedKind(ModelKind::NLP))
+    ));
+
+    let mixed_nonlinear = Model::new("mixed_nonlinear");
+    variable!(mixed_nonlinear, z, Int);
+    objective!(mixed_nonlinear, Min, z.sin());
+    assert!(matches!(
+        solve(&mixed_nonlinear, &MosekOptions::default()),
+        Err(SolverError::UnsupportedKind(ModelKind::MINLP))
+    ));
+
+    let semi = Model::new("semi");
+    variable!(semi, s <= 10.0, SemiCont(2.0));
+    objective!(semi, Min, s);
+    let error = solve(&semi, &MosekOptions::default()).unwrap_err();
+    assert!(error.to_string().contains("semi-continuous or semi-integer"));
+
+    let semi_integer = Model::new("semi_integer");
+    variable!(semi_integer, si <= 10.0, SemiInt(2.0));
+    objective!(semi_integer, Min, si);
+    let error = solve(&semi_integer, &MosekOptions::default()).unwrap_err();
+    assert!(error.to_string().contains("semi-continuous or semi-integer"));
+}
+
+#[test]
+fn mosek_reports_nonconvex_quadratic_data() {
+    let model = Model::new("nonconvex");
+    variable!(model, -1.0 <= x <= 1.0);
+    objective!(model, Min, -x.powi(2));
+    let error = solve(&model, &MosekOptions::default()).unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("MOSEK:"), "{message}");
+    assert!(
+        message.to_ascii_lowercase().contains("convex")
+            || message.to_ascii_lowercase().contains("semidefinite"),
+        "{message}"
+    );
+}
+
+#[test]
+fn branch_limit_keeps_constructed_incumbent() {
+    let model = Model::new("limited_mip");
+    let items = Set::range(0..40);
+    variable!(model, x[i in items], Bin);
+    for i in 0..40 {
+        model.set_initial(x[i], 0.0);
+    }
+    constraint!(
+        model,
+        capacity,
+        sum!(f64::from(u32::try_from(i % 9 + 3).unwrap()) * x[i] for i in 0..40) <= 105.0
+    );
+    objective!(
+        model,
+        Max,
+        sum!(f64::from(u32::try_from(i * 17 % 31 + 1).unwrap()) * x[i] for i in 0..40)
+    );
+
+    let options =
+        MosekOptions::default().presolve_use(mosek::Presolvemode::OFF).mio_max_num_branches(0);
+    let result = solve(&model, &options).unwrap();
+    assert_eq!(result.termination, TerminationStatus::NodeLimit);
+    assert!(result.has_solution());
+    assert!(result.best_bound.is_some());
+    assert!(result.gap.is_some());
+}

--- a/crates/oximo/Cargo.toml
+++ b/crates/oximo/Cargo.toml
@@ -16,6 +16,7 @@ default = ["highs", "io"]
 highs = ["dep:oximo-highs"]
 io = ["dep:oximo-io"]
 gurobi = ["dep:oximo-gurobi"]
+mosek = ["dep:oximo-mosek"]
 gams = ["dep:oximo-gams"]
 baron = ["dep:oximo-baron"]
 clarabel = ["dep:oximo-clarabel"]
@@ -33,6 +34,7 @@ oximo-core.workspace = true
 oximo-solver.workspace = true
 oximo-highs = { workspace = true, optional = true }
 oximo-gurobi = { workspace = true, optional = true }
+oximo-mosek = { workspace = true, optional = true }
 oximo-gams = { workspace = true, optional = true }
 oximo-baron = { workspace = true, optional = true }
 oximo-clarabel = { workspace = true, optional = true }

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -205,6 +205,7 @@ pub trait Solver {
 | `highs`         | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
 | `io`            | NL, MPS, and LP file writers                                 | yes     |
 | `gurobi`        | Gurobi solver (requires licensed install)                    | no      |
+| `mosek`         | MOSEK 11.2 - convex LP/MIP/QP/QCP/SOCP solver                | no      |
 | `gams`          | GAMS bridge - solve type depends on the selected sub-solver  | no      |
 | `baron`         | BARON - Global non-convex solver (requires licensed install) | no      |
 | `clarabel`      | Clarabel - LP/QP/SOCP conic solver (pure Rust, no install)   | no      |
@@ -298,6 +299,7 @@ With the `io` feature (default), you can export models to MPS, LP and NL format 
 ## Requirements
 
 - Gurobi feature: Gurobi, `GUROBI_HOME` set, valid license
+- MOSEK feature: MOSEK 11.2, `MOSEK_BINDIR_112` if needed, valid license
 - GAMS feature: GAMS on `PATH`, valid license
 - BARON feature: BARON on `PATH`, valid license
 

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -26,6 +26,10 @@ pub use oximo_highs::{HighsMethod, HighsOptions, HighsPresolve};
 #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
 pub use oximo_gurobi::{GurobiOptions, GurobiPersistent, GurobiPresolve};
 
+#[cfg(feature = "mosek")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mosek")))]
+pub use oximo_mosek::{MosekOptions, MosekPersistent};
+
 #[cfg(feature = "gams")]
 #[cfg_attr(docsrs, doc(cfg(feature = "gams")))]
 pub use oximo_gams::{GamsOptions, GamsSolver};
@@ -70,6 +74,10 @@ pub mod prelude {
     #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
     pub use oximo_gurobi::{GurobiOptions, GurobiPersistent, GurobiPresolve};
 
+    #[cfg(feature = "mosek")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "mosek")))]
+    pub use oximo_mosek::{MosekOptions, MosekPersistent};
+
     #[cfg(feature = "gams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "gams")))]
     pub use oximo_gams::{GamsOptions, GamsSolver};
@@ -97,6 +105,10 @@ pub mod solvers {
     #[cfg(feature = "gurobi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
     pub use oximo_gurobi::Gurobi;
+
+    #[cfg(feature = "mosek")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "mosek")))]
+    pub use oximo_mosek::Mosek;
 
     #[cfg(feature = "gams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "gams")))]

--- a/crates/oximo/tests/solve_mosek.rs
+++ b/crates/oximo/tests/solve_mosek.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "mosek")]
+
+use oximo::prelude::*;
+use oximo::solvers::Mosek;
+use oximo::{MosekOptions, MosekPersistent};
+
+#[test]
+fn mosek_feature_exposes_public_solver_and_options() {
+    let model = Model::new("umbrella_mosek");
+    variable!(model, x >= 1.0);
+    objective!(model, Min, x + 2.0);
+
+    let result = Mosek.solve(&model, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert!((result.value_of(x).unwrap() - 1.0).abs() < 1e-7);
+    assert!((result.objective().unwrap() - 3.0).abs() < 1e-7);
+}
+
+#[test]
+fn mosek_feature_solves_public_mip_qp_and_socp_apis() {
+    let mip = Model::new("umbrella_mosek_mip");
+    variable!(mip, x, Bin);
+    objective!(mip, Max, 2.0 * x);
+    let result = Mosek.solve(&mip, &MosekOptions::default().mio_tol_rel_gap(1e-4)).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert!((result.value_of(x).unwrap() - 1.0).abs() < 1e-7);
+
+    let qp = Model::new("umbrella_mosek_qp");
+    variable!(qp, qx >= 0.0);
+    constraint!(qp, total, qx >= 2.0);
+    objective!(qp, Min, qx.powi(2));
+    let result = Mosek.solve(&qp, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert!((result.value_of(qx).unwrap() - 2.0).abs() < 1e-6);
+
+    let socp = Model::new("umbrella_mosek_socp");
+    variable!(socp, sx);
+    variable!(socp, sy);
+    variable!(socp, t >= 0.0);
+    constraint!(socp, fix_x, sx == 3.0);
+    constraint!(socp, fix_y, sy == 4.0);
+    socp.add_soc_constraint("norm", [sx, sy], t);
+    objective!(socp, Min, t);
+    let result = Mosek.solve(&socp, &MosekOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert!((result.value_of(t).unwrap() - 5.0).abs() < 1e-6);
+}
+
+#[test]
+fn mosek_feature_exposes_persistent_solver_through_prelude() {
+    let model = Model::new("umbrella_mosek_persistent");
+    param!(model, price = 1.0);
+    variable!(model, 0.0 <= x <= 10.0);
+    objective!(model, Max, price * x);
+
+    let mut solver: MosekPersistent = Mosek.persistent();
+    for (coefficient, upper) in [(1.0, 10.0), (4.0, 3.0)] {
+        price.set_param_value(coefficient);
+        model.unfix_var(x.var_id().unwrap(), 0.0, upper);
+        let result = solver.solve(&model, &MosekOptions::default()).unwrap();
+        assert_eq!(result.termination, TerminationStatus::Optimal);
+        assert!((result.value_of(x).unwrap() - upper).abs() < 1e-7);
+        assert!((result.objective().unwrap() - coefficient * upper).abs() < 1e-7);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for the MOSEK solver through the `oximo-mosek` crate ([mosek bindings](https://github.com/MOSEK/mosek.rust?rgh-link-date=2026-07-22T19%3A01%3A21.000Z)).

Since the MOSEK Rust crate is generated against a particular MOSEK major/minor release, its build script detects the native installation and accepts only that major/minor pair, so the current mosek backend supports MOSEK 11.2, and not an arbitrary MOSEK installation.

A sound design would be versioned, mutually exclusive features:

```toml
oximo = { features = ["mosek-112"] }
# later:
oximo = { features = ["mosek-120"] }
```

Each feature would select the matching renamed MOSEK dependency and compile the matching parameter catalog. We would preserve MOSEK as the public solver name, but reject enabling multiple MOSEK-version features together.
The main maintenance cost is the complete parameter API, since constants can be added, removed, or changed between MOSEK releases, so each supported major/minor needs its own generated catalog.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/45