### PR TITLE
Add a unified model constraint view

### DIFF
--- a/.github/workflows/autodiff.yml
+++ b/.github/workflows/autodiff.yml
@@ -22,8 +22,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
+      # Newer Enzyme nightlies currently reject the generated `eval_tape_ad`
+      # derivative ABI during LLVM canonicalization.
+      # See: https://github.com/rust-lang/rust/issues/160470
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-07-26
           components: enzyme
       - uses: Swatinem/rust-cache@v2
       - name: Test oximo-autodiff with Enzyme
@@ -38,8 +42,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-07-26
           components: enzyme
       - uses: Swatinem/rust-cache@v2
       - name: Test oximo-pounce with Enzyme

--- a/crates/oximo-autodiff/src/evaluator.rs
+++ b/crates/oximo-autodiff/src/evaluator.rs
@@ -278,7 +278,8 @@ impl NlpEvaluator {
         {
             return false;
         }
-        let con_exprs: Vec<ExprId> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
+        let con_exprs: Vec<ExprId> =
+            model.constraints().algebraic().iter().map(|c| c.lhs).collect();
         if con_exprs != self.constraint_exprs {
             return false;
         }

--- a/crates/oximo-autodiff/src/evaluator.rs
+++ b/crates/oximo-autodiff/src/evaluator.rs
@@ -147,7 +147,8 @@ impl NlpEvaluator {
         let n_vars = model.variables().len();
         model.ensure_objective_declared().map_err(|_| AutodiffError::NoObjective)?;
         let objective_expr: Option<ExprId> = model.objective().as_ref().map(|o| o.expr);
-        let constraint_exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
+        let constraint_exprs: Vec<ExprId> =
+            model.constraints().algebraic().iter().map(|c| c.lhs).collect();
 
         let objective = match objective_expr {
             Some(e) => FunctionSlot::classify(&arena, e),
@@ -277,7 +278,7 @@ impl NlpEvaluator {
         {
             return false;
         }
-        let con_exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
+        let con_exprs: Vec<ExprId> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
         if con_exprs != self.constraint_exprs {
             return false;
         }
@@ -727,7 +728,7 @@ pub mod benchmark_support {
 
     pub fn classify(model: &Model, parallel: bool) -> usize {
         let arena = model.arena().clone();
-        let exprs: Vec<_> = model.constraints().iter().map(|c| c.lhs).collect();
+        let exprs: Vec<_> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
         classify_slots(&arena, &exprs, parallel).iter().map(|slot| slot.support.len()).sum()
     }
 
@@ -740,7 +741,7 @@ pub mod benchmark_support {
     impl Refresh {
         pub fn new(model: &Model) -> Self {
             let arena = model.arena().clone();
-            let exprs: Vec<_> = model.constraints().iter().map(|c| c.lhs).collect();
+            let exprs: Vec<_> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
             let slots = classify_slots(&arena, &exprs, false);
             Self { slots, exprs }
         }

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -216,7 +216,8 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let socs = model.soc_constraints();
     let objective = model.objective();
 
@@ -224,7 +225,7 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError
     write_options(&mut bar, opts, RES_NAME, TIM_NAME);
     let var_order = write_var_declarations(&mut bar, &vars)?;
     write_bounds(&mut bar, &vars);
-    let con_order = write_equations(&mut bar, &arena, &constraints, &socs)?;
+    let con_order = write_equations(&mut bar, &arena, constraints, &socs)?;
     write_objective(&mut bar, &arena, objective.as_ref())?;
     write_starting_point(&mut bar, &vars);
     let soc_bounds = socs
@@ -1166,7 +1167,7 @@ pub mod benchmark_support {
 
     pub fn render_equations(model: &Model, parallel: bool) -> Result<String, SolverError> {
         let arena = model.arena().clone();
-        let constraints = model.constraints().clone();
+        let constraints = model.constraints().algebraic().to_vec();
         let socs = model.soc_constraints().clone();
         let mut out = String::new();
         let map = if parallel {

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -253,7 +253,8 @@ fn objective_data(model: &Model, n: usize) -> Result<(f64, Triplets, Vec<f64>, f
 fn classify_rows_with(model: &Model, parallel: Option<bool>) -> Result<Vec<Row>, SolverError> {
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let arena_ref = &*arena;
     let vars_ref = &*vars;
     let classify_non_linear = |c: &oximo_core::Constraint| {
@@ -298,7 +299,8 @@ fn translation_capacities(
     explicit_forms: &[SocForm],
 ) -> (usize, usize, usize) {
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let is_fixed = |v: &Variable| v.lb.is_finite() && v.lb.total_cmp(&v.ub).is_eq();
     let mut row_count = 0;
     let mut nonzero_count = 0;
@@ -340,7 +342,8 @@ fn translation_capacities(
 /// the accumulated [`Rows`] and the two block sizes.
 fn linear_rows(model: &Model, rows: &[Row], mut acc: Rows) -> (Rows, usize, usize) {
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let is_fixed = |v: &Variable| v.lb.is_finite() && v.lb.total_cmp(&v.ub).is_eq();
     // ZeroCone rows: equalities, then fixed variables.
     for (i, (con, row)) in constraints.iter().zip(rows).enumerate() {

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -61,16 +61,27 @@ Names are unique per registry. Registering a duplicate variable or constraint na
 ### Accessors
 
 ```rust,ignore
-m.num_variables()      // usize
-m.num_constraints()    // usize
-m.variables()          // Ref<'_, Vec<Variable>>
-m.constraints()        // Ref<'_, Vec<Constraint>>
-m.arena()              // Ref<'_, ExprArena>
-m.kind()               // ModelKind, cached, invalidated on change
-m.try_objective()      // Result<Objective, Error>
-m.variable_id("x")     // Option<VarId>
-m.constraint_id("cap") // Option<ConstraintId>
+m.num_variables()   // usize
+m.num_constraints() // algebraic + explicit SOC constraints
+m.variables()       // Ref<'_, Vec<Variable>>
+m.constraints()     // ModelConstraints<'_>
+m.constraints().algebraic()          // typed algebraic registry
+m.constraints().second_order_cones() // typed explicit-SOC registry
+m.arena()          // Ref<'_, ExprArena>
+m.kind()           // ModelKind, cached, invalidated on change
+m.try_objective()  // Result<Objective, Error>
+m.variable_id("x") // Option<VarId>
+m.constraint_id("cap")      // Option<ConstraintId> (algebraic)
+m.soc_constraint_id("cone") // Option<SocConstraintId>
 ```
+
+`ModelConstraints::iter()` visits every declared constraint. Its `algebraic()`
+and `second_order_cones()` slices are convenient when both kinds are needed in
+one scope. Typed views keep backend passes homogeneous while preserving the
+same storage and typed IDs.
+SOC-shaped quadratic constraints declared with `constraint!` remain algebraic
+entries; only constraints declared with `soc_constraint!` or
+`add_soc_constraint` appear in `second_order_cones()`.
 
 ### Fixing and unfixing variables
 

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -25,7 +25,9 @@ pub use display::{ConstraintDisplay, ExprDisplay, ObjectiveDisplay, SocDisplay};
 pub use domain::Domain;
 pub use error::{Error, Result};
 pub use indexed::{IndexedParam, IndexedVar};
-pub use model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
+pub use model::{
+    ConstraintRef, IndexedVarBuilder, Model, ModelConstraints, ModelKind, display_index_key,
+};
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
 pub use set::{Axis, FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -48,6 +48,66 @@ pub enum ModelKind {
     MINLP,
 }
 
+/// A borrowed constraint from a [`Model`].
+///
+/// Algebraic constraints and explicitly declared second-order-cone constraints
+/// retain their typed IDs and storage. This enum provides a unified inspection
+/// boundary without changing either representation.
+#[derive(Copy, Clone, Debug)]
+pub enum ConstraintRef<'a> {
+    Algebraic { id: ConstraintId, constraint: &'a Constraint },
+    SecondOrderCone { id: SocConstraintId, constraint: &'a SocConstraint },
+}
+
+/// Unified borrowed view of every constraint declared on a [`Model`].
+///
+/// The underlying algebraic and explicit-SOC registries remain separate, so
+/// backends can iterate a homogeneous slice without a per-constraint branch.
+/// [`Self::iter`] visits algebraic constraints in [`ConstraintId`] order,
+/// followed by explicit cones in [`SocConstraintId`] order.
+#[derive(Debug)]
+pub struct ModelConstraints<'a> {
+    algebraic: Ref<'a, Vec<Constraint>>,
+    second_order_cones: Ref<'a, Vec<SocConstraint>>,
+}
+
+impl ModelConstraints<'_> {
+    /// Algebraic constraints in [`ConstraintId`] order.
+    pub fn algebraic(&self) -> &[Constraint] {
+        &self.algebraic
+    }
+
+    /// Explicit second-order-cone constraints in [`SocConstraintId`] order.
+    pub fn second_order_cones(&self) -> &[SocConstraint] {
+        &self.second_order_cones
+    }
+
+    /// Iterate over all declared constraints without allocating.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "registration rejects constraint counts above u32::MAX"
+    )]
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = ConstraintRef<'_>> + Clone {
+        let algebraic = self.algebraic.iter().enumerate().map(|(index, constraint)| {
+            ConstraintRef::Algebraic { id: ConstraintId(index as u32), constraint }
+        });
+        let second_order_cones =
+            self.second_order_cones.iter().enumerate().map(|(index, constraint)| {
+                ConstraintRef::SecondOrderCone { id: SocConstraintId(index as u32), constraint }
+            });
+        algebraic.chain(second_order_cones)
+    }
+
+    /// Total number of algebraic and explicit second-order-cone constraints.
+    pub fn len(&self) -> usize {
+        self.algebraic.len() + self.second_order_cones.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.algebraic.is_empty() && self.second_order_cones.is_empty()
+    }
+}
+
 /// The optimization model. Owns the expression arena, variable/parameter
 /// registries, constraints, and (optional) objective.
 ///
@@ -575,12 +635,18 @@ impl Model {
         }
     }
 
-    pub fn constraints(&self) -> Ref<'_, Vec<Constraint>> {
-        self.constraints.borrow()
+    /// Unified view of every algebraic and explicit second-order-cone
+    /// constraint declared on this model.
+    pub fn constraints(&self) -> ModelConstraints<'_> {
+        ModelConstraints {
+            algebraic: self.constraints.borrow(),
+            second_order_cones: self.soc_constraints.borrow(),
+        }
     }
 
+    /// Total number of algebraic and explicit second-order-cone constraints.
     pub fn num_constraints(&self) -> usize {
-        self.constraints.borrow().len()
+        self.constraints.borrow().len() + self.soc_constraints.borrow().len()
     }
 
     pub fn constraint_id(&self, name: &str) -> Option<ConstraintId> {
@@ -685,6 +751,11 @@ impl Model {
         }
     }
 
+    /// Typed explicit-SOC registry for specialized backend passes.
+    ///
+    /// Use [`Self::constraints`] when inspecting constraints generically. This
+    /// accessor exists so performance-sensitive translators can keep a
+    /// homogeneous borrow scoped to one conic pass.
     pub fn soc_constraints(&self) -> Ref<'_, Vec<SocConstraint>> {
         self.soc_constraints.borrow()
     }
@@ -1131,6 +1202,24 @@ mod tests {
         assert_eq!(m.kind(), ModelKind::LP);
         m.set_param(p, 2.0);
         assert_eq!(m.kind(), ModelKind::LP);
+    }
+
+    #[test]
+    fn unified_constraints_include_inactive_entries() {
+        let m = Model::new("inactive");
+        let x = m.__var("x").build();
+        let t = m.__var("t").lb(0.0).build();
+        m.__add_constraint("row", x.le(1.0));
+        m.add_soc_constraint("cone", [x], t);
+        m.constraints.borrow_mut()[0].active = false;
+        m.soc_constraints.borrow_mut()[0].active = false;
+
+        let constraints = m.constraints();
+        assert_eq!(constraints.len(), 2);
+        assert!(constraints.iter().all(|entry| match entry {
+            ConstraintRef::Algebraic { constraint, .. } => !constraint.active,
+            ConstraintRef::SecondOrderCone { constraint, .. } => !constraint.active,
+        }));
     }
 
     #[test]

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -2,7 +2,9 @@ pub use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, R
 pub use crate::domain::Domain;
 pub use crate::error::Error;
 pub use crate::indexed::{IndexedParam, IndexedVar};
-pub use crate::model::{IndexedVarBuilder, Model, ModelKind, display_index_key};
+pub use crate::model::{
+    ConstraintRef, IndexedVarBuilder, Model, ModelConstraints, ModelKind, display_index_key,
+};
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -125,7 +125,7 @@ fn range_constraint_with_const_bounds_collapses_to_one_row() {
 
     assert_eq!(m.num_constraints(), 1);
     let cons = m.constraints();
-    let band = &cons[m.constraint_id("band").expect("range row").index()];
+    let band = &cons.algebraic()[m.constraint_id("band").expect("range row").index()];
     assert!(band.is_range());
     assert!((band.lower - 1.0).abs() < f64::EPSILON);
     assert!((band.upper - 3.0).abs() < f64::EPSILON);
@@ -139,7 +139,7 @@ fn range_constraint_ge_form_is_equivalent() {
 
     assert_eq!(m.num_constraints(), 1);
     let cons = m.constraints();
-    let b = &cons[m.constraint_id("b").unwrap().index()];
+    let b = &cons.algebraic()[m.constraint_id("b").unwrap().index()];
     assert!(b.is_range());
     assert!((b.lower - 1.0).abs() < f64::EPSILON);
     assert!((b.upper - 3.0).abs() < f64::EPSILON);
@@ -155,8 +155,8 @@ fn range_constraint_with_expr_bounds_falls_back_to_two_rows() {
 
     assert_eq!(m.num_constraints(), 2);
     let cons = m.constraints();
-    let lo_row = &cons[m.constraint_id("band_lo").expect("lo row").index()];
-    let hi_row = &cons[m.constraint_id("band_hi").expect("hi row").index()];
+    let lo_row = &cons.algebraic()[m.constraint_id("band_lo").expect("lo row").index()];
+    let hi_row = &cons.algebraic()[m.constraint_id("band_hi").expect("hi row").index()];
     assert_eq!(lo_row.as_single().map(|(s, _)| s), Some(Sense::Ge));
     assert_eq!(hi_row.as_single().map(|(s, _)| s), Some(Sense::Le));
 }
@@ -167,7 +167,8 @@ fn anonymous_range_makes_one_auto_row() {
     variable!(m, x >= 0.0);
     constraint!(m, 0.0 <= x <= 5.0);
     assert_eq!(m.num_constraints(), 1);
-    let c = &m.constraints()[m.constraint_id("_c0").expect("auto row").index()];
+    let constraints = m.constraints();
+    let c = &constraints.algebraic()[m.constraint_id("_c0").expect("auto row").index()];
     assert!(c.is_range());
 }
 
@@ -181,7 +182,7 @@ fn family_range_const_bounds_makes_one_row_per_element() {
 
     assert_eq!(m.num_constraints(), 3);
     let cons = m.constraints();
-    let c = &cons[m.constraint_id("cap[1]").expect("range row").index()];
+    let c = &cons.algebraic()[m.constraint_id("cap[1]").expect("range row").index()];
     assert!(c.is_range());
     assert!((c.lower - 2.0).abs() < f64::EPSILON);
     assert!((c.upper - 5.0).abs() < f64::EPSILON);
@@ -193,7 +194,8 @@ fn inverted_range_stays_a_range_not_an_equality() {
     variable!(m, x);
     constraint!(m, c, 5.0 <= x <= 1.0);
     assert_eq!(m.num_constraints(), 1);
-    let c = &m.constraints()[m.constraint_id("c").unwrap().index()];
+    let constraints = m.constraints();
+    let c = &constraints.algebraic()[m.constraint_id("c").unwrap().index()];
     assert!(c.is_range());
     assert_eq!(c.as_single(), None);
 }
@@ -205,8 +207,8 @@ fn nonlinear_range_falls_back_to_two_rows() {
     constraint!(m, c, 1.0 <= x * x <= 4.0);
     assert_eq!(m.num_constraints(), 2);
     let cons = m.constraints();
-    let lo = &cons[m.constraint_id("c_lo").expect("lo row").index()];
-    let hi = &cons[m.constraint_id("c_hi").expect("hi row").index()];
+    let lo = &cons.algebraic()[m.constraint_id("c_lo").expect("lo row").index()];
+    let hi = &cons.algebraic()[m.constraint_id("c_hi").expect("hi row").index()];
     assert!(!lo.is_range());
     assert_eq!(lo.as_single().map(|(s, _)| s), Some(Sense::Ge));
     assert_eq!(hi.as_single().map(|(s, _)| s), Some(Sense::Le));
@@ -219,7 +221,8 @@ fn computed_name_range_collapses_to_one_row() {
     let tag = "band";
     constraint!(m, name = tag.to_string(), 1.0 <= x <= 2.0);
     assert_eq!(m.num_constraints(), 1);
-    let c = &m.constraints()[m.constraint_id("band").expect("range row").index()];
+    let constraints = m.constraints();
+    let c = &constraints.algebraic()[m.constraint_id("band").expect("range row").index()];
     assert!(c.is_range());
 }
 
@@ -690,7 +693,8 @@ fn soc_affine_terms_and_bound() {
     variable!(m, y);
     variable!(m, t >= 0.0);
     soc_constraint!(m, cone, [x - y, 2.0 * y + 1.0] <= t + 2.0);
-    let socs = m.soc_constraints();
+    let model_constraints = m.constraints();
+    let socs = model_constraints.second_order_cones();
     assert_eq!(socs[0].terms.len(), 2);
 }
 

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -336,16 +336,55 @@ fn rhs_expr_folded_into_lhs() {
     // x <= y + 3   ↦  canonical: (x - y - 3) <= 0
     constraint!(m, c, x <= y + 3.0);
     let cs = m.constraints();
-    assert_eq!(cs.len(), 1);
-    assert_eq!(cs[0].as_single(), Some((Sense::Le, 0.0)));
+    let algebraic = cs.algebraic();
+    assert_eq!(algebraic.len(), 1);
+    assert_eq!(algebraic[0].as_single(), Some((Sense::Le, 0.0)));
 
     // Decode the LHS and confirm the original `y + 3` made it into the linear
     // form so `coeff*x - coeff*y - 3 <= 0` is what the solver will see.
     let arena = m.arena();
-    let terms = extract_linear(&arena, cs[0].lhs).expect("linear");
+    let terms = extract_linear(&arena, algebraic[0].lhs).expect("linear");
     assert_eq!(terms.constant, -3.0);
     let mut sorted = terms.coeffs.clone();
     sorted.sort_by_key(|(v, _)| v.0);
     assert_eq!(sorted[0].1, 1.0);
     assert_eq!(sorted[1].1, -1.0);
+}
+
+#[test]
+fn unified_constraints_preserve_typed_views_ids_and_order() {
+    let m = Model::new("mixed_constraints");
+    variable!(m, x);
+    variable!(m, t >= 0.0);
+    constraint!(m, shared, x <= 1.0);
+    let soc_id = m.add_soc_constraint("shared", [x], t);
+
+    assert_eq!(m.num_constraints(), 2);
+    assert_eq!(m.constraints().algebraic().len(), 1);
+    assert_eq!(m.num_soc_constraints(), 1);
+    assert_eq!(m.constraint_id("shared"), Some(ConstraintId(0)));
+    assert_eq!(m.soc_constraint_id("shared"), Some(soc_id));
+
+    let constraints = m.constraints();
+    assert_eq!(constraints.len(), 2);
+    assert!(!constraints.is_empty());
+    assert_eq!(constraints.algebraic()[0].name, "shared");
+    assert_eq!(constraints.second_order_cones()[0].name, "shared");
+
+    let mut iter = constraints.iter();
+    match iter.next().expect("algebraic constraint") {
+        ConstraintRef::Algebraic { id, constraint } => {
+            assert_eq!(id, ConstraintId(0));
+            assert_eq!(constraint.name, "shared");
+        }
+        ConstraintRef::SecondOrderCone { .. } => panic!("algebraic constraints come first"),
+    }
+    match iter.next().expect("SOC constraint") {
+        ConstraintRef::SecondOrderCone { id, constraint } => {
+            assert_eq!(id, soc_id);
+            assert_eq!(constraint.name, "shared");
+        }
+        ConstraintRef::Algebraic { .. } => panic!("explicit cones come second"),
+    }
+    assert!(iter.next().is_none());
 }

--- a/crates/oximo-core/tests/soc.rs
+++ b/crates/oximo-core/tests/soc.rs
@@ -8,7 +8,8 @@ use oximo_core::prelude::*;
 fn detect_first(m: &Model) -> Option<SocForm> {
     let arena = m.arena();
     let vars = m.variables();
-    let constraints = m.constraints();
+    let model_constraints = m.constraints();
+    let constraints = model_constraints.algebraic();
     detect_soc(&arena, &vars, &constraints[0])
 }
 
@@ -106,7 +107,8 @@ fn explicit_form_recovers_affine_rows() {
     m.add_soc_constraint("cone", [x - y, 2.0 * y + 1.0], t);
 
     let arena = m.arena();
-    let socs = m.soc_constraints();
+    let model_constraints = m.constraints();
+    let socs = model_constraints.second_order_cones();
     let form = explicit_soc_form(&arena, &socs[0]).expect("affine members");
     assert_eq!(form.terms.len(), 2);
     assert_eq!(form.terms[0].coeffs.len(), 2);

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -44,7 +44,8 @@ pub fn solve(
     validate_solver(opts, kind)?;
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let socs = model.soc_constraints();
     let objective = model.objective();
     let sense = objective.as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
@@ -60,7 +61,7 @@ pub fn solve(
         kind,
         &arena,
         &vars,
-        &constraints,
+        constraints,
         &socs,
         objective.as_ref(),
         sense_kw,
@@ -116,7 +117,6 @@ pub fn solve(
 
     drop(arena);
     drop(vars);
-    drop(constraints);
     drop(socs);
 
     // - Write .gms file
@@ -1052,7 +1052,7 @@ pub mod benchmark_support {
 
     pub fn render_equations(model: &Model, parallel: bool) -> String {
         let arena = model.arena().clone();
-        let constraints = model.constraints().clone();
+        let constraints = model.constraints().algebraic().to_vec();
         let socs = model.soc_constraints().clone();
         let mut out = String::new();
         if parallel {
@@ -1145,7 +1145,8 @@ mod tests {
     fn render(model: &Model, opts: &GamsOptions) -> String {
         let arena = model.arena();
         let vars = model.variables();
-        let constraints = model.constraints();
+        let model_constraints = model.constraints();
+        let constraints = model_constraints.algebraic();
         let socs = model.soc_constraints();
         let objective = model.objective();
         let sense_kw = match objective.as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense) {
@@ -1158,7 +1159,7 @@ mod tests {
             model.kind(),
             &arena,
             &vars,
-            &constraints,
+            constraints,
             &socs,
             objective.as_ref(),
             sense_kw,

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -76,7 +76,8 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
 
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let socs = model.soc_constraints();
     let objective = model.objective();
     let has_semi = vars.iter().any(|v| v.domain.semi_threshold().is_some());
@@ -89,7 +90,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     // synthetic variable names stay unique across both.
     let mut aux_counter = 0_u32;
     let gurobi_constrs =
-        add_constraints(&arena, &constraints, &mut grb_model, &gurobi_vars, &mut aux_counter)?;
+        add_constraints(&arena, constraints, &mut grb_model, &gurobi_vars, &mut aux_counter)?;
     let soc_rows = add_soc_rows(&arena, &vars, &socs, &mut grb_model, &gurobi_vars)?;
 
     let obj_constant = match objective.as_ref() {
@@ -682,7 +683,8 @@ pub mod benchmark_support {
 
     pub fn extract(model: &Model, parallel: bool) -> usize {
         let arena = model.arena();
-        let constraints = model.constraints();
+        let model_constraints = model.constraints();
+        let constraints = model_constraints.algebraic();
         let arena_ref = &*arena;
         let count = |constraint: &Constraint| {
             extract_linear(arena_ref, constraint.lhs).map_or(0, |terms| terms.coeffs.len() + 1)

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -91,7 +91,8 @@ pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> 
 
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
 
     let objective = model.objective();
     let obj = objective.as_ref();
@@ -129,7 +130,7 @@ pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> 
 
     // RowProblem receives rows sequentially, so lower and upload each row in
     // one pass.
-    for c in constraints.iter() {
+    for c in constraints {
         let t = extract_linear(arena_ref, c.lhs).ok_or_else(|| SolverError::Nonlinear {
             location: format!("constraint {:?}", c.name),
             term: describe_nonlinear_term(arena_ref, c.lhs, &|v| var_name(vars_ref, v))
@@ -385,7 +386,8 @@ pub mod benchmark_support {
     pub fn rows(model: &Model, parallel: bool) -> Result<usize, SolverError> {
         let arena = model.arena();
         let vars = model.variables();
-        let constraints = model.constraints();
+        let model_constraints = model.constraints();
+        let constraints = model_constraints.algebraic();
         let arena_ref = &*arena;
         let vars_ref = &*vars;
         let row_nnz = |constraint: &oximo_core::Constraint| {

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -47,7 +47,8 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     }
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
 
     let obj_terms = extract_linear(&arena, objective.expr).ok_or_else(|| IoError::Nonlinear {
@@ -77,7 +78,7 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         constraints.iter().map(|c| c.name.to_string()).collect();
 
     writeln!(out, "Subject To")?;
-    for c in constraints.iter() {
+    for c in constraints {
         let t = extract_linear(&arena, c.lhs).ok_or_else(|| IoError::Nonlinear {
             location: format!("constraint {:?}", c.name),
             term: describe_nonlinear_term(&arena, c.lhs, &|v| var_name(&vars, v))

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -40,7 +40,8 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     }
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
 
     let obj_terms = extract_linear(&arena, objective.expr).ok_or_else(|| IoError::Nonlinear {
@@ -87,7 +88,7 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
 
     writeln!(out, "ROWS")?;
     writeln!(out, " N  OBJ")?;
-    for c in constraints.iter() {
+    for c in constraints {
         let tag = match c.as_single() {
             Some((Sense::Le, _)) => 'L',
             Some((Sense::Ge, _)) => 'G',
@@ -145,7 +146,7 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
 
     if constraints.iter().any(Constraint::is_range) {
         writeln!(out, "RANGES")?;
-        for c in constraints.iter() {
+        for c in constraints {
             if c.is_range() {
                 writeln!(out, "    RNG       {:<10}{}", c.name, c.upper - c.lower)?;
             }

--- a/crates/oximo-io/src/nl/analyze.rs
+++ b/crates/oximo-io/src/nl/analyze.rs
@@ -270,7 +270,8 @@ pub mod benchmark_support {
     pub fn analyze(model: &Model, parallel: bool) -> Result<usize, IoError> {
         let arena = model.arena();
         let vars = model.variables();
-        let constraints = model.constraints();
+        let model_constraints = model.constraints();
+        let constraints = model_constraints.algebraic();
         let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
         let arena_ref = &*arena;
         let analysis = build(arena_ref, &vars, &constraints, &objective, parallel)?;

--- a/crates/oximo-io/src/nl/mod.rs
+++ b/crates/oximo-io/src/nl/mod.rs
@@ -88,14 +88,15 @@ pub fn write_nl_with<W: Write>(
         return Err(IoError::Conic);
     }
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
 
     let arena = model.arena();
     let analysis =
-        analyze::Analysis::build(&arena, &vars, &constraints, &objective, opts.nonfinite_strings)?;
+        analyze::Analysis::build(&arena, &vars, constraints, &objective, opts.nonfinite_strings)?;
     let perm = permute::Permutation::build(&vars, &analysis);
-    let stats = header::Stats::build(&vars, &constraints, &analysis, &perm, opts);
+    let stats = header::Stats::build(&vars, constraints, &analysis, &perm, opts);
 
     let mut w = Writer::new(out, opts);
     header::write_header(&mut w, model, &stats, opts)?;
@@ -103,7 +104,7 @@ pub fn write_nl_with<W: Write>(
         &mut w,
         &arena,
         &vars,
-        &constraints,
+        constraints,
         &objective,
         &analysis,
         &perm,
@@ -157,12 +158,13 @@ pub fn write_nl_files(model: &Model, stub: &Path, opts: &WriteOptions) -> Result
 
 fn write_aux_files(model: &Model, stub: &Path, nonfinite_strings: bool) -> Result<(), IoError> {
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
 
     let arena = model.arena();
     let analysis =
-        analyze::Analysis::build(&arena, &vars, &constraints, &objective, nonfinite_strings)?;
+        analyze::Analysis::build(&arena, &vars, constraints, &objective, nonfinite_strings)?;
     let perm = permute::Permutation::build(&vars, &analysis);
 
     let row_path = stub.with_extension("row");

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -158,7 +158,8 @@ fn build_rows_and_cones(
 ) -> Result<Meta, SolverError> {
     let arena = model.arena();
     let variables = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let mut row_by_constraint = vec![None; constraints.len()];
     let mut detected = Vec::new();
     let mut scratch = TaskScratch::default();
@@ -576,7 +577,8 @@ pub mod benchmark_support {
     pub fn rows(model: &Model, parallel: bool) -> Result<usize, SolverError> {
         let arena = model.arena();
         let variables = model.variables();
-        let constraints = model.constraints();
+        let model_constraints = model.constraints();
+        let constraints = model_constraints.algebraic();
         let arena_ref = &*arena;
         let variables_ref = &*variables;
         let row = |c: &oximo_core::Constraint| {

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -127,7 +127,7 @@ pub(crate) struct HybridOracle {
 
 impl HybridOracle {
     pub(crate) fn new(model: &Model) -> Self {
-        let parallel = should_parallelize_classification(model.kind(), model.constraints().len());
+        let parallel = should_parallelize_classification(model.kind(), model.constraints().algebraic().len());
         Self::new_with(model, parallel)
     }
 
@@ -135,7 +135,7 @@ impl HybridOracle {
         let arena = model.arena();
         let obj_expr = model.objective().as_ref().map(|o| o.expr);
         let obj = obj_expr.map_or_else(FunctionSlot::zero, |e| FunctionSlot::classify(&arena, e));
-        let con_exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
+        let con_exprs: Vec<ExprId> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
         let arena_ref = &*arena;
         let cons = classify_slots(arena_ref, &con_exprs, parallel);
         let params = params_snapshot(&arena);
@@ -162,10 +162,12 @@ impl HybridOracle {
     /// Whether `model` has the same variables and the same objective/constraint
     /// expressions this oracle was built from, so a [`Self::refresh`] suffices.
     pub(crate) fn matches(&self, model: &Model) -> bool {
+        let model_constraints = model.constraints();
+        let constraints = model_constraints.algebraic();
         self.n_vars == model.variables().len()
             && self.obj_expr == model.objective().as_ref().map(|o| o.expr)
-            && self.con_exprs.len() == model.constraints().len()
-            && model.constraints().iter().map(|c| c.lhs).eq(self.con_exprs.iter().copied())
+            && self.con_exprs.len() == constraints.len()
+            && constraints.iter().map(|c| c.lhs).eq(self.con_exprs.iter().copied())
     }
 
     /// Re-extract every slot at the current parameter values and re-snapshot
@@ -461,7 +463,7 @@ pub mod benchmark_support {
 
     pub fn classify(model: &Model, parallel: bool) -> usize {
         let arena = model.arena();
-        let exprs: Vec<ExprId> = model.constraints().iter().map(|c| c.lhs).collect();
+        let exprs: Vec<ExprId> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
         let arena_ref = &*arena;
         if parallel {
             exprs.par_iter().map(|&e| FunctionSlot::classify(arena_ref, e).support.len()).sum()

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -127,7 +127,8 @@ pub(crate) struct HybridOracle {
 
 impl HybridOracle {
     pub(crate) fn new(model: &Model) -> Self {
-        let parallel = should_parallelize_classification(model.kind(), model.constraints().algebraic().len());
+        let parallel =
+            should_parallelize_classification(model.kind(), model.constraints().algebraic().len());
         Self::new_with(model, parallel)
     }
 
@@ -135,7 +136,8 @@ impl HybridOracle {
         let arena = model.arena();
         let obj_expr = model.objective().as_ref().map(|o| o.expr);
         let obj = obj_expr.map_or_else(FunctionSlot::zero, |e| FunctionSlot::classify(&arena, e));
-        let con_exprs: Vec<ExprId> = model.constraints().algebraic().iter().map(|c| c.lhs).collect();
+        let con_exprs: Vec<ExprId> =
+            model.constraints().algebraic().iter().map(|c| c.lhs).collect();
         let arena_ref = &*arena;
         let cons = classify_slots(arena_ref, &con_exprs, parallel);
         let params = params_snapshot(&arena);

--- a/crates/oximo-pounce/src/translate.rs
+++ b/crates/oximo-pounce/src/translate.rs
@@ -98,10 +98,11 @@ pub(crate) fn setup(model: &Model, opts: &PounceOptions) -> Result<Prepared, Sol
     }
     drop(vars);
 
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
     let mut g_l = Vec::with_capacity(constraints.len());
     let mut g_u = Vec::with_capacity(constraints.len());
-    for c in constraints.iter() {
+    for c in constraints {
         g_l.push(c.lower.max(-POUNCE_INFINITY));
         g_u.push(c.upper.min(POUNCE_INFINITY));
     }

--- a/crates/oximo-pounce/src/translate.rs
+++ b/crates/oximo-pounce/src/translate.rs
@@ -99,6 +99,9 @@ pub(crate) fn setup(model: &Model, opts: &PounceOptions) -> Result<Prepared, Sol
     drop(vars);
 
     let model_constraints = model.constraints();
+    if !model_constraints.second_order_cones().is_empty() {
+        return Err(SolverError::UnsupportedKind(ModelKind::SOCP));
+    }
     let constraints = model_constraints.algebraic();
     let mut g_l = Vec::with_capacity(constraints.len());
     let mut g_u = Vec::with_capacity(constraints.len());

--- a/crates/oximo-pounce/tests/solve_pounce.rs
+++ b/crates/oximo-pounce/tests/solve_pounce.rs
@@ -145,6 +145,21 @@ fn integer_models_are_rejected() {
 }
 
 #[test]
+fn soc_constraints_are_rejected_in_mixed_models() {
+    let m = Model::new("mixed_soc");
+    variable!(m, x >= 0.0);
+    variable!(m, t >= 0.0);
+    variable!(m, y >= 0.0);
+    m.add_soc_constraint("cone", [x], t);
+    constraint!(m, nonlinear, y.powi(3) <= 1.0);
+    objective!(m, Min, y);
+
+    assert_eq!(m.kind(), ModelKind::NLP);
+    let err = Pounce.solve(&m, &PounceOptions::default()).unwrap_err();
+    assert!(matches!(err, SolverError::UnsupportedKind(ModelKind::SOCP)));
+}
+
+#[test]
 fn persistent_matches_cold_on_parameter_sweep() {
     let m = Model::new("nlp_sweep");
     param!(m, w = 1.0);

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -53,7 +53,8 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
     }
     let arena = model.arena();
     let vars = model.variables();
-    let constraints = model.constraints();
+    let model_constraints = model.constraints();
+    let constraints = model_constraints.algebraic();
 
     let objective = model.objective();
     let obj = objective.as_ref();
@@ -86,7 +87,7 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
     }
 
     let arena_ref: &ExprArena = &arena;
-    for c in constraints.iter() {
+    for c in constraints {
         let t = extract_linear(arena_ref, c.lhs).ok_or_else(|| SolverError::Nonlinear {
             location: format!("constraint {:?}", c.name),
             term: describe_nonlinear_term(arena_ref, c.lhs, &|v| var_name(&vars, v))

--- a/crates/oximo-solver/src/infeasibility.rs
+++ b/crates/oximo-solver/src/infeasibility.rs
@@ -71,7 +71,8 @@ impl std::fmt::Display for IisReport<'_> {
         writeln!(f, "irreducible infeasible subsystem ({} members)", iis.len())?;
 
         if !iis.constraints.is_empty() {
-            let cons = m.constraints();
+            let model_constraints = m.constraints();
+            let cons = model_constraints.algebraic();
             writeln!(f, "\nconstraints ({})", iis.constraints.len())?;
             for id in &iis.constraints {
                 match cons.get(id.index()) {

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -262,7 +262,8 @@ impl std::fmt::Display for ModelReport<'_> {
 
         // Constraint duals, only when the solver returned any
         if !r.dual.is_empty() {
-            let cons = m.constraints();
+            let model_constraints = m.constraints();
+            let cons = model_constraints.algebraic();
             writeln!(f, "\nconstraints ({})", cons.len())?;
             let width = cons.iter().map(|c| c.name.len()).max().unwrap_or(0);
             for (i, c) in cons.iter().enumerate() {

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use oximo_core::{
-    ConstraintId, Expr, ExprNode, IndexKey, IndexedVar, Model, ObjectiveSense, SocConstraintId,
-    VarId,
+    ConstraintId, ConstraintRef, Expr, ExprNode, IndexKey, IndexedVar, Model, ObjectiveSense,
+    SocConstraintId, VarId,
 };
 use rustc_hash::FxHashMap;
 
@@ -263,11 +263,16 @@ impl std::fmt::Display for ModelReport<'_> {
         // Constraint duals, only when the solver returned any
         if !r.dual.is_empty() {
             let model_constraints = m.constraints();
-            let cons = model_constraints.algebraic();
+            let cons: Vec<_> = model_constraints
+                .iter()
+                .filter_map(|constraint| match constraint {
+                    ConstraintRef::Algebraic { id, constraint } => Some((id, constraint)),
+                    ConstraintRef::SecondOrderCone { .. } => None,
+                })
+                .collect();
             writeln!(f, "\nconstraints ({})", cons.len())?;
-            let width = cons.iter().map(|c| c.name.len()).max().unwrap_or(0);
-            for (i, c) in cons.iter().enumerate() {
-                let id = ConstraintId(u32::try_from(i).expect("constraint index fits u32"));
+            let width = cons.iter().map(|(_, c)| c.name.len()).max().unwrap_or(0);
+            for (id, c) in cons {
                 let d = r.dual_of(id).map_or_else(|| "n/a".to_owned(), num);
                 writeln!(f, "  {:<width$}  dual = {d}", c.name)?;
             }
@@ -356,5 +361,27 @@ mod tests {
         assert!(out.contains("(LP, maximize)"), "{out}");
         assert!(out.contains("x = 5"), "{out}");
         assert!(out.contains("dual = 1"), "{out}");
+    }
+
+    #[test]
+    fn report_keeps_algebraic_duals_paired_when_skipping_soc_rows() {
+        use oximo_core::{constraint, objective, variable};
+
+        let m = Model::new("mixed");
+        variable!(m, x >= 0.0);
+        variable!(m, t >= 0.0);
+        let first = constraint!(m, first, x <= 1.0);
+        let second = constraint!(m, second, x >= 0.5);
+        m.add_soc_constraint("cone", [x], t);
+        objective!(m, Min, x);
+
+        let mut dual = FxHashMap::default();
+        dual.insert(first, 1.0);
+        dual.insert(second, 2.0);
+        let r = SolverResult { dual, ..Default::default() };
+
+        let out = r.report(&m).to_string();
+        assert!(out.contains("first   dual = 1"), "{out}");
+        assert!(out.contains("second  dual = 2"), "{out}");
     }
 }


### PR DESCRIPTION
## Description

Currently, the model stores algebraic constraints and explicit SOC constraints in separate registries. When creating a backend, we had to remember to inspect both `constraints()` and `soc_constraints()`, making it easy for a new backend to silently omit explicit SOC constraints.

This PR:
- Makes `Model::constraints()` return a unified `ModelConstraints` view.
- Adds `ConstraintRef`, preserving the appropriate typed ID for each entry:
	 - `ConstraintId` for algebraic constraints
     - `SocConstraintId` for explicit SOC constraints
- Keeps typed homogeneous accessors:
     - `algebraic_constraints()`
     - `soc_constraints()`
- Migrates existing backends.

I want to add this before SOS1 and SOS2.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features mosek` passes (requires MOSEK)
- [x] `cargo test --features baron` passes (requires BARON)