### PR TITLE
Performance improvements using rayon

### DIFF
--- a/crates/oximo-autodiff/src/evaluator.rs
+++ b/crates/oximo-autodiff/src/evaluator.rs
@@ -373,7 +373,7 @@ impl NlpEvaluator {
     pub fn eval_constraint(&self, x: &[f64], g: &mut [f64]) {
         assert_eq!(x.len(), self.n_vars, "point dimension");
         assert_eq!(g.len(), self.constraints.len(), "constraint dimension");
-        if self.constraints.len() < PAR_CONSTRAINT_THRESHOLD {
+        if self.constraints.len() < PAR_CONSTRAINT_THRESHOLD || rayon::current_num_threads() == 1 {
             self.eval_constraint_serial(x, g);
         } else {
             self.eval_constraint_parallel(x, g);
@@ -414,7 +414,7 @@ impl NlpEvaluator {
     pub fn eval_constraint_jacobian(&self, x: &[f64], vals: &mut [f64]) {
         assert_eq!(x.len(), self.n_vars, "point dimension");
         assert_eq!(vals.len(), self.jac_structure.len(), "jacobian nnz");
-        if self.constraints.len() < PAR_CONSTRAINT_THRESHOLD {
+        if self.constraints.len() < PAR_CONSTRAINT_THRESHOLD || rayon::current_num_threads() == 1 {
             self.eval_constraint_jacobian_serial(x, vals);
         } else {
             self.eval_constraint_jacobian_parallel(x, vals);
@@ -523,7 +523,7 @@ impl NlpEvaluator {
             return;
         }
 
-        if self.seeds.len() < PAR_SEED_THRESHOLD {
+        if self.seeds.len() < PAR_SEED_THRESHOLD || rayon::current_num_threads() == 1 {
             self.hessian_seeds_serial(x, obj_factor, lambda, vals);
         } else {
             self.hessian_seeds_parallel(x, obj_factor, lambda, vals);
@@ -702,7 +702,6 @@ fn build_seeds(
 #[expect(clippy::cast_precision_loss, clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
-    use rayon::prelude::*;
 
     use super::*;
 
@@ -729,7 +728,7 @@ pub mod benchmark_support {
     pub fn classify(model: &Model, parallel: bool) -> usize {
         let arena = model.arena().clone();
         let exprs: Vec<_> = model.constraints().iter().map(|c| c.lhs).collect();
-        classify(&arena, &exprs, parallel).iter().map(|slot| slot.support.len()).sum()
+        classify_slots(&arena, &exprs, parallel).iter().map(|slot| slot.support.len()).sum()
     }
 
     #[derive(Debug)]
@@ -742,7 +741,7 @@ pub mod benchmark_support {
         pub fn new(model: &Model) -> Self {
             let arena = model.arena().clone();
             let exprs: Vec<_> = model.constraints().iter().map(|c| c.lhs).collect();
-            let slots = classify(&arena, &exprs, false);
+            let slots = classify_slots(&arena, &exprs, false);
             Self { slots, exprs }
         }
 
@@ -753,7 +752,7 @@ pub mod benchmark_support {
         }
     }
 
-    fn classify(
+    fn classify_slots(
         arena: &oximo_expr::ExprArena,
         exprs: &[ExprId],
         parallel: bool,
@@ -784,6 +783,7 @@ pub mod benchmark_support {
 }
 
 #[cfg(test)]
+#[expect(clippy::cast_precision_loss)]
 mod tests {
     //! Serial vs parallel equivalence of the threshold-gated derivative paths.
     //!

--- a/crates/oximo-clarabel/Cargo.toml
+++ b/crates/oximo-clarabel/Cargo.toml
@@ -10,7 +10,7 @@ description = "Clarabel LP/QP/SOCP conic backend for oximo"
 readme = "README.md"
 
 [features]
-benchmark-support = ["dep:rayon"]
+benchmark-support = []
 faer = ["clarabel/faer-sparse"]
 
 [package.metadata.docs.rs]
@@ -22,8 +22,8 @@ oximo-expr.workspace = true
 oximo-core.workspace = true
 oximo-solver.workspace = true
 clarabel.workspace = true
+rayon.workspace = true
 rustc-hash.workspace = true
-rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
 oximo-highs.workspace = true

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -29,11 +29,15 @@ use oximo_core::{
 };
 use oximo_expr::{LinearTerms, VarId, describe_nonlinear_term, extract_linear, extract_quadratic};
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
+use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
 use crate::{ClarabelDirectSolve, ClarabelOptions};
 
+const PAR_ROW_THRESHOLD: usize = 1024;
+
 /// The linear-or-conic view of one algebraic constraint.
+#[derive(Debug)]
 enum Row {
     Lin(LinearTerms),
     Soc(SocForm),
@@ -161,6 +165,10 @@ pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, Solv
 ///
 /// Panics if variable or constraint indices overflow `u32`.
 pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
+    build_problem_with(model, None)
+}
+
+fn build_problem_with(model: &Model, parallel: Option<bool>) -> Result<Problem, SolverError> {
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if !crate::supported(kind) {
@@ -171,9 +179,9 @@ pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
     let n = vars.len();
 
     let (sign, p_trip, q, obj_constant) = objective_data(model, n)?;
-    let rows = classify_rows(model)?;
+    let rows = classify_rows_with(model, parallel)?;
     let (mut acc, m_zero, m_nonneg) = linear_rows(model, &rows);
-    let (soc_sizes, soc_block_starts, n_explicit) = soc_blocks(model, &rows, &mut acc)?;
+    let (soc_sizes, soc_block_starts, n_explicit) = soc_blocks(model, &rows, &mut acc, parallel)?;
 
     let Rows { a_trip, b, row_duals } = acc;
     let m = b.len();
@@ -227,23 +235,42 @@ fn objective_data(model: &Model, n: usize) -> Result<(f64, Triplets, Vec<f64>, f
 /// Classify every algebraic constraint as linear or SOC. The kind gate
 /// guarantees a quadratic constraint detects as SOC, so a miss here is a
 /// genuine nonlinear.
-fn classify_rows(model: &Model) -> Result<Vec<Row>, SolverError> {
+fn classify_rows_with(model: &Model, parallel: Option<bool>) -> Result<Vec<Row>, SolverError> {
     let arena = model.arena();
     let vars = model.variables();
-    model
-        .constraints()
-        .iter()
-        .map(|c| match extract_linear(&arena, c.lhs) {
-            Some(t) => Ok(Row::Lin(t)),
-            None => {
-                detect_soc(&arena, &vars, c).map(Row::Soc).ok_or_else(|| SolverError::Nonlinear {
-                    location: format!("constraint {:?}", c.name),
-                    term: describe_nonlinear_term(&arena, c.lhs, &|v| var_name(&vars, v))
-                        .unwrap_or_else(|| "<nonlinear>".into()),
-                })
-            }
+    let constraints = model.constraints();
+    let arena_ref = &*arena;
+    let vars_ref = &*vars;
+    let classify_non_linear = |c: &oximo_core::Constraint| {
+        detect_soc(arena_ref, vars_ref, c).map(Row::Soc).ok_or_else(|| SolverError::Nonlinear {
+            location: format!("constraint {:?}", c.name),
+            term: describe_nonlinear_term(arena_ref, c.lhs, &|v| var_name(vars_ref, v))
+                .unwrap_or_else(|| "<nonlinear>".into()),
         })
-        .collect()
+    };
+
+    // Preserve the very cheap LP fast path by extracting affine rows serially
+    // and then fan out only a large set of quadratic/SOC candidates.
+    // This means LP rows never take the Rayon path.
+    let mut rows: Vec<Option<Row>> = (0..constraints.len()).map(|_| None).collect();
+    let mut pending = Vec::new();
+    for (index, constraint) in constraints.iter().enumerate() {
+        match extract_linear(arena_ref, constraint.lhs) {
+            Some(terms) => rows[index] = Some(Row::Lin(terms)),
+            None => pending.push((index, constraint)),
+        }
+    }
+    let use_parallel =
+        parallel.unwrap_or(pending.len() >= PAR_ROW_THRESHOLD && rayon::current_num_threads() > 1);
+    let detected: Vec<Result<Row, SolverError>> = if use_parallel {
+        pending.par_iter().map(|(_, c)| classify_non_linear(c)).collect()
+    } else {
+        pending.iter().map(|(_, c)| classify_non_linear(c)).collect()
+    };
+    for ((index, _), result) in pending.into_iter().zip(detected) {
+        rows[index] = Some(result?);
+    }
+    Ok(rows.into_iter().map(Option::unwrap).collect())
 }
 
 /// Lower the linear constraints and variable bounds into cone rows: the
@@ -317,20 +344,12 @@ fn soc_blocks(
     model: &Model,
     rows: &[Row],
     acc: &mut Rows,
+    parallel: Option<bool>,
 ) -> Result<(Vec<usize>, Vec<usize>, usize), SolverError> {
     let arena = model.arena();
     let socs = model.soc_constraints();
-    let explicit_forms = socs
-        .iter()
-        .map(|s| {
-            explicit_soc_form(&arena, s).ok_or_else(|| {
-                SolverError::Backend(format!(
-                    "SOC constraint '{}' has a member outside this model's arena",
-                    s.name
-                ))
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let arena_ref = &*arena;
+    let explicit_forms = explicit_soc_forms(arena_ref, &socs, parallel)?;
     let detected_forms = rows.iter().filter_map(|r| match r {
         Row::Soc(f) => Some(f.clone()),
         Row::Lin(_) => None,
@@ -348,6 +367,28 @@ fn soc_blocks(
         soc_sizes.push(1 + form.terms.len());
     }
     Ok((soc_sizes, soc_block_starts, n_explicit))
+}
+
+fn explicit_soc_forms(
+    arena_ref: &oximo_expr::ExprArena,
+    socs: &[oximo_core::SocConstraint],
+    parallel: Option<bool>,
+) -> Result<Vec<SocForm>, SolverError> {
+    let extract = |s: &oximo_core::SocConstraint| {
+        explicit_soc_form(arena_ref, s).ok_or_else(|| {
+            SolverError::Backend(format!(
+                "SOC constraint '{}' has a member outside this model's arena",
+                s.name
+            ))
+        })
+    };
+    let use_parallel = parallel.unwrap_or(false);
+    let explicit_results: Vec<Result<SocForm, SolverError>> = if use_parallel {
+        socs.par_iter().map(extract).collect()
+    } else {
+        socs.iter().map(extract).collect()
+    };
+    explicit_results.into_iter().collect()
 }
 
 /// Assemble the cone list in row order: zero cone, nonnegative cone, then one
@@ -552,7 +593,6 @@ fn map_status(s: SolverStatus) -> TerminationStatus {
 #[expect(clippy::cast_precision_loss, clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
-    use rayon::prelude::*;
 
     use super::*;
 
@@ -629,6 +669,7 @@ pub mod benchmark_support {
 }
 
 #[cfg(test)]
+#[expect(clippy::cast_precision_loss)]
 mod tests {
     use oximo_core::prelude::*;
     use oximo_solver::UniversalOptionsExt;
@@ -637,6 +678,90 @@ mod tests {
 
     fn close(a: f64, b: f64, tol: f64) -> bool {
         (a - b).abs() < tol
+    }
+
+    #[test]
+    fn forced_serial_and_parallel_translation_are_identical() {
+        let m = Model::new("ordered");
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, t >= 0.0);
+        for i in 0..PAR_ROW_THRESHOLD + 3 {
+            if i % 2 == 0 {
+                m.__add_constraint_auto((x + (i as f64 + 1.0) * y).le(i as f64 + 10.0));
+            } else {
+                m.__add_constraint_auto((x.powi(2) + y.powi(2) - t.powi(2)).le(0.0));
+            }
+        }
+        for i in 0..PAR_ROW_THRESHOLD + 3 {
+            m.add_soc_constraint(format!("soc{i}"), [x, y], t);
+        }
+        objective!(m, Min, t);
+
+        let serial = build_problem_with(&m, Some(false)).unwrap();
+        let parallel = build_problem_with(&m, Some(true)).unwrap();
+        let automatic = build_problem(&m).unwrap();
+        assert_eq!(serial.p_mat.colptr, parallel.p_mat.colptr);
+        assert_eq!(serial.p_mat.rowval, parallel.p_mat.rowval);
+        assert_eq!(serial.p_mat.nzval, parallel.p_mat.nzval);
+        assert_eq!(serial.q, parallel.q);
+        assert_eq!(serial.a_mat.colptr, parallel.a_mat.colptr);
+        assert_eq!(serial.a_mat.rowval, parallel.a_mat.rowval);
+        assert_eq!(serial.a_mat.nzval, parallel.a_mat.nzval);
+        assert_eq!(serial.b, parallel.b);
+        assert_eq!(serial.cones, parallel.cones);
+        assert_eq!(serial.meta.row_duals, parallel.meta.row_duals);
+        assert_eq!(serial.meta.soc_block_starts, parallel.meta.soc_block_starts);
+        assert_eq!(serial.meta.n_explicit, parallel.meta.n_explicit);
+        assert_eq!(serial.a_mat.colptr, automatic.a_mat.colptr);
+        assert_eq!(serial.a_mat.rowval, automatic.a_mat.rowval);
+        assert_eq!(serial.a_mat.nzval, automatic.a_mat.nzval);
+        assert_eq!(serial.b, automatic.b);
+        assert_eq!(serial.cones, automatic.cones);
+        assert_eq!(serial.meta.row_duals, automatic.meta.row_duals);
+    }
+
+    #[test]
+    fn automatic_large_detected_soc_translation_matches_forced_paths() {
+        let m = Model::new("automatic_detected_soc");
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, t >= 0.0);
+        objective!(m, Min, t);
+        for _ in 0..PAR_ROW_THRESHOLD + 3 {
+            m.__add_constraint_auto((x.powi(2) + y.powi(2) - t.powi(2)).le(0.0));
+        }
+
+        let serial = build_problem_with(&m, Some(false)).unwrap();
+        let automatic = build_problem(&m).unwrap();
+        let parallel = build_problem_with(&m, Some(true)).unwrap();
+        assert_eq!(serial.a_mat.colptr, automatic.a_mat.colptr);
+        assert_eq!(serial.a_mat.rowval, automatic.a_mat.rowval);
+        assert_eq!(serial.a_mat.nzval, automatic.a_mat.nzval);
+        assert_eq!(serial.b, automatic.b);
+        assert_eq!(serial.cones, automatic.cones);
+        assert_eq!(automatic.a_mat.colptr, parallel.a_mat.colptr);
+        assert_eq!(automatic.a_mat.rowval, parallel.a_mat.rowval);
+        assert_eq!(automatic.a_mat.nzval, parallel.a_mat.nzval);
+        assert_eq!(automatic.b, parallel.b);
+        assert_eq!(automatic.cones, parallel.cones);
+    }
+
+    #[test]
+    fn parallel_row_classification_keeps_first_error_order() {
+        let m = Model::new("errors");
+        variable!(m, x);
+        variable!(m, y);
+        variable!(m, z);
+        m.__add_constraint("first", (x * y * z).le(1.0));
+        m.__add_constraint("second", x.exp().le(2.0));
+        objective!(m, Min, x);
+        let serial = classify_rows_with(&m, Some(false)).unwrap_err();
+        let automatic = classify_rows_with(&m, None).unwrap_err();
+        let parallel = classify_rows_with(&m, Some(true)).unwrap_err();
+        assert_eq!(serial.to_string(), parallel.to_string());
+        assert_eq!(serial.to_string(), automatic.to_string());
+        assert!(serial.to_string().contains("first"));
     }
 
     #[test]

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -16,7 +16,7 @@ use crate::set::{Axis, FromIndexKey, IndexKey, Set};
 use crate::soc::{SocConstraint, SocConstraintId, detect_soc};
 use crate::var::{VarBuilder, Variable};
 
-const PAR_KIND_THRESHOLD: usize = 64;
+const PAR_KIND_THRESHOLD: usize = 1024;
 
 /// The kind of mathematical program a `Model` represents.
 ///
@@ -783,49 +783,77 @@ impl Model {
         if let Some(k) = self.cached_kind.get() {
             return k;
         }
-        let k = self.infer_kind(false);
+        let k = self.infer_kind_with(None);
         self.cached_kind.set(Some(k));
         k
     }
 
     /// Infer the model kind without reading or updating the kind cache.
     ///
-    /// `parallel` only changes how constraint expressions are classified. This
-    /// is used by the benchmark harness to time fresh serial and parallel work.
-    fn infer_kind(&self, parallel: bool) -> ModelKind {
-        let arena_ref = self.arena.borrow();
-        let arena: &ExprArena = &arena_ref;
-        let vars_ref = self.variables.borrow();
-        let vars: &[Variable] = &vars_ref;
-        let has_int = vars.iter().any(|v| v.domain.is_integer());
-        let obj_class =
-            self.objective.borrow().as_ref().map_or(ExprClass::Linear, |o| classify(arena, o.expr));
+    /// Automatic inference keeps the initial classification scan serial, then
+    /// parallelizes only a large set of already-known quadratic candidates for
+    /// SOC recognition. This keeps LP/NLP models off the Rayon path.
+    fn infer_kind_with(&self, parallel: Option<bool>) -> ModelKind {
+        self.infer_kind_impl(parallel)
+    }
 
-        let constraints_ref = self.constraints.borrow();
-        let constraints: &[Constraint] = &constraints_ref;
-        let summarize = |c: &Constraint| match classify(arena, c.lhs) {
-            ExprClass::Linear => (false, false, false),
-            ExprClass::Quadratic if detect_soc(arena, vars, c).is_some() => (false, false, true),
-            ExprClass::Quadratic => (false, true, false),
-            ExprClass::Nonlinear => (true, false, false),
-        };
-        let combine = |left: (bool, bool, bool), right: (bool, bool, bool)| {
-            (left.0 || right.0, left.1 || right.1, left.2 || right.2)
-        };
-        let (any_nonlinear, plain_quad_con, detected_soc) = if obj_class == ExprClass::Nonlinear {
-            (true, false, false)
-        } else if parallel && constraints.len() >= PAR_KIND_THRESHOLD {
-            constraints.par_iter().map(summarize).reduce(|| (false, false, false), combine)
-        } else {
-            let mut summary = (false, false, false);
-            for constraint in constraints {
-                summary = combine(summary, summarize(constraint));
-                if summary.0 {
-                    break;
+    /// Infer the kind with a forced serial or parallel SOC-recognition pass.
+    /// This is used by benchmarks and parity tests.
+    #[cfg(any(test, feature = "benchmark-support"))]
+    fn infer_kind(&self, parallel: bool) -> ModelKind {
+        self.infer_kind_impl(Some(parallel))
+    }
+
+    fn infer_kind_impl(&self, parallel: Option<bool>) -> ModelKind {
+        let arena = self.arena.borrow();
+        let vars = self.variables.borrow();
+        let has_int = vars.iter().any(|v| v.domain.is_integer());
+        let obj_class = self
+            .objective
+            .borrow()
+            .as_ref()
+            .map_or(ExprClass::Linear, |o| classify(&arena, o.expr));
+
+        let mut any_nonlinear = obj_class == ExprClass::Nonlinear;
+        let mut plain_quad_con = false;
+        let mut detected_soc = false;
+        if !any_nonlinear {
+            let constraints = self.constraints.borrow();
+            let arena_ref = &*arena;
+            let vars_ref = &*vars;
+            let mut quadratic = Vec::new();
+            for c in constraints.iter() {
+                match classify(arena_ref, c.lhs) {
+                    ExprClass::Linear => {}
+                    ExprClass::Quadratic => quadratic.push(c),
+                    ExprClass::Nonlinear => {
+                        any_nonlinear = true;
+                        break;
+                    }
                 }
             }
-            summary
-        };
+            if !any_nonlinear {
+                let use_parallel = parallel.unwrap_or(
+                    quadratic.len() >= PAR_KIND_THRESHOLD && rayon::current_num_threads() > 1,
+                );
+                if use_parallel {
+                    let cones: Vec<bool> = quadratic
+                        .par_iter()
+                        .map(|c| detect_soc(arena_ref, vars_ref, c).is_some())
+                        .collect();
+                    detected_soc = cones.iter().any(|&is_soc| is_soc);
+                    plain_quad_con = cones.iter().any(|&is_soc| !is_soc);
+                } else {
+                    for c in quadratic {
+                        if detect_soc(arena_ref, vars_ref, c).is_some() {
+                            detected_soc = true;
+                        } else {
+                            plain_quad_con = true;
+                        }
+                    }
+                }
+            }
+        }
         let has_soc = detected_soc || !self.soc_constraints.borrow().is_empty();
 
         let pick = |cont, int| if has_int { int } else { cont };
@@ -1025,6 +1053,7 @@ pub mod benchmark_support {
 }
 
 #[cfg(test)]
+#[expect(clippy::cast_precision_loss)]
 mod tests {
     use oximo_expr::extract_linear;
 
@@ -1160,5 +1189,41 @@ mod tests {
         assert!((m.param_value_idx(&price, "a").unwrap() - 1.5).abs() < f64::EPSILON);
         assert!((m.param_value_idx(&price, "b").unwrap() - 2.5).abs() < f64::EPSILON);
         assert!(m.param_value_idx(&price, "z").is_none());
+    }
+
+    #[test]
+    fn kind_forced_serial_and_parallel_classification_agree() {
+        let qcp = Model::new("qcp");
+        let x = qcp.__var("x").build();
+        let y = qcp.__var("y").build();
+        qcp.__minimize(x + y);
+        for i in 0..PAR_KIND_THRESHOLD + 3 {
+            qcp.__add_constraint_auto((x.powi(2) + y).le(i as f64 + 1.0));
+        }
+        assert_eq!(qcp.infer_kind(false), ModelKind::QCP);
+        assert_eq!(qcp.infer_kind(false), qcp.infer_kind(true));
+        assert_eq!(qcp.infer_kind(false), qcp.infer_kind_with(None));
+
+        let socp = Model::new("socp");
+        let x = socp.__var("x").build();
+        let t = socp.__var("t").lb(0.0).build();
+        socp.__minimize(t);
+        for _ in 0..PAR_KIND_THRESHOLD + 3 {
+            socp.__add_constraint_auto((x.powi(2) - t.powi(2)).le(0.0));
+        }
+        assert_eq!(socp.infer_kind(false), ModelKind::SOCP);
+        assert_eq!(socp.infer_kind(false), socp.infer_kind(true));
+        assert_eq!(socp.infer_kind(false), socp.infer_kind_with(None));
+
+        let nlp = Model::new("nlp");
+        let x = nlp.__var("x").build();
+        let y = nlp.__var("y").build();
+        let z = nlp.__var("z").build();
+        nlp.__minimize(x + y + z);
+        for _ in 0..PAR_KIND_THRESHOLD + 3 {
+            nlp.__add_constraint_auto((x * y * z).le(1.0));
+        }
+        assert_eq!(nlp.infer_kind(false), ModelKind::NLP);
+        assert_eq!(nlp.infer_kind(false), nlp.infer_kind(true));
     }
 }

--- a/crates/oximo-highs/Cargo.toml
+++ b/crates/oximo-highs/Cargo.toml
@@ -10,14 +10,14 @@ description = "HiGHS LP/MILP/QP backend for oximo"
 readme = "README.md"
 
 [features]
-benchmark-support = []
+benchmark-support = ["dep:rayon"]
 
 [dependencies]
 oximo-expr.workspace = true
 oximo-core.workspace = true
 oximo-solver.workspace = true
 highs.workspace = true
-rayon.workspace = true
+rayon = { workspace = true, optional = true }
 rustc-hash.workspace = true
 thiserror.workspace = true
 

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -12,7 +12,6 @@ use oximo_expr::{
     extract_quadratic,
 };
 use oximo_solver::{PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus};
-use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::HighsOptions;
@@ -127,7 +126,7 @@ pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> 
     let arena_ref: &ExprArena = &arena;
     let vars_ref: &[Variable] = &vars;
     let con_terms: Vec<LinearTerms> = constraints
-        .par_iter()
+        .iter()
         .map(|c| {
             extract_linear(arena_ref, c.lhs).ok_or_else(|| SolverError::Nonlinear {
                 location: format!("constraint {:?}", c.name),
@@ -135,7 +134,7 @@ pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> 
                     .unwrap_or_else(|| "<nonlinear>".into()),
             })
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<_, _>>()?;
 
     for (c, t) in constraints.iter().zip(&con_terms) {
         let lower = c.lower - t.constant;
@@ -303,37 +302,21 @@ fn collect_solution(
     }
     let drows = &drows_full[..num_constraints.min(drows_full.len())];
 
-    // Below this, rayon's HashMap collect overhead exceeds the gain.
-    // TODO: benchmark and tune this threshold.
-    const PAR_THRESHOLD: usize = 8192;
-    if cols.len() + dcols.len() + drows.len() < PAR_THRESHOLD {
-        let mut primal: FxHashMap<VarId, f64> =
-            FxHashMap::with_capacity_and_hasher(cols.len(), FxBuildHasher);
-        let mut reduced_costs: FxHashMap<VarId, f64> =
-            FxHashMap::with_capacity_and_hasher(dcols.len(), FxBuildHasher);
-        let mut dual: FxHashMap<ConstraintId, f64> =
-            FxHashMap::with_capacity_and_hasher(drows.len(), FxBuildHasher);
-        for (i, val) in cols.iter().enumerate() {
-            primal.insert(VarId(u32::try_from(i).unwrap()), *val);
-        }
-        for (i, val) in dcols.iter().enumerate() {
-            reduced_costs.insert(VarId(u32::try_from(i).unwrap()), *val);
-        }
-        for (i, val) in drows.iter().enumerate() {
-            dual.insert(ConstraintId(u32::try_from(i).unwrap()), *val);
-        }
-        return (primal, reduced_costs, dual);
+    let mut primal: FxHashMap<VarId, f64> =
+        FxHashMap::with_capacity_and_hasher(cols.len(), FxBuildHasher);
+    let mut reduced_costs: FxHashMap<VarId, f64> =
+        FxHashMap::with_capacity_and_hasher(dcols.len(), FxBuildHasher);
+    let mut dual: FxHashMap<ConstraintId, f64> =
+        FxHashMap::with_capacity_and_hasher(drows.len(), FxBuildHasher);
+    for (i, val) in cols.iter().enumerate() {
+        primal.insert(VarId(u32::try_from(i).unwrap()), *val);
     }
-
-    let primal: FxHashMap<VarId, f64> =
-        cols.par_iter().enumerate().map(|(i, v)| (VarId(u32::try_from(i).unwrap()), *v)).collect();
-    let reduced_costs: FxHashMap<VarId, f64> =
-        dcols.par_iter().enumerate().map(|(i, v)| (VarId(u32::try_from(i).unwrap()), *v)).collect();
-    let dual: FxHashMap<ConstraintId, f64> = drows
-        .par_iter()
-        .enumerate()
-        .map(|(i, v)| (ConstraintId(u32::try_from(i).unwrap()), *v))
-        .collect();
+    for (i, val) in dcols.iter().enumerate() {
+        reduced_costs.insert(VarId(u32::try_from(i).unwrap()), *val);
+    }
+    for (i, val) in drows.iter().enumerate() {
+        dual.insert(ConstraintId(u32::try_from(i).unwrap()), *val);
+    }
     (primal, reduced_costs, dual)
 }
 
@@ -382,6 +365,7 @@ fn map_status(s: HighsModelStatus) -> TerminationStatus {
 #[expect(clippy::cast_precision_loss, clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
+    use rayon::prelude::*;
 
     use super::*;
 

--- a/crates/oximo-pounce/Cargo.toml
+++ b/crates/oximo-pounce/Cargo.toml
@@ -10,7 +10,7 @@ description = "POUNCE (pure-Rust IPOPT) NLP backend for oximo. Finite difference
 readme = "README.md"
 
 [features]
-benchmark-support = ["dep:rayon"]
+benchmark-support = []
 enzyme = ["oximo-autodiff/enzyme"]
 
 [dependencies]
@@ -19,9 +19,9 @@ oximo-core.workspace = true
 oximo-solver.workspace = true
 oximo-autodiff.workspace = true
 pounce-rs.workspace = true
+rayon.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
-rayon = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -327,6 +327,8 @@ pub mod benchmark_support {
     pub const VALUE_THRESHOLD: usize = 1_024;
     /// Crossover candidate used only to size the preprocessing benchmark cases.
     pub const JACOBIAN_THRESHOLD: usize = 1_024;
+    // Keep each task large enough to amortize its register buffer.
+    const VALUE_MIN_LEN: usize = 64;
 
     pub fn model(rows: usize, nonlinear: bool) -> Model {
         let model = Model::new("pounce_bench");
@@ -385,13 +387,10 @@ pub mod benchmark_support {
                 self.values
                     .par_iter_mut()
                     .zip(self.inner.cons.par_iter())
-                    .map_init(
-                        || vec![0.0; self.inner.regs.len()],
-                        |regs, (out, slot)| {
-                            *out = slot_value(slot, &self.point, &self.inner.params, regs);
-                        },
-                    )
-                    .for_each(drop);
+                    .with_min_len(VALUE_MIN_LEN)
+                    .for_each_with(vec![0.0; self.inner.regs.len()], |regs, (out, slot)| {
+                        *out = slot_value(slot, &self.point, &self.inner.params, regs);
+                    });
             } else {
                 self.inner.eval_constraints(&self.point, &mut self.values);
             }
@@ -445,7 +444,7 @@ pub mod benchmark_support {
         use super::*;
 
         #[test]
-        fn worker_scratch_reuse_matches_serial_results() {
+        fn parallel_scratch_matches_serial_results() {
             let model = super::model(33, false);
             let mut serial = Oracle::new(&model);
             let mut parallel = Oracle::new(&model);

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -449,10 +449,19 @@ pub mod benchmark_support {
             let mut serial = Oracle::new(&model);
             let mut parallel = Oracle::new(&model);
 
-            assert_eq!(serial.values(false), parallel.values(true));
-            assert_eq!(serial.values(false), parallel.values(true));
-            assert_eq!(serial.sparse_jacobian(false), parallel.sparse_jacobian(true));
-            assert_eq!(serial.sparse_jacobian(false), parallel.sparse_jacobian(true));
+            serial.values(false);
+            parallel.values(true);
+            assert_eq!(serial.values, parallel.values);
+            serial.values(false);
+            parallel.values(true);
+            assert_eq!(serial.values, parallel.values);
+
+            serial.sparse_jacobian(false);
+            parallel.sparse_jacobian(true);
+            assert_eq!(serial.sparse, parallel.sparse);
+            serial.sparse_jacobian(false);
+            parallel.sparse_jacobian(true);
+            assert_eq!(serial.sparse, parallel.sparse);
         }
     }
 }

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -16,13 +16,36 @@ use oximo_autodiff::slot::{
 use oximo_autodiff::sparsity::{hessian_lagrangian_structure, jacobian_structure};
 use oximo_autodiff::tape::params_snapshot;
 use oximo_autodiff::{FunctionSlot, SlotKind};
-use oximo_core::Model;
+use oximo_core::{Model, ModelKind};
 use oximo_expr::ExprId;
+use rayon::prelude::*;
 
 use crate::tnlp::DerivativeOracle;
 
+// Large NLP slot classification benefits from Rayon at every measured size.
+// QCP classification does not.
+// All refresh/value/Jacobian work remains serial.
+const PAR_CLASSIFY_THRESHOLD: usize = 32;
+
+fn should_parallelize_nlp_classification(kind: ModelKind, len: usize) -> bool {
+    kind == ModelKind::NLP && len >= PAR_CLASSIFY_THRESHOLD && rayon::current_num_threads() > 1
+}
+
+fn classify_slots(
+    arena: &oximo_expr::ExprArena,
+    exprs: &[ExprId],
+    parallel: bool,
+) -> Vec<FunctionSlot> {
+    if parallel {
+        exprs.par_iter().map(|&e| FunctionSlot::classify(arena, e)).collect()
+    } else {
+        exprs.iter().map(|&e| FunctionSlot::classify(arena, e)).collect()
+    }
+}
+
 /// Classified objective/constraint slots plus the precomputed sparsity and
 /// scratch space to serve [`DerivativeOracle`] on stable Rust.
+#[derive(Debug)]
 pub(crate) struct HybridOracle {
     obj: FunctionSlot,
     cons: Vec<FunctionSlot>,
@@ -49,12 +72,18 @@ pub(crate) struct HybridOracle {
 
 impl HybridOracle {
     pub(crate) fn new(model: &Model) -> Self {
+        let parallel =
+            should_parallelize_nlp_classification(model.kind(), model.constraints().len());
+        Self::new_with(model, parallel)
+    }
+
+    fn new_with(model: &Model, parallel: bool) -> Self {
         let arena = model.arena();
         let obj_expr = model.objective().as_ref().map(|o| o.expr);
         let obj = obj_expr.map_or_else(FunctionSlot::zero, |e| FunctionSlot::classify(&arena, e));
         let con_exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
-        let cons: Vec<FunctionSlot> =
-            con_exprs.iter().map(|&e| FunctionSlot::classify(&arena, e)).collect();
+        let arena_ref = &*arena;
+        let cons = classify_slots(arena_ref, &con_exprs, parallel);
         let params = params_snapshot(&arena);
         let mut oracle = Self {
             obj,
@@ -289,7 +318,6 @@ impl DerivativeOracle for HybridOracle {
 #[expect(clippy::cast_precision_loss, clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
-    use rayon::prelude::*;
 
     use super::*;
 
@@ -354,12 +382,16 @@ pub mod benchmark_support {
 
         pub fn values(&mut self, parallel: bool) -> f64 {
             if parallel {
-                self.values.par_iter_mut().zip(self.inner.cons.par_iter()).for_each(
-                    |(out, slot)| {
-                        let mut regs = vec![0.0; self.inner.regs.len()];
-                        *out = slot_value(slot, &self.point, &self.inner.params, &mut regs);
-                    },
-                );
+                self.values
+                    .par_iter_mut()
+                    .zip(self.inner.cons.par_iter())
+                    .map_init(
+                        || vec![0.0; self.inner.regs.len()],
+                        |regs, (out, slot)| {
+                            *out = slot_value(slot, &self.point, &self.inner.params, regs);
+                        },
+                    )
+                    .for_each(drop);
             } else {
                 self.inner.eval_constraints(&self.point, &mut self.values);
             }
@@ -372,11 +404,16 @@ pub mod benchmark_support {
                     .inner
                     .cons
                     .par_iter()
-                    .map(|slot| {
-                        let mut scratch = vec![0.0; self.inner.n_vars];
-                        slot_gradient_add(slot, &self.point, &mut scratch);
-                        slot.support.iter().map(|&j| scratch[j as usize]).collect()
-                    })
+                    .map_init(
+                        || vec![0.0; self.inner.n_vars],
+                        |scratch, slot| {
+                            for &j in &slot.support {
+                                scratch[j as usize] = 0.0;
+                            }
+                            slot_gradient_add(slot, &self.point, scratch);
+                            slot.support.iter().map(|&j| scratch[j as usize]).collect()
+                        },
+                    )
                     .collect();
                 self.sparse.clear();
                 self.sparse.extend(rows.into_iter().flatten());
@@ -402,11 +439,30 @@ pub mod benchmark_support {
             self.dense.iter().sum()
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn worker_scratch_reuse_matches_serial_results() {
+            let model = super::model(33, false);
+            let mut serial = Oracle::new(&model);
+            let mut parallel = Oracle::new(&model);
+
+            assert_eq!(serial.values(false), parallel.values(true));
+            assert_eq!(serial.values(false), parallel.values(true));
+            assert_eq!(serial.sparse_jacobian(false), parallel.sparse_jacobian(true));
+            assert_eq!(serial.sparse_jacobian(false), parallel.sparse_jacobian(true));
+        }
+    }
 }
 
 #[cfg(test)]
+#[expect(clippy::cast_precision_loss)]
 mod tests {
     use oximo_core::prelude::*;
+    use rayon::ThreadPoolBuilder;
 
     use super::*;
 
@@ -580,5 +636,51 @@ mod tests {
         let mut jac = vec![0.0; o.jac_structure.len()];
         o.eval_constraint_jacobian(&[1.0], &mut jac);
         assert_close(jac[0], 3.0, 1e-12, "constraint coefficient after refresh");
+    }
+
+    fn repeated_model(rows: usize, nonlinear: bool) -> Model {
+        let m = Model::new("repeated");
+        variable!(m, -5.0 <= x <= 5.0);
+        variable!(m, -5.0 <= y <= 5.0);
+        variable!(m, -5.0 <= z <= 5.0);
+        objective!(m, Min, x.powi(2) + y + z);
+        for i in 0..rows {
+            let lhs = if nonlinear {
+                x * y * z + (i as f64 + 1.0) * x
+            } else if i % 2 == 0 {
+                x.powi(2) + y * z + (i as f64 + 1.0) * x
+            } else {
+                x + 2.0 * y - z
+            };
+            m.__add_constraint_auto(lhs.le(i as f64 + 10.0));
+        }
+        m
+    }
+
+    #[test]
+    fn forced_serial_and_parallel_nlp_classification_are_identical() {
+        let m = repeated_model(PAR_CLASSIFY_THRESHOLD + 3, true);
+        let serial = HybridOracle::new_with(&m, false);
+        let parallel = HybridOracle::new_with(&m, true);
+        assert_eq!(serial.jac_structure, parallel.jac_structure);
+        assert_eq!(serial.hess_structure, parallel.hess_structure);
+        assert_eq!(serial.exact_hessian, parallel.exact_hessian);
+    }
+
+    #[test]
+    fn automatic_nlp_classification_respects_the_pool_and_threshold() {
+        let one = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        one.install(|| {
+            assert!(!should_parallelize_nlp_classification(ModelKind::NLP, PAR_CLASSIFY_THRESHOLD));
+        });
+        let many = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+        many.install(|| {
+            assert!(!should_parallelize_nlp_classification(
+                ModelKind::NLP,
+                PAR_CLASSIFY_THRESHOLD - 1
+            ));
+            assert!(should_parallelize_nlp_classification(ModelKind::NLP, PAR_CLASSIFY_THRESHOLD));
+            assert!(!should_parallelize_nlp_classification(ModelKind::QCP, PAR_CLASSIFY_THRESHOLD));
+        });
     }
 }

--- a/crates/oximo/benches/preprocessing.rs
+++ b/crates/oximo/benches/preprocessing.rs
@@ -7,7 +7,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 
 fn configure() -> Criterion {
     Criterion::default()
-        .warm_up_time(Duration::from_secs(3))
+        .warm_up_time(Duration::from_secs(1))
         .measurement_time(Duration::from_secs(5))
         .sample_size(30)
 }


### PR DESCRIPTION
## Description

Based on the benchmarks from https://github.com/oximo-rs/oximo/pull/47 and https://github.com/oximo-rs/oximo/pull/48.

We uses serial-vs-Rayon results to retain only safe automatic parallelism.
Parallelism is now limited to:
- Model-kind inference: detected SOC candidates at >= 1,024.
- Clarabel translation: detected nonlinear/SOC rows at >= 1,024.
- POUNCE: initial NLP constraint classification at >= 32.

All other measured paths remain serial, since they don't show an overall win using automatic parallelism. This can probably be improved quite a lot in the future.

I believe the next logical steps are:
1. Optimize the serial hot paths.
      - Reuse buffers and scratch storage.
      - Avoid Vec<Vec<_>> / gather-then-copy designs.
      - Preallocate output and index maps.
      - Reduce cloning of arenas, constraints, and str.

2. Improve the existing good paths.
      - For core/Clarabel, benchmark intermediate sizes around 256–2,048 to tighten the 1,024 crossover.
      - We need to keep specialization by model class, so that we never let a QCP/LP regression due to an NLP/SOCP improvement.

3. Rework POUNCE before revisiting value/Jacobian parallelism.
      - I believe that the main blocker is per-worker allocation and result collection, we can maybe do reusable worker-local scratch plus direct disjoint output writes? Flamegraph first?

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features mosek` passes (requires MOSEK)
- [x] `cargo test --features baron` passes (requires BARON)