### PR TITLE
Switch to `gurobi-rs` and support Gurobi v13+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -1082,42 +1082,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "grb"
-version = "3.0.1"
+name = "guro-sys"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9834f67c380d91552cfaa9ac309dde5b53c0d783254992ac37e4bcc12cfa2518"
+checksum = "c719ae97ba5186df64e76974ba3ad4d88e4c39f03495bba2871738d9f94a9003"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "gurobi-macro"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9290ea816ed945a7da7b718e7067a845ccaae72237af887c9b977be0fc0f2453"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
+name = "gurobi-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d89767c1c0886f862279124247369d5275fd650a623c98dcc2fab4eb3975657"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cstr-enum",
  "csv",
  "fnv",
- "grb-macro",
- "grb-sys2",
+ "guro-sys",
+ "gurobi-macro",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "grb-macro"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70071e86d36b20a3f2280ef419a0efe9aa8c85b79c318b28a2b707e1ed52b0d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "grb-sys2"
-version = "12.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae602a07b509e70fed9e88acc4b157087e310a1741ee674fe51e7e4aef06c92a"
-dependencies = [
- "anyhow",
 ]
 
 [[package]]
@@ -1677,7 +1677,7 @@ dependencies = [
 name = "oximo-gurobi"
 version = "0.5.1"
 dependencies = [
- "grb",
+ "gurobi-rs",
  "oximo-core",
  "oximo-expr",
  "oximo-solver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ndarray          = "0.17"
 thiserror        = "2.0"
 num-traits       = "0.2"
 highs            = "2.4"
-grb              = "3.0"    
+gurobi-rs        = { version = "1.0.0", features = ["gurobi13"] }
 mosek            = "11.2"
 clarabel         = "0.11"
 pounce-rs        = { version = "0.10", features = ["convex", "qp"] }

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ pub trait Solver {
 | --------------- | ------------------------------------------------------------ | ------- |
 | `highs`         | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
 | `io`            | NL, MPS, and LP file writers                                 | yes     |
-| `gurobi`        | Gurobi solver (requires licensed install)                    | no      |
+| `gurobi`        | Gurobi v13+ solver (requires licensed install)               | no      |
 | `mosek`         | MOSEK 11.2 - convex LP/MIP/QP/QCP/SOCP solver                | no      |
 | `gams`          | GAMS bridge - solve type depends on the selected sub-solver  | no      |
 | `baron`         | BARON - Global non-convex solver (requires licensed install) | no      |

--- a/crates/oximo-gurobi/Cargo.toml
+++ b/crates/oximo-gurobi/Cargo.toml
@@ -16,7 +16,7 @@ benchmark-support = ["dep:rayon"]
 oximo-expr.workspace = true
 oximo-core.workspace = true
 oximo-solver.workspace = true
-grb = { workspace = true, features = ["gurobi12"] }
+gurobi-rs.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
 rayon = { workspace = true, optional = true }

--- a/crates/oximo-gurobi/README.md
+++ b/crates/oximo-gurobi/README.md
@@ -2,9 +2,11 @@
 
 Gurobi backend for [oximo](https://github.com/oximo-rs/oximo).
 
-Wraps the [`grb`](https://crates.io/crates/grb) crate (`gurobi12` feature). Supports `LP`, `MILP`, `QP`, `MIQP`, `NLP`, and `MINLP` model kinds. Nonlinear expressions (`Pow`, `Sin`, `Cos`, `Exp`, `Log`, `Abs`, bilinear `Mul`) are lowered to auxiliary variables wired together with Gurobi's native `add_genconstr_*` and `add_qconstr` APIs. `NonConvex = 2` is enabled automatically when needed.
+Uses the [`gurobi-rs`](https://crates.io/crates/gurobi-rs) crate with its `gurobi13` feature.
 
-Gurobi v13.0+ works with the `gurobi12` feature, which is the default for this crate. For more information see [grb/issue#31](https://github.com/ykrist/rust-grb/issues/31). To use older versions, enable the `gurobi11` feature instead (see [grb docs](https://docs.rs/grb/latest/grb/#features) for details).
+Gurobi 13.0+ is required.
+Nonlinear expressions are represented by Gurobi 13 preorder expression trees with checked opcode/data/parent arrays.
+`NonConvex = 2` is enabled automatically when needed.
 
 ## Requirements
 
@@ -12,7 +14,7 @@ Gurobi v13.0+ works with the `gurobi12` feature, which is the default for this c
 
 1. Download and install [Gurobi](https://www.gurobi.com/downloads/) for your platform.
 2. Obtain a license and activate it by using `grbgetkey <key>`.
-3. Set `GUROBI_HOME` to the Gurobi install directory (the `grb` crate uses this to locate headers and the shared library).
+3. Set `GUROBI_HOME` to the Gurobi install directory (`gurobi-rs` uses this to locate headers and the shared library).
 
 ```sh
 # Linux example
@@ -66,6 +68,35 @@ println!("primal      = {:?}", result.primal_status);
 println!("obj         = {:?}", result.objective());
 ```
 
+## Callbacks
+
+The backend re-exports the typed callback surface. Ordinary and callback solves share result collection, and callback failures are returned as `SolverError` values. Use `CallbackMask` to restrict registration locations:
+
+```rust,ignore
+use oximo_gurobi::{Callback, CallbackMask, CallbackLocation, CbResult, Gurobi, GurobiOptions, Where};
+
+struct Progress;
+impl Callback for Progress {
+    fn callback(&mut self, where_: Where) -> CbResult {
+        // inspect `where_` using gurobi-rs callback contexts
+        let _ = where_;
+        Ok(())
+    }
+}
+
+let mut progress = Progress;
+let mut solver = Gurobi;
+let result = solver.solve_with_callback_filtered(
+    &m,
+    &GurobiOptions::default(),
+    &mut progress,
+    CallbackMask::from(CallbackLocation::Polling) | CallbackLocation::Mip,
+)?;
+```
+
+Persistent handles expose the corresponding `solve_with_callback` and
+`solve_with_callback_filtered` methods.
+
 Run the bundled example:
 
 ```sh
@@ -115,6 +146,9 @@ a transparent rebuild, so results always match a cold solve.
 | `.numeric_focus(i32)`          | int    | `NumericFocus`   |
 | `.log_file(impl Into<String>)` | str    | `LogFile`        |
 | `.mem_limit(f64)`              | double | `MemLimit`       |
+
+For Gurobi 13's Primal-Dual Hybrid Gradient method, use
+`GurobiOptions::default().method(oximo_gurobi::GRB_METHOD_PDHG)` (see [Installing and Running GPU-enabled Gurobi](https://support.gurobi.com/hc/en-us/articles/43498824105873-Installing-and-Running-GPU-enabled-Gurobi)).
 
 Full list of supported parameters is in [src/options.rs](src/options.rs). See the [Gurobi parameter reference](https://docs.gurobi.com/projects/optimizer/en/current/reference/parameters.html) for semantics.
 

--- a/crates/oximo-gurobi/src/lib.rs
+++ b/crates/oximo-gurobi/src/lib.rs
@@ -10,6 +10,8 @@ mod translate;
 #[doc(hidden)]
 pub use translate::benchmark_support;
 
+pub use gurobi_rs::callback::{Callback, CallbackLocation, CallbackMask, CbResult, Where};
+pub use gurobi_rs::{GRB_METHOD_PDHG, Opcode, Status};
 pub use options::{GurobiOptions, GurobiPresolve};
 pub use persistent::GurobiPersistent;
 pub use translate::solve;
@@ -63,6 +65,43 @@ impl Solver for Gurobi {
 
     fn solve(&mut self, model: &Model, opts: &GurobiOptions) -> Result<SolverResult, SolverError> {
         translate::solve(model, opts)
+    }
+}
+
+impl Gurobi {
+    /// Solve while receiving events from Gurobi's callback API.
+    ///
+    /// # Errors
+    /// Returns a [`SolverError`] for model construction, callback, or Gurobi
+    /// optimization failures.
+    pub fn solve_with_callback<F>(
+        &mut self,
+        model: &Model,
+        opts: &GurobiOptions,
+        callback: &mut F,
+    ) -> Result<SolverResult, SolverError>
+    where
+        F: Callback,
+    {
+        translate::solve_with_callback(model, opts, callback, None)
+    }
+
+    /// Solve while receiving only the selected Gurobi callback locations.
+    ///
+    /// # Errors
+    /// Returns a [`SolverError`] for model construction, callback, or Gurobi
+    /// optimization failures.
+    pub fn solve_with_callback_filtered<F>(
+        &mut self,
+        model: &Model,
+        opts: &GurobiOptions,
+        callback: &mut F,
+        locations: impl Into<CallbackMask>,
+    ) -> Result<SolverResult, SolverError>
+    where
+        F: Callback,
+    {
+        translate::solve_with_callback(model, opts, callback, Some(locations.into()))
     }
 }
 

--- a/crates/oximo-gurobi/src/nonlinear.rs
+++ b/crates/oximo-gurobi/src/nonlinear.rs
@@ -1,5 +1,7 @@
 //! Lower nonlinear oximo expressions onto Gurobi 13 expression trees.
 
+use std::collections::HashMap;
+
 use gurobi_rs::Opcode;
 use gurobi_rs::expr::{LinExpr, QuadExpr};
 use gurobi_rs::prelude::*;
@@ -8,6 +10,7 @@ use oximo_solver::SolverError;
 
 /// A value that can stay on Gurobi's direct linear/quadratic fast path, or a
 /// variable containing a native nonlinear expression-tree result.
+#[derive(Clone)]
 pub(crate) enum LoweredExpr {
     Linear(LinExpr),
     Quadratic(QuadExpr),
@@ -28,9 +31,24 @@ pub(crate) struct LoweringCtx<'a> {
     pub gurobi_vars: &'a [Var],
     pub aux_counter: u32,
     pub generated: Vec<GeneratedConstraint>,
+    quadratic_cache: HashMap<ExprId, Option<LoweredExpr>>,
+    materialized: HashMap<ExprId, Var>,
+    reference_counts: Vec<usize>,
 }
 
-impl LoweringCtx<'_> {
+impl<'a> LoweringCtx<'a> {
+    pub(crate) fn new(model: &'a mut Model, gurobi_vars: &'a [Var], aux_counter: u32) -> Self {
+        LoweringCtx {
+            model,
+            gurobi_vars,
+            aux_counter,
+            generated: Vec::new(),
+            quadratic_cache: HashMap::new(),
+            materialized: HashMap::new(),
+            reference_counts: Vec::new(),
+        }
+    }
+
     fn next_name(&mut self, tag: &str) -> String {
         let n = self.aux_counter;
         self.aux_counter = self.aux_counter.saturating_add(1);
@@ -201,8 +219,11 @@ fn try_mul(values: Vec<LoweredExpr>) -> Option<LoweredExpr> {
 fn try_quadratic(
     arena: &ExprArena,
     id: ExprId,
-    ctx: &LoweringCtx<'_>,
+    ctx: &mut LoweringCtx<'_>,
 ) -> Result<Option<LoweredExpr>, SolverError> {
+    if let Some(value) = ctx.quadratic_cache.get(&id) {
+        return Ok(value.clone());
+    }
     let value = match arena.get(id) {
         ExprNode::Const(c) => LoweredExpr::Linear(linear_constant(*c)),
         ExprNode::Param(p) => LoweredExpr::Linear(linear_constant(arena.param_value(*p))),
@@ -215,13 +236,17 @@ fn try_quadratic(
             LoweredExpr::Linear(e)
         }
         ExprNode::Neg(inner) => {
-            let Some(inner) = try_quadratic(arena, *inner, ctx)? else { return Ok(None) };
+            let Some(inner) = try_quadratic(arena, *inner, ctx)? else {
+                return Ok(cache_quadratic_none(ctx, id));
+            };
             try_scale(inner, -1.0)
         }
         ExprNode::Add(children) => {
             let mut acc = LoweredExpr::Linear(linear_constant(0.0));
             for child in children {
-                let Some(value) = try_quadratic(arena, *child, ctx)? else { return Ok(None) };
+                let Some(value) = try_quadratic(arena, *child, ctx)? else {
+                    return Ok(cache_quadratic_none(ctx, id));
+                };
                 acc = try_add(acc, value);
             }
             acc
@@ -229,54 +254,124 @@ fn try_quadratic(
         ExprNode::Mul(children) => {
             let mut values = Vec::with_capacity(children.len());
             for child in children {
-                let Some(value) = try_quadratic(arena, *child, ctx)? else { return Ok(None) };
+                let Some(value) = try_quadratic(arena, *child, ctx)? else {
+                    return Ok(cache_quadratic_none(ctx, id));
+                };
                 values.push(value);
             }
-            let Some(value) = try_mul(values) else { return Ok(None) };
+            let Some(value) = try_mul(values) else {
+                return Ok(cache_quadratic_none(ctx, id));
+            };
             value
         }
         ExprNode::Pow(base, exp) => {
-            let Some(alpha) = as_const(arena, *exp) else { return Ok(None) };
-            let Some(base) = try_quadratic(arena, *base, ctx)? else { return Ok(None) };
+            let Some(alpha) = as_const(arena, *exp) else {
+                return Ok(cache_quadratic_none(ctx, id));
+            };
+            let Some(base) = try_quadratic(arena, *base, ctx)? else {
+                return Ok(cache_quadratic_none(ctx, id));
+            };
             if alpha == 0.0 {
                 LoweredExpr::Linear(linear_constant(1.0))
             } else if (alpha - 1.0).abs() < f64::EPSILON {
                 base
             } else if (alpha - 2.0).abs() < f64::EPSILON {
-                let LoweredExpr::Linear(base) = base else { return Ok(None) };
+                let LoweredExpr::Linear(base) = base else {
+                    return Ok(cache_quadratic_none(ctx, id));
+                };
                 LoweredExpr::Quadratic(multiply_linears(&base, &base))
             } else {
-                return Ok(None);
+                return Ok(cache_quadratic_none(ctx, id));
             }
         }
         ExprNode::Div(num, den) => {
-            let Some(den) = as_const(arena, *den) else { return Ok(None) };
+            let Some(den) = as_const(arena, *den) else {
+                return Ok(cache_quadratic_none(ctx, id));
+            };
             if den == 0.0 {
                 return Err(SolverError::Backend(
                     "division by zero: constant denominator is 0".into(),
                 ));
             }
-            let Some(num) = try_quadratic(arena, *num, ctx)? else { return Ok(None) };
+            let Some(num) = try_quadratic(arena, *num, ctx)? else {
+                return Ok(cache_quadratic_none(ctx, id));
+            };
             try_scale(num, 1.0 / den)
         }
         ExprNode::Sin(_)
         | ExprNode::Cos(_)
         | ExprNode::Exp(_)
         | ExprNode::Log(_)
-        | ExprNode::Abs(_) => return Ok(None),
+        | ExprNode::Abs(_) => return Ok(cache_quadratic_none(ctx, id)),
     };
+    ctx.quadratic_cache.insert(id, Some(value.clone()));
     Ok(Some(value))
+}
+
+fn cache_quadratic_none(ctx: &mut LoweringCtx<'_>, id: ExprId) -> Option<LoweredExpr> {
+    ctx.quadratic_cache.insert(id, None);
+    None
+}
+
+fn for_each_child(node: &ExprNode, f: &mut impl FnMut(ExprId)) {
+    match node {
+        ExprNode::Add(children) | ExprNode::Mul(children) => {
+            for child in children {
+                f(*child);
+            }
+        }
+        ExprNode::Neg(inner)
+        | ExprNode::Sin(inner)
+        | ExprNode::Cos(inner)
+        | ExprNode::Exp(inner)
+        | ExprNode::Log(inner)
+        | ExprNode::Abs(inner) => f(*inner),
+        ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) => {
+            f(*base);
+            f(*exp);
+        }
+        ExprNode::Const(_) | ExprNode::Param(_) | ExprNode::Var(_) | ExprNode::Linear { .. } => {}
+    }
+}
+
+fn reference_counts(arena: &ExprArena, root: ExprId) -> Vec<usize> {
+    let mut seen = vec![false; arena.len()];
+    let mut order = Vec::new();
+    let mut stack = vec![(root, false)];
+    while let Some((id, expanded)) = stack.pop() {
+        if expanded {
+            order.push(id);
+            continue;
+        }
+        if seen[id.index()] {
+            continue;
+        }
+        seen[id.index()] = true;
+        stack.push((id, true));
+        for_each_child(arena.get(id), &mut |child| stack.push((child, false)));
+    }
+
+    let mut counts = vec![0_usize; arena.len()];
+    counts[root.index()] = 1;
+    for id in order.into_iter().rev() {
+        let count = counts[id.index()];
+        for_each_child(arena.get(id), &mut |child| {
+            counts[child.index()] = counts[child.index()].saturating_add(count);
+        });
+    }
+    counts
 }
 
 struct TreeBuilder {
     opcode: Vec<i32>,
     data: Vec<f64>,
     parent: Vec<i32>,
+    materializing: Option<ExprId>,
 }
 
 impl TreeBuilder {
-    fn new() -> Self {
-        Self { opcode: Vec::new(), data: Vec::new(), parent: Vec::new() }
+    fn new(materializing: Option<ExprId>) -> Self {
+        Self { opcode: Vec::new(), data: Vec::new(), parent: Vec::new(), materializing }
     }
 
     fn push(
@@ -459,6 +554,26 @@ fn materialize_abs(
     Ok(result)
 }
 
+fn materialize_shared(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    id: ExprId,
+) -> Result<Var, SolverError> {
+    if let Some(&result) = ctx.materialized.get(&id) {
+        return Ok(result);
+    }
+    let result = if let Some(value) = try_quadratic(arena, id, ctx)? {
+        materialize_lowered(ctx, value)?
+    } else {
+        match arena.get(id) {
+            ExprNode::Abs(inner) => materialize_abs(ctx, arena, *inner)?,
+            _ => native_expr(ctx, arena, id)?,
+        }
+    };
+    ctx.materialized.insert(id, result);
+    Ok(result)
+}
+
 fn append_tree(
     ctx: &mut LoweringCtx<'_>,
     arena: &ExprArena,
@@ -466,6 +581,20 @@ fn append_tree(
     parent: Option<usize>,
     tree: &mut TreeBuilder,
 ) -> Result<usize, SolverError> {
+    if tree.materializing != Some(id) {
+        if let Some(&result) = ctx.materialized.get(&id) {
+            let index = ctx.model.var_index(&result).map_err(map_gurobi)?;
+            return tree.push(Opcode::Variable, f64::from(index), parent);
+        }
+        let shared = ctx.reference_counts.get(id.index()).copied().unwrap_or_default() > 1;
+        let leaf =
+            matches!(arena.get(id), ExprNode::Const(_) | ExprNode::Param(_) | ExprNode::Var(_));
+        if shared && !leaf {
+            let result = materialize_shared(ctx, arena, id)?;
+            let index = ctx.model.var_index(&result).map_err(map_gurobi)?;
+            return tree.push(Opcode::Variable, f64::from(index), parent);
+        }
+    }
     match arena.get(id) {
         ExprNode::Const(c) => tree.push(Opcode::Constant, *c, parent),
         ExprNode::Param(p) => tree.push(Opcode::Constant, arena.param_value(*p), parent),
@@ -534,7 +663,7 @@ fn native_expr(
     id: ExprId,
 ) -> Result<Var, SolverError> {
     let result = ctx.new_aux("nl", f64::NEG_INFINITY, f64::INFINITY).map_err(map_gurobi)?;
-    let mut tree = TreeBuilder::new();
+    let mut tree = TreeBuilder::new(Some(id));
     append_tree(ctx, arena, id, None, &mut tree)?;
     let name = ctx.next_name("nl_def");
     let generated = ctx
@@ -542,6 +671,7 @@ fn native_expr(
         .add_genconstr_nl(&name, result, &tree.opcode, &tree.data, &tree.parent)
         .map_err(map_gurobi)?;
     ctx.generated.push(GeneratedConstraint::General(generated));
+    ctx.materialized.insert(id, result);
     Ok(result)
 }
 
@@ -553,6 +683,7 @@ pub(crate) fn lower(
     if let Some(value) = try_quadratic(arena, id, ctx)? {
         return Ok(value);
     }
+    ctx.reference_counts = reference_counts(arena, id);
     Ok(LoweredExpr::Var(native_expr(ctx, arena, id)?))
 }
 

--- a/crates/oximo-gurobi/src/nonlinear.rs
+++ b/crates/oximo-gurobi/src/nonlinear.rs
@@ -311,15 +311,27 @@ fn append_sum(
     parent: Option<usize>,
     tree: &mut TreeBuilder,
 ) -> Result<usize, SolverError> {
-    if let Some((&last, rest)) = ids.split_last() {
-        if rest.is_empty() {
-            return append_tree(ctx, arena, last, parent, tree);
+    match ids {
+        [] => tree.push(Opcode::Constant, 0.0, parent),
+        [id] => append_tree(ctx, arena, *id, parent, tree),
+        _ => {
+            let mut operators = Vec::with_capacity(ids.len() - 1);
+            let mut current_parent = tree.push(Opcode::Plus, 0.0, parent)?;
+            operators.push(current_parent);
+            for _ in 1..ids.len() - 1 {
+                current_parent = tree.push(Opcode::Plus, 0.0, Some(current_parent))?;
+                operators.push(current_parent);
+            }
+
+            append_tree(ctx, arena, ids[0], Some(current_parent), tree)?;
+            if ids.len() > 2 {
+                append_tree(ctx, arena, ids[1], Some(current_parent), tree)?;
+                for (id, op) in ids[2..ids.len() - 1].iter().zip(operators.iter().rev().skip(1)) {
+                    append_tree(ctx, arena, *id, Some(*op), tree)?;
+                }
+            }
+            append_tree(ctx, arena, ids[ids.len() - 1], Some(operators[0]), tree)
         }
-        let op = tree.push(Opcode::Plus, 0.0, parent)?;
-        append_sum(ctx, arena, rest, Some(op), tree)?;
-        append_tree(ctx, arena, last, Some(op), tree)
-    } else {
-        tree.push(Opcode::Constant, 0.0, parent)
     }
 }
 
@@ -330,15 +342,27 @@ fn append_product(
     parent: Option<usize>,
     tree: &mut TreeBuilder,
 ) -> Result<usize, SolverError> {
-    if let Some((&last, rest)) = ids.split_last() {
-        if rest.is_empty() {
-            return append_tree(ctx, arena, last, parent, tree);
+    match ids {
+        [] => tree.push(Opcode::Constant, 1.0, parent),
+        [id] => append_tree(ctx, arena, *id, parent, tree),
+        _ => {
+            let mut operators = Vec::with_capacity(ids.len() - 1);
+            let mut current_parent = tree.push(Opcode::Multiply, 0.0, parent)?;
+            operators.push(current_parent);
+            for _ in 1..ids.len() - 1 {
+                current_parent = tree.push(Opcode::Multiply, 0.0, Some(current_parent))?;
+                operators.push(current_parent);
+            }
+
+            append_tree(ctx, arena, ids[0], Some(current_parent), tree)?;
+            if ids.len() > 2 {
+                append_tree(ctx, arena, ids[1], Some(current_parent), tree)?;
+                for (id, op) in ids[2..ids.len() - 1].iter().zip(operators.iter().rev().skip(1)) {
+                    append_tree(ctx, arena, *id, Some(*op), tree)?;
+                }
+            }
+            append_tree(ctx, arena, ids[ids.len() - 1], Some(operators[0]), tree)
         }
-        let op = tree.push(Opcode::Multiply, 0.0, parent)?;
-        append_product(ctx, arena, rest, Some(op), tree)?;
-        append_tree(ctx, arena, last, Some(op), tree)
-    } else {
-        tree.push(Opcode::Constant, 1.0, parent)
     }
 }
 
@@ -353,11 +377,13 @@ fn append_linear_parts(
     parent: Option<usize>,
     tree: &mut TreeBuilder,
 ) -> Result<usize, SolverError> {
-    let Some((last, rest)) = parts.split_last() else {
-        return tree.push(Opcode::Constant, 0.0, parent);
-    };
-    if rest.is_empty() {
-        return match last {
+    fn append_part(
+        ctx: &mut LoweringCtx<'_>,
+        part: &LinearPart,
+        parent: Option<usize>,
+        tree: &mut TreeBuilder,
+    ) -> Result<usize, SolverError> {
+        match part {
             LinearPart::Constant(c) => tree.push(Opcode::Constant, *c, parent),
             LinearPart::Term(var, coeff) => {
                 let op = tree.push(Opcode::Multiply, 0.0, parent)?;
@@ -365,18 +391,31 @@ fn append_linear_parts(
                 let index = ctx.model.var_index(var).map_err(map_gurobi)?;
                 tree.push(Opcode::Variable, f64::from(index), Some(op))
             }
-        };
+        }
     }
-    let op = tree.push(Opcode::Plus, 0.0, parent)?;
-    append_linear_parts(ctx, rest, Some(op), tree)?;
-    match last {
-        LinearPart::Constant(c) => tree.push(Opcode::Constant, *c, Some(op)),
-        LinearPart::Term(_, coeff) => {
-            let mul = tree.push(Opcode::Multiply, 0.0, Some(op))?;
-            tree.push(Opcode::Constant, *coeff, Some(mul))?;
-            let LinearPart::Term(var, _) = last else { unreachable!() };
-            let index = ctx.model.var_index(var).map_err(map_gurobi)?;
-            tree.push(Opcode::Variable, f64::from(index), Some(mul))
+
+    match parts {
+        [] => tree.push(Opcode::Constant, 0.0, parent),
+        [part] => append_part(ctx, part, parent, tree),
+        _ => {
+            let mut operators = Vec::with_capacity(parts.len() - 1);
+            let mut current_parent = tree.push(Opcode::Plus, 0.0, parent)?;
+            operators.push(current_parent);
+            for _ in 1..parts.len() - 1 {
+                current_parent = tree.push(Opcode::Plus, 0.0, Some(current_parent))?;
+                operators.push(current_parent);
+            }
+
+            append_part(ctx, &parts[0], Some(current_parent), tree)?;
+            if parts.len() > 2 {
+                append_part(ctx, &parts[1], Some(current_parent), tree)?;
+                for (part, op) in
+                    parts[2..parts.len() - 1].iter().zip(operators.iter().rev().skip(1))
+                {
+                    append_part(ctx, part, Some(*op), tree)?;
+                }
+            }
+            append_part(ctx, &parts[parts.len() - 1], Some(operators[0]), tree)
         }
     }
 }

--- a/crates/oximo-gurobi/src/nonlinear.rs
+++ b/crates/oximo-gurobi/src/nonlinear.rs
@@ -497,6 +497,11 @@ fn append_tree(
             append_tree(ctx, arena, *exp, Some(op), tree)
         }
         ExprNode::Div(num, den) => {
+            if let Some(0.0) = as_const(arena, *den) {
+                return Err(SolverError::Backend(
+                    "division by zero: constant denominator is 0".into(),
+                ));
+            }
             let op = tree.push(Opcode::Divide, 0.0, parent)?;
             append_tree(ctx, arena, *num, Some(op), tree)?;
             append_tree(ctx, arena, *den, Some(op), tree)

--- a/crates/oximo-gurobi/src/nonlinear.rs
+++ b/crates/oximo-gurobi/src/nonlinear.rs
@@ -1,48 +1,56 @@
-//! Lower an oximo expression tree onto Gurobi's native types.
-//!
-//! Gurobi 12 supports linear, quadratic, and a fixed set of general nonlinear
-//! function constraints (exp/log/sin/cos/pow/...) where each one takes the form
-//! `y = f(x)` between two variables. Anything more complex must be flattened
-//! into a DAG of auxiliary variables connected by those primitive equalities.
-//! This module is that flattening pass.
+//! Lower nonlinear oximo expressions onto Gurobi 13 expression trees.
 
-// TODO: This will change once we can get support for V13 in the grb crate
-// since we will be able to use generic expresion trees
-
-use grb::expr::{LinExpr, QuadExpr};
-use grb::prelude::*;
+use gurobi_rs::Opcode;
+use gurobi_rs::expr::{LinExpr, QuadExpr};
+use gurobi_rs::prelude::*;
 use oximo_expr::{ExprArena, ExprId, ExprNode, VarId};
 use oximo_solver::SolverError;
 
+/// A value that can stay on Gurobi's direct linear/quadratic fast path, or a
+/// variable containing a native nonlinear expression-tree result.
 pub(crate) enum LoweredExpr {
     Linear(LinExpr),
     Quadratic(QuadExpr),
     Var(Var),
 }
 
+/// A definition generated while lowering one original nonlinear constraint.
+/// IIS membership of any of these definitions is attributed to that original
+/// constraint by the translation layer.
+pub(crate) enum GeneratedConstraint {
+    Linear(Constr),
+    Quadratic(QConstr),
+    General(GenConstr),
+}
+
 pub(crate) struct LoweringCtx<'a> {
     pub model: &'a mut Model,
     pub gurobi_vars: &'a [Var],
     pub aux_counter: u32,
+    pub generated: Vec<GeneratedConstraint>,
 }
 
 impl LoweringCtx<'_> {
     fn next_name(&mut self, tag: &str) -> String {
         let n = self.aux_counter;
-        self.aux_counter += 1;
+        self.aux_counter = self.aux_counter.saturating_add(1);
         format!("aux_{tag}_{n}")
     }
 
-    fn new_aux(&mut self, tag: &str, lb: f64, ub: f64) -> Result<Var, grb::Error> {
+    fn new_aux(&mut self, tag: &str, lb: f64, ub: f64) -> Result<Var, gurobi_rs::Error> {
         let name = self.next_name(tag);
-        let m = &mut *self.model;
-        #[expect(clippy::unnecessary_cast)]
-        let v = add_ctsvar!(m, name: &name, bounds: lb..ub)?;
-        Ok(v)
+        self.model.add_var(&name, Continuous, 0.0, lb, ub, [])
+    }
+
+    fn variable(&self, v: VarId) -> Result<Var, SolverError> {
+        self.gurobi_vars
+            .get(v.index())
+            .copied()
+            .ok_or_else(|| SolverError::Backend(format!("variable index {} is out of range", v.0)))
     }
 }
 
-fn map_grb(e: grb::Error) -> SolverError {
+fn map_gurobi(e: gurobi_rs::Error) -> SolverError {
     SolverError::Backend(format!("Gurobi: {e}"))
 }
 
@@ -60,8 +68,9 @@ fn linear_constant(c: f64) -> LinExpr {
 
 fn quad_from_linear(e: LinExpr) -> QuadExpr {
     let mut q = QuadExpr::new();
-    q.add_constant(e.get_offset());
-    for (v, c) in e.into_parts().0 {
+    let (coeffs, offset) = e.into_parts();
+    q.add_constant(offset);
+    for (v, c) in coeffs {
         q.add_term(c, v);
     }
     q
@@ -78,8 +87,9 @@ fn add_linears(mut a: LinExpr, b: LinExpr) -> LinExpr {
 
 fn add_quads(mut a: QuadExpr, b: QuadExpr) -> QuadExpr {
     let (qcoeffs, linexpr) = b.into_parts();
-    a.add_constant(linexpr.get_offset());
-    for (v, c) in linexpr.into_parts().0 {
+    let (coeffs, offset) = linexpr.into_parts();
+    a.add_constant(offset);
+    for (v, c) in coeffs {
         a.add_term(c, v);
     }
     for ((x, y), c) in qcoeffs {
@@ -98,73 +108,194 @@ fn scale_quad(mut e: QuadExpr, k: f64) -> QuadExpr {
     e
 }
 
-/// Convert any lowered form to a `LinExpr`.
-///
-/// Panics if quadratic, callers must only invoke when the value
-/// is known linear (i.e. degree <= 1).
+fn linear_is_constant(e: &LinExpr) -> bool {
+    e.iter_terms().next().is_none()
+}
+
+fn multiply_linears(a: &LinExpr, b: &LinExpr) -> QuadExpr {
+    let a_off = a.get_offset();
+    let b_off = b.get_offset();
+    let mut q = QuadExpr::new();
+    q.add_constant(a_off * b_off);
+    for (va, ca) in a.iter_terms() {
+        q.add_term(ca * b_off, *va);
+    }
+    for (vb, cb) in b.iter_terms() {
+        q.add_term(a_off * cb, *vb);
+    }
+    for (va, ca) in a.iter_terms() {
+        for (vb, cb) in b.iter_terms() {
+            q.add_qterm(ca * cb, *va, *vb);
+        }
+    }
+    q
+}
+
 fn into_linexpr(l: LoweredExpr) -> LinExpr {
     match l {
         LoweredExpr::Linear(e) => e,
         LoweredExpr::Var(v) => linear_from_var(v),
-        LoweredExpr::Quadratic(_) => {
-            panic!("internal: into_linexpr called on Quadratic LoweredExpr")
-        }
+        LoweredExpr::Quadratic(_) => panic!("internal: expected a linear expression"),
     }
 }
 
-/// Combine two lowered values additively, promoting to the highest order.
-fn lowered_add(a: LoweredExpr, b: LoweredExpr) -> LoweredExpr {
+fn try_add(a: LoweredExpr, b: LoweredExpr) -> LoweredExpr {
     use LoweredExpr::{Linear, Quadratic, Var};
     match (a, b) {
         (Linear(x), Linear(y)) => Linear(add_linears(x, y)),
-        (Var(v), Linear(y)) | (Linear(y), Var(v)) => Linear(add_linears(y, linear_from_var(v))),
-        (Var(v), Var(w)) => Linear(add_linears(linear_from_var(v), linear_from_var(w))),
         (Quadratic(x), Quadratic(y)) => Quadratic(add_quads(x, y)),
         (Quadratic(x), other) | (other, Quadratic(x)) => {
-            let y = into_linexpr(other);
-            Quadratic(add_quads(x, quad_from_linear(y)))
+            Quadratic(add_quads(x, quad_from_linear(into_linexpr(other))))
         }
+        (Var(v), Linear(y)) | (Linear(y), Var(v)) => Linear(add_linears(y, linear_from_var(v))),
+        (Var(v), Var(w)) => Linear(add_linears(linear_from_var(v), linear_from_var(w))),
     }
 }
 
-fn lowered_scale(l: LoweredExpr, k: f64) -> LoweredExpr {
-    use LoweredExpr::{Linear, Quadratic, Var};
-    if k == 0.0 {
-        return Linear(linear_constant(0.0));
-    }
+fn try_scale(l: LoweredExpr, k: f64) -> LoweredExpr {
     match l {
-        Linear(e) => Linear(scale_linear(e, k)),
-        Quadratic(e) => Quadratic(scale_quad(e, k)),
-        Var(v) => Linear(scale_linear(linear_from_var(v), k)),
+        LoweredExpr::Linear(e) => LoweredExpr::Linear(scale_linear(e, k)),
+        LoweredExpr::Quadratic(e) => LoweredExpr::Quadratic(scale_quad(e, k)),
+        LoweredExpr::Var(v) => LoweredExpr::Linear(scale_linear(linear_from_var(v), k)),
     }
 }
 
-fn lowered_neg(l: LoweredExpr) -> LoweredExpr {
-    lowered_scale(l, -1.0)
+fn try_mul(values: Vec<LoweredExpr>) -> Option<LoweredExpr> {
+    let mut acc = LoweredExpr::Linear(linear_constant(1.0));
+    for value in values {
+        acc = match (acc, value) {
+            (LoweredExpr::Linear(a), LoweredExpr::Linear(b)) => {
+                if linear_is_constant(&a) {
+                    LoweredExpr::Linear(scale_linear(b, a.get_offset()))
+                } else if linear_is_constant(&b) {
+                    LoweredExpr::Linear(scale_linear(a, b.get_offset()))
+                } else {
+                    LoweredExpr::Quadratic(multiply_linears(&a, &b))
+                }
+            }
+            (LoweredExpr::Quadratic(a), LoweredExpr::Linear(b)) => {
+                if linear_is_constant(&b) {
+                    LoweredExpr::Quadratic(scale_quad(a, b.get_offset()))
+                } else {
+                    return None;
+                }
+            }
+            (LoweredExpr::Linear(a), LoweredExpr::Quadratic(b)) => {
+                if linear_is_constant(&a) {
+                    LoweredExpr::Quadratic(scale_quad(b, a.get_offset()))
+                } else {
+                    return None;
+                }
+            }
+            (LoweredExpr::Quadratic(_), LoweredExpr::Quadratic(_)) => return None,
+            (LoweredExpr::Var(_), _) | (_, LoweredExpr::Var(_)) => {
+                unreachable!("quadratic probe normalizes variables")
+            }
+        };
+    }
+    Some(acc)
 }
 
-/// Materialize `lowered` into a single Gurobi variable, returning the existing
-/// one if it is already opaque. Bounds default to +-inf, callers should tighten
-/// when they know more about the value's range.
-fn as_aux_var(lowered: LoweredExpr, ctx: &mut LoweringCtx<'_>) -> Result<Var, SolverError> {
-    match lowered {
-        LoweredExpr::Var(v) => Ok(v),
-        LoweredExpr::Linear(e) => {
-            let aux = ctx.new_aux("v", f64::NEG_INFINITY, f64::INFINITY).map_err(map_grb)?;
-            let name = ctx.next_name("eq");
-            ctx.model.add_constr(&name, c!(aux == e)).map_err(map_grb)?;
-            Ok(aux)
+/// Probe whether an expression is representable directly as linear or
+/// quadratic.
+fn try_quadratic(
+    arena: &ExprArena,
+    id: ExprId,
+    ctx: &LoweringCtx<'_>,
+) -> Result<Option<LoweredExpr>, SolverError> {
+    let value = match arena.get(id) {
+        ExprNode::Const(c) => LoweredExpr::Linear(linear_constant(*c)),
+        ExprNode::Param(p) => LoweredExpr::Linear(linear_constant(arena.param_value(*p))),
+        ExprNode::Var(v) => LoweredExpr::Linear(linear_from_var(ctx.variable(*v)?)),
+        ExprNode::Linear { coeffs, constant } => {
+            let mut e = linear_constant(*constant);
+            for &(v, c) in coeffs {
+                e.add_term(c, ctx.variable(v)?);
+            }
+            LoweredExpr::Linear(e)
         }
-        LoweredExpr::Quadratic(e) => {
-            let aux = ctx.new_aux("v", f64::NEG_INFINITY, f64::INFINITY).map_err(map_grb)?;
-            let name = ctx.next_name("qeq");
-            ctx.model.add_qconstr(&name, c!(aux == e)).map_err(map_grb)?;
-            Ok(aux)
+        ExprNode::Neg(inner) => {
+            let Some(inner) = try_quadratic(arena, *inner, ctx)? else { return Ok(None) };
+            try_scale(inner, -1.0)
         }
+        ExprNode::Add(children) => {
+            let mut acc = LoweredExpr::Linear(linear_constant(0.0));
+            for child in children {
+                let Some(value) = try_quadratic(arena, *child, ctx)? else { return Ok(None) };
+                acc = try_add(acc, value);
+            }
+            acc
+        }
+        ExprNode::Mul(children) => {
+            let mut values = Vec::with_capacity(children.len());
+            for child in children {
+                let Some(value) = try_quadratic(arena, *child, ctx)? else { return Ok(None) };
+                values.push(value);
+            }
+            let Some(value) = try_mul(values) else { return Ok(None) };
+            value
+        }
+        ExprNode::Pow(base, exp) => {
+            let Some(alpha) = as_const(arena, *exp) else { return Ok(None) };
+            let Some(base) = try_quadratic(arena, *base, ctx)? else { return Ok(None) };
+            if alpha == 0.0 {
+                LoweredExpr::Linear(linear_constant(1.0))
+            } else if (alpha - 1.0).abs() < f64::EPSILON {
+                base
+            } else if (alpha - 2.0).abs() < f64::EPSILON {
+                let LoweredExpr::Linear(base) = base else { return Ok(None) };
+                LoweredExpr::Quadratic(multiply_linears(&base, &base))
+            } else {
+                return Ok(None);
+            }
+        }
+        ExprNode::Div(num, den) => {
+            let Some(den) = as_const(arena, *den) else { return Ok(None) };
+            if den == 0.0 {
+                return Err(SolverError::Backend(
+                    "division by zero: constant denominator is 0".into(),
+                ));
+            }
+            let Some(num) = try_quadratic(arena, *num, ctx)? else { return Ok(None) };
+            try_scale(num, 1.0 / den)
+        }
+        ExprNode::Sin(_)
+        | ExprNode::Cos(_)
+        | ExprNode::Exp(_)
+        | ExprNode::Log(_)
+        | ExprNode::Abs(_) => return Ok(None),
+    };
+    Ok(Some(value))
+}
+
+struct TreeBuilder {
+    opcode: Vec<i32>,
+    data: Vec<f64>,
+    parent: Vec<i32>,
+}
+
+impl TreeBuilder {
+    fn new() -> Self {
+        Self { opcode: Vec::new(), data: Vec::new(), parent: Vec::new() }
+    }
+
+    fn push(
+        &mut self,
+        opcode: Opcode,
+        data: f64,
+        parent: Option<usize>,
+    ) -> Result<usize, SolverError> {
+        let index = self.opcode.len();
+        let parent = parent.map_or(Ok(-1), i32::try_from).map_err(|_| {
+            SolverError::Backend("nonlinear expression tree parent index exceeds i32".into())
+        })?;
+        self.opcode.push(opcode as i32);
+        self.data.push(data);
+        self.parent.push(parent);
+        Ok(index)
     }
 }
 
-/// True if `id` is a literal constant or a parameter, returns the value if so.
 fn as_const(arena: &ExprArena, id: ExprId) -> Option<f64> {
     match arena.get(id) {
         ExprNode::Const(c) => Some(*c),
@@ -173,271 +304,220 @@ fn as_const(arena: &ExprArena, id: ExprId) -> Option<f64> {
     }
 }
 
+fn append_sum(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    ids: &[ExprId],
+    parent: Option<usize>,
+    tree: &mut TreeBuilder,
+) -> Result<usize, SolverError> {
+    if let Some((&last, rest)) = ids.split_last() {
+        if rest.is_empty() {
+            return append_tree(ctx, arena, last, parent, tree);
+        }
+        let op = tree.push(Opcode::Plus, 0.0, parent)?;
+        append_sum(ctx, arena, rest, Some(op), tree)?;
+        append_tree(ctx, arena, last, Some(op), tree)
+    } else {
+        tree.push(Opcode::Constant, 0.0, parent)
+    }
+}
+
+fn append_product(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    ids: &[ExprId],
+    parent: Option<usize>,
+    tree: &mut TreeBuilder,
+) -> Result<usize, SolverError> {
+    if let Some((&last, rest)) = ids.split_last() {
+        if rest.is_empty() {
+            return append_tree(ctx, arena, last, parent, tree);
+        }
+        let op = tree.push(Opcode::Multiply, 0.0, parent)?;
+        append_product(ctx, arena, rest, Some(op), tree)?;
+        append_tree(ctx, arena, last, Some(op), tree)
+    } else {
+        tree.push(Opcode::Constant, 1.0, parent)
+    }
+}
+
+enum LinearPart {
+    Constant(f64),
+    Term(Var, f64),
+}
+
+fn append_linear_parts(
+    ctx: &mut LoweringCtx<'_>,
+    parts: &[LinearPart],
+    parent: Option<usize>,
+    tree: &mut TreeBuilder,
+) -> Result<usize, SolverError> {
+    let Some((last, rest)) = parts.split_last() else {
+        return tree.push(Opcode::Constant, 0.0, parent);
+    };
+    if rest.is_empty() {
+        return match last {
+            LinearPart::Constant(c) => tree.push(Opcode::Constant, *c, parent),
+            LinearPart::Term(var, coeff) => {
+                let op = tree.push(Opcode::Multiply, 0.0, parent)?;
+                tree.push(Opcode::Constant, *coeff, Some(op))?;
+                let index = ctx.model.var_index(var).map_err(map_gurobi)?;
+                tree.push(Opcode::Variable, f64::from(index), Some(op))
+            }
+        };
+    }
+    let op = tree.push(Opcode::Plus, 0.0, parent)?;
+    append_linear_parts(ctx, rest, Some(op), tree)?;
+    match last {
+        LinearPart::Constant(c) => tree.push(Opcode::Constant, *c, Some(op)),
+        LinearPart::Term(_, coeff) => {
+            let mul = tree.push(Opcode::Multiply, 0.0, Some(op))?;
+            tree.push(Opcode::Constant, *coeff, Some(mul))?;
+            let LinearPart::Term(var, _) = last else { unreachable!() };
+            let index = ctx.model.var_index(var).map_err(map_gurobi)?;
+            tree.push(Opcode::Variable, f64::from(index), Some(mul))
+        }
+    }
+}
+
+fn materialize_lowered(ctx: &mut LoweringCtx<'_>, value: LoweredExpr) -> Result<Var, SolverError> {
+    match value {
+        LoweredExpr::Var(v) => Ok(v),
+        LoweredExpr::Linear(e) => {
+            let aux =
+                ctx.new_aux("affine", f64::NEG_INFINITY, f64::INFINITY).map_err(map_gurobi)?;
+            let name = ctx.next_name("affine_eq");
+            let row = ctx.model.add_constr(&name, c!(aux == e)).map_err(map_gurobi)?;
+            ctx.generated.push(GeneratedConstraint::Linear(row));
+            Ok(aux)
+        }
+        LoweredExpr::Quadratic(e) => {
+            let aux =
+                ctx.new_aux("quadratic", f64::NEG_INFINITY, f64::INFINITY).map_err(map_gurobi)?;
+            let name = ctx.next_name("quadratic_eq");
+            let row = ctx.model.add_qconstr(&name, c!(aux == e)).map_err(map_gurobi)?;
+            ctx.generated.push(GeneratedConstraint::Quadratic(row));
+            Ok(aux)
+        }
+    }
+}
+
+fn materialize_abs(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    inner: ExprId,
+) -> Result<Var, SolverError> {
+    let argument = if let Some(value) = try_quadratic(arena, inner, ctx)? {
+        materialize_lowered(ctx, value)?
+    } else {
+        native_expr(ctx, arena, inner)?
+    };
+    let result = ctx.new_aux("abs", 0.0, f64::INFINITY).map_err(map_gurobi)?;
+    let name = ctx.next_name("abs_def");
+    let generated = ctx.model.add_genconstr_abs(&name, result, argument).map_err(map_gurobi)?;
+    ctx.generated.push(GeneratedConstraint::General(generated));
+    Ok(result)
+}
+
+fn append_tree(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    id: ExprId,
+    parent: Option<usize>,
+    tree: &mut TreeBuilder,
+) -> Result<usize, SolverError> {
+    match arena.get(id) {
+        ExprNode::Const(c) => tree.push(Opcode::Constant, *c, parent),
+        ExprNode::Param(p) => tree.push(Opcode::Constant, arena.param_value(*p), parent),
+        ExprNode::Var(v) => {
+            let var = ctx.variable(*v)?;
+            let index = ctx.model.var_index(&var).map_err(map_gurobi)?;
+            tree.push(Opcode::Variable, f64::from(index), parent)
+        }
+        ExprNode::Linear { coeffs, constant } => {
+            let mut terms = Vec::with_capacity(coeffs.len() + usize::from(*constant != 0.0));
+            if *constant != 0.0 {
+                terms.push(LinearPart::Constant(*constant));
+            }
+            for &(var, coeff) in coeffs {
+                let v = ctx.variable(var)?;
+                terms.push(LinearPart::Term(v, coeff));
+            }
+            append_linear_parts(ctx, &terms, parent, tree)
+        }
+        ExprNode::Neg(inner) => {
+            let op = tree.push(Opcode::Uminus, 0.0, parent)?;
+            append_tree(ctx, arena, *inner, Some(op), tree)
+        }
+        ExprNode::Add(children) => append_sum(ctx, arena, children, parent, tree),
+        ExprNode::Mul(children) => append_product(ctx, arena, children, parent, tree),
+        ExprNode::Pow(base, exp) => {
+            let op = tree.push(Opcode::Pow, 0.0, parent)?;
+            append_tree(ctx, arena, *base, Some(op), tree)?;
+            append_tree(ctx, arena, *exp, Some(op), tree)
+        }
+        ExprNode::Div(num, den) => {
+            let op = tree.push(Opcode::Divide, 0.0, parent)?;
+            append_tree(ctx, arena, *num, Some(op), tree)?;
+            append_tree(ctx, arena, *den, Some(op), tree)
+        }
+        ExprNode::Sin(inner)
+        | ExprNode::Cos(inner)
+        | ExprNode::Exp(inner)
+        | ExprNode::Log(inner) => {
+            let opcode = match arena.get(id) {
+                ExprNode::Sin(_) => Opcode::Sin,
+                ExprNode::Cos(_) => Opcode::Cos,
+                ExprNode::Exp(_) => Opcode::Exp,
+                ExprNode::Log(_) => Opcode::Log,
+                _ => unreachable!(),
+            };
+            let op = tree.push(opcode, 0.0, parent)?;
+            append_tree(ctx, arena, *inner, Some(op), tree)
+        }
+        ExprNode::Abs(inner) => {
+            let result = materialize_abs(ctx, arena, *inner)?;
+            let index = ctx.model.var_index(&result).map_err(map_gurobi)?;
+            tree.push(Opcode::Variable, f64::from(index), parent)
+        }
+    }
+}
+
+fn native_expr(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    id: ExprId,
+) -> Result<Var, SolverError> {
+    let result = ctx.new_aux("nl", f64::NEG_INFINITY, f64::INFINITY).map_err(map_gurobi)?;
+    let mut tree = TreeBuilder::new();
+    append_tree(ctx, arena, id, None, &mut tree)?;
+    let name = ctx.next_name("nl_def");
+    let generated = ctx
+        .model
+        .add_genconstr_nl(&name, result, &tree.opcode, &tree.data, &tree.parent)
+        .map_err(map_gurobi)?;
+    ctx.generated.push(GeneratedConstraint::General(generated));
+    Ok(result)
+}
+
 pub(crate) fn lower(
     arena: &ExprArena,
     id: ExprId,
     ctx: &mut LoweringCtx<'_>,
 ) -> Result<LoweredExpr, SolverError> {
-    match arena.get(id) {
-        ExprNode::Const(c) => Ok(LoweredExpr::Linear(linear_constant(*c))),
-        ExprNode::Var(v) => Ok(LoweredExpr::Linear(linear_from_var(grb_var(ctx, *v)))),
-        ExprNode::Param(p) => Ok(LoweredExpr::Linear(linear_constant(arena.param_value(*p)))),
-        ExprNode::Linear { coeffs, constant } => {
-            let mut e = linear_constant(*constant);
-            for (v, c) in coeffs {
-                e.add_term(*c, grb_var(ctx, *v));
-            }
-            Ok(LoweredExpr::Linear(e))
-        }
-        ExprNode::Neg(inner) => {
-            let l = lower(arena, *inner, ctx)?;
-            Ok(lowered_neg(l))
-        }
-        ExprNode::Add(children) => {
-            let mut acc = LoweredExpr::Linear(linear_constant(0.0));
-            for c in children {
-                let l = lower(arena, *c, ctx)?;
-                acc = lowered_add(acc, l);
-            }
-            Ok(acc)
-        }
-        ExprNode::Mul(children) => lower_mul(arena, children, ctx),
-        ExprNode::Pow(base, exp) => lower_pow(arena, *base, *exp, ctx),
-        ExprNode::Div(num, den) => lower_div(arena, *num, *den, ctx),
-        ExprNode::Sin(a) => lower_unary(arena, *a, ctx, UnaryFn::Sin),
-        ExprNode::Cos(a) => lower_unary(arena, *a, ctx, UnaryFn::Cos),
-        ExprNode::Exp(a) => lower_unary(arena, *a, ctx, UnaryFn::Exp),
-        ExprNode::Log(a) => lower_unary(arena, *a, ctx, UnaryFn::Log),
-        ExprNode::Abs(a) => lower_unary(arena, *a, ctx, UnaryFn::Abs),
+    if let Some(value) = try_quadratic(arena, id, ctx)? {
+        return Ok(value);
     }
+    Ok(LoweredExpr::Var(native_expr(ctx, arena, id)?))
 }
 
-fn grb_var(ctx: &LoweringCtx<'_>, v: VarId) -> Var {
-    ctx.gurobi_vars[v.index()]
-}
-
-fn lower_mul(
-    arena: &ExprArena,
-    children: &[ExprId],
-    ctx: &mut LoweringCtx<'_>,
-) -> Result<LoweredExpr, SolverError> {
-    let mut scalar = 1.0_f64;
-    let mut non_consts: Vec<ExprId> = Vec::new();
-    for c in children {
-        if let Some(k) = as_const(arena, *c) {
-            scalar *= k;
-        } else {
-            non_consts.push(*c);
-        }
-    }
-    if non_consts.is_empty() {
-        return Ok(LoweredExpr::Linear(linear_constant(scalar)));
-    }
-    if non_consts.len() == 1 {
-        let l = lower(arena, non_consts[0], ctx)?;
-        return Ok(lowered_scale(l, scalar));
-    }
-    if non_consts.len() == 2 {
-        let a = lower(arena, non_consts[0], ctx)?;
-        let b = lower(arena, non_consts[1], ctx)?;
-        // Linear * Linear -> quadratic, if either side has variable terms.
-        if let (LoweredExpr::Linear(la), LoweredExpr::Linear(lb)) = (&a, &b) {
-            let q = multiply_linears(la, lb, scalar);
-            return Ok(LoweredExpr::Quadratic(q));
-        }
-        // Mixed with Quadratic or Var -> materialize aux vars and recompose.
-        let va = as_aux_var(a, ctx)?;
-        let vb = as_aux_var(b, ctx)?;
-        let mut q = QuadExpr::new();
-        q.add_qterm(scalar, va, vb);
-        return Ok(LoweredExpr::Quadratic(q));
-    }
-    // 3+ non-constant factors: degree > 2. Fold left, materializing aux vars.
-    let mut acc_var = {
-        let a = lower(arena, non_consts[0], ctx)?;
-        let b = lower(arena, non_consts[1], ctx)?;
-        let va = as_aux_var(a, ctx)?;
-        let vb = as_aux_var(b, ctx)?;
-        let mut q = QuadExpr::new();
-        q.add_qterm(1.0, va, vb);
-        as_aux_var(LoweredExpr::Quadratic(q), ctx)?
-    };
-    for c in &non_consts[2..] {
-        let next = lower(arena, *c, ctx)?;
-        let vn = as_aux_var(next, ctx)?;
-        let mut q = QuadExpr::new();
-        q.add_qterm(1.0, acc_var, vn);
-        acc_var = as_aux_var(LoweredExpr::Quadratic(q), ctx)?;
-    }
-    Ok(lowered_scale(LoweredExpr::Var(acc_var), scalar))
-}
-
-fn multiply_linears(a: &LinExpr, b: &LinExpr, scalar: f64) -> QuadExpr {
-    let a_off = a.get_offset();
-    let b_off = b.get_offset();
-    let mut q = QuadExpr::new();
-    q.add_constant(scalar * a_off * b_off);
-    for (va, ca) in a.iter_terms() {
-        q.add_term(scalar * ca * b_off, *va);
-    }
-    for (vb, cb) in b.iter_terms() {
-        q.add_term(scalar * a_off * cb, *vb);
-    }
-    for (va, ca) in a.iter_terms() {
-        for (vb, cb) in b.iter_terms() {
-            q.add_qterm(scalar * ca * cb, *va, *vb);
-        }
-    }
-    q
-}
-
-fn lower_pow(
-    arena: &ExprArena,
-    base: ExprId,
-    exp: ExprId,
-    ctx: &mut LoweringCtx<'_>,
-) -> Result<LoweredExpr, SolverError> {
-    // Constant exponent -> either expand to a Mul chain (small ints) or use
-    // Gurobi's add_genconstr_pow. Non-constant exponent -> exp(b*log(a)).
-    if let Some(alpha) = as_const(arena, exp) {
-        if alpha == 0.0 {
-            return Ok(LoweredExpr::Linear(linear_constant(1.0)));
-        }
-        if (alpha - 1.0).abs() < f64::EPSILON {
-            return lower(arena, base, ctx);
-        }
-        if (alpha - alpha.round()).abs() < f64::EPSILON && alpha > 0.0 && alpha <= 4.0 {
-            // Pre-checks guarantee alpha in {1.0, 2.0, 3.0, 4.0}, alpha == 1 was
-            // already handled above, so bucket the remaining three values.
-            let n: u32 = match alpha.round() {
-                v if v < 2.5 => 2,
-                v if v < 3.5 => 3,
-                _ => 4,
-            };
-            let base_lowered = lower(arena, base, ctx)?;
-            let v = as_aux_var(base_lowered, ctx)?;
-            let mut q = QuadExpr::new();
-            q.add_qterm(1.0, v, v);
-            let mut acc = LoweredExpr::Quadratic(q);
-            for _ in 2..n {
-                let aux = as_aux_var(acc, ctx)?;
-                let mut next = QuadExpr::new();
-                next.add_qterm(1.0, aux, v);
-                acc = LoweredExpr::Quadratic(next);
-            }
-            return Ok(acc);
-        }
-        // General constant exponent via Gurobi's genconstr_pow
-        let base_lowered = lower(arena, base, ctx)?;
-        let x = as_aux_var(base_lowered, ctx)?;
-        let y = ctx.new_aux("pow", f64::NEG_INFINITY, f64::INFINITY).map_err(map_grb)?;
-        let name = ctx.next_name("pow");
-        ctx.model.add_genconstr_pow(&name, x, y, alpha, "").map_err(map_grb)?;
-        return Ok(LoweredExpr::Var(y));
-    }
-    // exp(b*log(a))
-    let base_lowered = lower(arena, base, ctx)?;
-    let x = as_aux_var(base_lowered, ctx)?;
-    let log_y = ctx.new_aux("log", f64::NEG_INFINITY, f64::INFINITY).map_err(map_grb)?;
-    let log_name = ctx.next_name("log");
-    ctx.model.add_genconstr_natural_log(&log_name, x, log_y, "").map_err(map_grb)?;
-    let b_lowered = lower(arena, exp, ctx)?;
-    let b_var = as_aux_var(b_lowered, ctx)?;
-    let prod = ctx.new_aux("mul", f64::NEG_INFINITY, f64::INFINITY).map_err(map_grb)?;
-    let mut q = QuadExpr::new();
-    q.add_qterm(1.0, b_var, log_y);
-    let prod_eq = ctx.next_name("mul_eq");
-    ctx.model.add_qconstr(&prod_eq, c!(prod == q)).map_err(map_grb)?;
-    let result = ctx.new_aux("exp", 0.0, f64::INFINITY).map_err(map_grb)?;
-    let exp_name = ctx.next_name("exp");
-    ctx.model.add_genconstr_natural_exp(&exp_name, prod, result, "").map_err(map_grb)?;
-    Ok(LoweredExpr::Var(result))
-}
-
-/// Lower `num / den` as `num * recip`, introducing a reciprocal variable
-/// `recip` pinned by the bilinear equality `den * recip == 1`.
-///
-/// This avoids a `pow(den, -1)` lowering. Gurobi's `genconstr_pow` has a pole
-/// at 0 and so requires its base to stay in a strictly positive domain,
-/// which rules out negative or zero-straddling denominators. The bilinear pin
-/// carries no such restriction: it is a plain non-convex quadratic
-/// (handled via `NonConvex = 2`) valid for `den` of either sign,
-/// and is infeasible only at `den == 0`.
-fn lower_div(
-    arena: &ExprArena,
-    num: ExprId,
-    den: ExprId,
-    ctx: &mut LoweringCtx<'_>,
-) -> Result<LoweredExpr, SolverError> {
-    // `div_into` folds every nonzero constant denominator into the linear path
-    // at construction, so the only constant `den` that reaches here is a literal
-    // zero.
-    if as_const(arena, den) == Some(0.0) {
-        return Err(SolverError::Backend("division by zero: constant denominator is 0".into()));
-    }
-
-    // recip = 1 / den, pinned by `den * recip == 1`.
-    let den_lowered = lower(arena, den, ctx)?;
-    let x = as_aux_var(den_lowered, ctx)?;
-    let recip = ctx.new_aux("recip", f64::NEG_INFINITY, f64::INFINITY).map_err(map_grb)?;
-    let mut pin = QuadExpr::new();
-    pin.add_qterm(1.0, x, recip);
-    let name = ctx.next_name("recip_eq");
-    ctx.model.add_qconstr(&name, c!(pin == 1.0)).map_err(map_grb)?;
-
-    // Constant numerator stays linear in `recip`, otherwise form `num * recip`.
-    if let Some(k) = as_const(arena, num) {
-        return Ok(lowered_scale(LoweredExpr::Var(recip), k));
-    }
-    let num_lowered = lower(arena, num, ctx)?;
-    let vn = as_aux_var(num_lowered, ctx)?;
-    let mut q = QuadExpr::new();
-    q.add_qterm(1.0, vn, recip);
-    Ok(LoweredExpr::Quadratic(q))
-}
-
-enum UnaryFn {
-    Sin,
-    Cos,
-    Exp,
-    Log,
-    Abs,
-}
-
-fn lower_unary(
-    arena: &ExprArena,
-    inner: ExprId,
-    ctx: &mut LoweringCtx<'_>,
-    f: UnaryFn,
-) -> Result<LoweredExpr, SolverError> {
-    let lowered = lower(arena, inner, ctx)?;
-    let x = as_aux_var(lowered, ctx)?;
-    let (lb, ub, tag) = match f {
-        UnaryFn::Sin | UnaryFn::Cos => (-1.0, 1.0, "trig"),
-        UnaryFn::Exp => (0.0, f64::INFINITY, "exp"),
-        UnaryFn::Log => (f64::NEG_INFINITY, f64::INFINITY, "log"),
-        UnaryFn::Abs => (0.0, f64::INFINITY, "abs"),
-    };
-    let y = ctx.new_aux(tag, lb, ub).map_err(map_grb)?;
-    let name = ctx.next_name(tag);
-    match f {
-        UnaryFn::Sin => ctx.model.add_genconstr_sin(&name, x, y, "").map_err(map_grb)?,
-        UnaryFn::Cos => ctx.model.add_genconstr_cos(&name, x, y, "").map_err(map_grb)?,
-        UnaryFn::Exp => ctx.model.add_genconstr_natural_exp(&name, x, y, "").map_err(map_grb)?,
-        UnaryFn::Log => ctx.model.add_genconstr_natural_log(&name, x, y, "").map_err(map_grb)?,
-        UnaryFn::Abs => ctx.model.add_genconstr_abs(&name, y, x).map_err(map_grb)?,
-    };
-    Ok(LoweredExpr::Var(y))
-}
-
-/// Helpers used by translate.rs to materialize a lowered constraint or
-/// objective expression.
 impl LoweredExpr {
-    pub(crate) fn into_expr_for_objective(self) -> grb::expr::Expr {
+    pub(crate) fn into_expr_for_objective(self) -> gurobi_rs::expr::Expr {
         match self {
-            LoweredExpr::Linear(e) => grb::expr::Expr::from(e),
-            LoweredExpr::Quadratic(e) => grb::expr::Expr::from(e),
-            LoweredExpr::Var(v) => grb::expr::Expr::from(v),
+            Self::Linear(e) => gurobi_rs::expr::Expr::from(e),
+            Self::Quadratic(e) => gurobi_rs::expr::Expr::from(e),
+            Self::Var(v) => gurobi_rs::expr::Expr::from(v),
         }
     }
 }

--- a/crates/oximo-gurobi/src/options.rs
+++ b/crates/oximo-gurobi/src/options.rs
@@ -296,6 +296,10 @@ impl GurobiOptions {
         self.presolve = Some(p);
         self
     }
+
+    pub(crate) fn has_non_convex(&self) -> bool {
+        self.int_params.iter().any(|(param, _)| *param == IntParam::NonConvex)
+    }
 }
 
 impl HasUniversal for GurobiOptions {
@@ -393,6 +397,12 @@ mod tests {
         // but our vec preserves the full call sequence.
         let o = GurobiOptions::default().seed(123).seed(99);
         assert_eq!(o.int_params, vec![(IntParam::Seed, 123), (IntParam::Seed, 99)]);
+    }
+
+    #[test]
+    fn detects_explicit_non_convex_setting() {
+        assert!(!GurobiOptions::default().has_non_convex());
+        assert!(GurobiOptions::default().non_convex(0).has_non_convex());
     }
 
     #[test]

--- a/crates/oximo-gurobi/src/options.rs
+++ b/crates/oximo-gurobi/src/options.rs
@@ -1,5 +1,5 @@
-use grb::Model as GrbModel;
-use grb::parameter::{DoubleParam, IntParam, StrParam};
+use gurobi_rs::Model as GurobiModel;
+use gurobi_rs::parameter::{DoubleParam, IntParam, StrParam};
 use oximo_solver::{HasUniversal, UniversalOptions};
 
 /// Gurobi presolve level. Maps to the Gurobi `Presolve` parameter.
@@ -261,6 +261,28 @@ impl GurobiOptions {
         (str, job_id, JobID),
         (str, dummy, Dummy),
     );
+
+    // Gurobi 13 nonlinear-barrier, PDHG, and MIP-start parameters.
+    gurobi_params!(
+        (int, nl_bar_iter_limit, NLBarIterLimit),
+        (dbl, nl_bar_c_feas_tol, NLBarCFeasTol),
+        (dbl, nl_bar_d_feas_tol, NLBarDFeasTol),
+        (dbl, nl_bar_p_feas_tol, NLBarPFeasTol),
+        (dbl, pdhg_abs_tol, PDHGAbsTol),
+        (dbl, pdhg_conv_tol, PDHGConvTol),
+        (dbl, pdhg_rel_tol, PDHGRelTol),
+        (dbl, pdhg_iter_limit, PDHGIterLimit),
+        (int, pdhg_gpu, PDHGGPU),
+        (int, no_rel_heur_solutions, NoRelHeurSolutions),
+        (int, inherit_params, InheritParams),
+        (int, fix_vars_in_indicators, FixVarsInIndicators),
+        (dbl, start_time_limit, StartTimeLimit),
+        (dbl, start_work_limit, StartWorkLimit),
+        (dbl, improve_start_work, ImproveStartWork),
+        (int, master_knapsack_cuts, MasterKnapsackCuts),
+        (int, obj_pass_number, ObjPassNumber),
+        (int, optimality_target, OptimalityTarget),
+    );
 }
 
 impl GurobiOptions {
@@ -287,18 +309,18 @@ impl HasUniversal for GurobiOptions {
 }
 
 /// Apply typed [`GurobiOptions`] onto a live Gurobi model.
-pub(crate) fn apply(model: &mut GrbModel, o: &GurobiOptions) -> Result<(), grb::Error> {
+pub(crate) fn apply(model: &mut GurobiModel, o: &GurobiOptions) -> Result<(), gurobi_rs::Error> {
     if let Some(d) = o.universal.time_limit {
-        model.set_param(grb::param::TimeLimit, d.as_secs_f64())?;
+        model.set_param(gurobi_rs::param::TimeLimit, d.as_secs_f64())?;
     }
     if let Some(n) = o.universal.threads {
-        model.set_param(grb::param::Threads, i32::try_from(n).unwrap_or(i32::MAX))?;
+        model.set_param(gurobi_rs::param::Threads, i32::try_from(n).unwrap_or(i32::MAX))?;
     }
     if let Some(b) = o.universal.verbose {
-        model.set_param(grb::param::OutputFlag, i32::from(b))?;
+        model.set_param(gurobi_rs::param::OutputFlag, i32::from(b))?;
     }
     if let Some(g) = o.mip_gap {
-        model.set_param(grb::param::MIPGap, g)?;
+        model.set_param(gurobi_rs::param::MIPGap, g)?;
     }
     if let Some(p) = o.presolve {
         let v = match p {
@@ -307,7 +329,7 @@ pub(crate) fn apply(model: &mut GrbModel, o: &GurobiOptions) -> Result<(), grb::
             GurobiPresolve::Conservative => 1,
             GurobiPresolve::Aggressive => 2,
         };
-        model.set_param(grb::param::Presolve, v)?;
+        model.set_param(gurobi_rs::param::Presolve, v)?;
     }
     for (p, v) in &o.int_params {
         model.set_param(*p, *v)?;

--- a/crates/oximo-gurobi/src/persistent.rs
+++ b/crates/oximo-gurobi/src/persistent.rs
@@ -1,12 +1,13 @@
-use grb::prelude::*;
+use gurobi_rs::prelude::*;
 use oximo_core::{Model, ModelKind};
 use oximo_solver::{Iis, Snapshot, Solver, SolverError, SolverResult, snapshot};
 
 use crate::GurobiOptions;
 use crate::options::apply as apply_options;
 use crate::translate::{
-    Built, build, compute_iis_resident, default_env, map_grb_err, run_and_collect,
+    Built, build, compute_iis_resident, default_env, map_gurobi_err, run_and_collect,
 };
+use crate::{Callback, CallbackMask};
 
 /// The resident Gurobi model plus the baseline snapshot the fast path diffs against
 /// (`None` when the fast path is ineligible).
@@ -128,6 +129,84 @@ impl GurobiPersistent {
         let st = self.state.as_mut().expect("state present before solve");
         run_and_collect(&mut st.built, kind)
     }
+
+    fn solve_resident_with_callback<F>(
+        &mut self,
+        model: &Model,
+        opts: &GurobiOptions,
+        callback: &mut F,
+        mask: Option<CallbackMask>,
+    ) -> Result<SolverResult, SolverError>
+    where
+        F: Callback,
+    {
+        let kind = model.kind();
+        let mut updated = false;
+        if matches!(kind, ModelKind::LP | ModelKind::MILP) {
+            if let Some(st) = self.state.as_mut() {
+                if let Some(base) = st.snap.as_ref() {
+                    let snap = snapshot(model)?;
+                    if snap.fingerprint == base.fingerprint {
+                        push_deltas(&mut st.built, base, &snap, opts)?;
+                        st.snap = Some(snap);
+                        updated = true;
+                    }
+                }
+            }
+        }
+        if !updated {
+            self.rebuild(model, opts)?;
+        }
+        let st = self.state.as_mut().expect("state present before solve");
+        crate::translate::run_and_collect_with_callback(&mut st.built, kind, callback, mask)
+    }
+
+    /// Solve the resident model while receiving Gurobi callback events.
+    ///
+    /// # Errors
+    /// Returns a [`SolverError`] for model construction, callback, or Gurobi
+    /// optimization failures. On failure, the resident state is cleared.
+    pub fn solve_with_callback<F>(
+        &mut self,
+        model: &Model,
+        opts: &GurobiOptions,
+        callback: &mut F,
+    ) -> Result<SolverResult, SolverError>
+    where
+        F: Callback,
+    {
+        match self.solve_resident_with_callback(model, opts, callback, None) {
+            Ok(result) => Ok(result),
+            Err(error) => {
+                self.state = None;
+                Err(error)
+            }
+        }
+    }
+
+    /// Solve the resident model with only the selected callback locations.
+    ///
+    /// # Errors
+    /// Returns a [`SolverError`] for model construction, callback, or Gurobi
+    /// optimization failures. On failure, the resident state is cleared.
+    pub fn solve_with_callback_filtered<F>(
+        &mut self,
+        model: &Model,
+        opts: &GurobiOptions,
+        callback: &mut F,
+        locations: impl Into<CallbackMask>,
+    ) -> Result<SolverResult, SolverError>
+    where
+        F: Callback,
+    {
+        match self.solve_resident_with_callback(model, opts, callback, Some(locations.into())) {
+            Ok(result) => Ok(result),
+            Err(error) => {
+                self.state = None;
+                Err(error)
+            }
+        }
+    }
 }
 
 impl Solver for GurobiPersistent {
@@ -170,18 +249,24 @@ fn push_deltas(
             built
                 .model
                 .set_obj_attr(attr::Obj, &built.vars[i], snap.obj_costs[i])
-                .map_err(map_grb_err)?;
+                .map_err(map_gurobi_err)?;
         }
         if snap.lb[i].to_bits() != base.lb[i].to_bits() {
-            built.model.set_obj_attr(attr::LB, &built.vars[i], snap.lb[i]).map_err(map_grb_err)?;
+            built
+                .model
+                .set_obj_attr(attr::LB, &built.vars[i], snap.lb[i])
+                .map_err(map_gurobi_err)?;
         }
         if snap.ub[i].to_bits() != base.ub[i].to_bits() {
-            built.model.set_obj_attr(attr::UB, &built.vars[i], snap.ub[i]).map_err(map_grb_err)?;
+            built
+                .model
+                .set_obj_attr(attr::UB, &built.vars[i], snap.ub[i])
+                .map_err(map_gurobi_err)?;
         }
     }
     if snap.obj_constant.to_bits() != base.obj_constant.to_bits() {
-        built.model.set_attr(attr::ObjCon, snap.obj_constant).map_err(map_grb_err)?;
+        built.model.set_attr(attr::ObjCon, snap.obj_constant).map_err(map_gurobi_err)?;
     }
-    apply_options(&mut built.model, opts).map_err(map_grb_err)?;
+    apply_options(&mut built.model, opts).map_err(map_gurobi_err)?;
     Ok(())
 }

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -1,7 +1,8 @@
 use std::time::Instant;
 
-use grb::expr::{LinExpr, QuadExpr};
-use grb::prelude::*;
+use gurobi_rs::constr::RangeExpr;
+use gurobi_rs::expr::{LinExpr, QuadExpr};
+use gurobi_rs::prelude::*;
 use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, SocConstraint,
     SocConstraintId, VarId, Variable, var_name,
@@ -13,10 +14,10 @@ use oximo_solver::{
 use rustc_hash::FxHashMap;
 
 use crate::GurobiOptions;
-use crate::nonlinear::{LoweredExpr, LoweringCtx, lower};
+use crate::nonlinear::{GeneratedConstraint, LoweredExpr, LoweringCtx, lower};
 use crate::options::apply as apply_options;
 
-pub(crate) fn map_grb_err(e: grb::Error) -> SolverError {
+pub(crate) fn map_gurobi_err(e: gurobi_rs::Error) -> SolverError {
     SolverError::Backend(format!("Gurobi: {e}"))
 }
 
@@ -47,10 +48,10 @@ pub(crate) fn default_env() -> Result<Env, SolverError> {
 /// A built Gurobi model plus the handles needed to read its solution and to drive
 /// incremental re-solves.
 pub(crate) struct Built {
-    pub model: grb::Model,
-    pub vars: Vec<grb::Var>,
-    pub constrs: Vec<GrbRow>,
-    pub soc_rows: Vec<(grb::QConstr, LinearTerms)>,
+    pub model: gurobi_rs::Model,
+    pub vars: Vec<gurobi_rs::Var>,
+    pub constrs: Vec<ConstraintHandle>,
+    pub soc_rows: Vec<SocHandle>,
     pub obj_constant: f64,
     pub has_semi: bool,
 }
@@ -82,36 +83,47 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     let objective = model.objective();
     let has_semi = vars.iter().any(|v| v.domain.semi_threshold().is_some());
 
-    let mut grb_model = grb::Model::with_env("oximo", env).map_err(map_grb_err)?;
+    let mut gurobi_model = gurobi_rs::Model::with_env("oximo", env).map_err(map_gurobi_err)?;
 
-    let gurobi_vars = add_variables(&mut grb_model, &vars)?;
+    let gurobi_vars = add_variables(&mut gurobi_model, &vars)?;
 
     // Aux-variable counter shared by the constraint and objective lowering so the
     // synthetic variable names stay unique across both.
     let mut aux_counter = 0_u32;
     let gurobi_constrs =
-        add_constraints(&arena, constraints, &mut grb_model, &gurobi_vars, &mut aux_counter)?;
-    let soc_rows = add_soc_rows(&arena, &vars, &socs, &mut grb_model, &gurobi_vars)?;
+        add_constraints(&arena, constraints, &mut gurobi_model, &gurobi_vars, &mut aux_counter)?;
+    let soc_rows = add_soc_rows(&arena, &vars, &socs, &mut gurobi_model, &gurobi_vars)?;
 
     let obj_constant = match objective.as_ref() {
-        Some(o) => {
-            set_objective(&arena, o.expr, o.sense, &mut grb_model, &gurobi_vars, &mut aux_counter)?
-        }
+        Some(o) => set_objective(
+            &arena,
+            o.expr,
+            o.sense,
+            &mut gurobi_model,
+            &gurobi_vars,
+            &mut aux_counter,
+        )?,
         None => 0.0,
     };
 
-    apply_options(&mut grb_model, opts).map_err(map_grb_err)?;
+    // Warm starts are assigned only after the full structural model has been
+    // built. This keeps the batch variable construction and the start vector
+    // compatible with Gurobi's pending-update rules.
+    apply_initial_values(&gurobi_model, &vars, &gurobi_vars)?;
+
+    apply_options(&mut gurobi_model, opts).map_err(map_gurobi_err)?;
     if nonlinear_kind {
         // Gurobi requires NonConvex=2 for general nonlinear constraints and
         // bilinear non-convex objectives. Skip if the user already set it.
-        let current = grb_model.get_param(grb::param::NonConvex).map_err(map_grb_err)?;
+        let current =
+            gurobi_model.get_param(gurobi_rs::param::NonConvex).map_err(map_gurobi_err)?;
         if current < 2 {
-            grb_model.set_param(grb::param::NonConvex, 2).map_err(map_grb_err)?;
+            gurobi_model.set_param(gurobi_rs::param::NonConvex, 2).map_err(map_gurobi_err)?;
         }
     }
 
     Ok(Built {
-        model: grb_model,
+        model: gurobi_model,
         vars: gurobi_vars,
         constrs: gurobi_constrs,
         soc_rows,
@@ -131,9 +143,35 @@ pub(crate) fn run_and_collect(
     kind: ModelKind,
 ) -> Result<SolverResult, SolverError> {
     let started = Instant::now();
-    built.model.optimize().map_err(map_grb_err)?;
-    let elapsed = started.elapsed();
+    built.model.optimize().map_err(map_gurobi_err)?;
+    collect_after_optimize(built, kind, started.elapsed())
+}
 
+/// Optimize with a user callback and collect results through the same path as
+/// an ordinary solve. Callback failures are surfaced as [`SolverError`].
+pub(crate) fn run_and_collect_with_callback<F>(
+    built: &mut Built,
+    kind: ModelKind,
+    callback: &mut F,
+    mask: Option<gurobi_rs::callback::CallbackMask>,
+) -> Result<SolverResult, SolverError>
+where
+    F: gurobi_rs::callback::Callback,
+{
+    let started = Instant::now();
+    match mask {
+        Some(mask) => built.model.optimize_with_callback_filtered(callback, mask),
+        None => built.model.optimize_with_callback(callback),
+    }
+    .map_err(map_gurobi_err)?;
+    collect_after_optimize(built, kind, started.elapsed())
+}
+
+fn collect_after_optimize(
+    built: &mut Built,
+    kind: ModelKind,
+    elapsed: std::time::Duration,
+) -> Result<SolverResult, SolverError> {
     let termination = map_status(&built.model)?;
     #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let iterations = built.model.get_attr(attr::IterCount).unwrap_or(0.0) as u64;
@@ -166,6 +204,22 @@ pub(crate) fn run_and_collect(
     })
 }
 
+/// Build, optimize with a callback, and collect the ordinary solver result.
+pub fn solve_with_callback<F>(
+    model: &Model,
+    opts: &GurobiOptions,
+    callback: &mut F,
+    mask: Option<gurobi_rs::callback::CallbackMask>,
+) -> Result<SolverResult, SolverError>
+where
+    F: gurobi_rs::callback::Callback,
+{
+    let kind = model.kind();
+    let env = default_env()?;
+    let mut built = build(model, opts, &env)?;
+    run_and_collect_with_callback(&mut built, kind, callback, mask)
+}
+
 /// Build `model`, solve it, and when Gurobi finds it infeasible compute an
 /// irreducible infeasible subsystem via Gurobi's `computeIIS`.
 ///
@@ -185,8 +239,8 @@ pub fn compute_iis(model: &Model, opts: &GurobiOptions) -> Result<Iis, SolverErr
     let mut built = build(model, opts, &env)?;
     // Force a definite Infeasible/Unbounded verdict so we don't ask for an IIS on an
     // unbounded model.
-    built.model.set_param(grb::param::DualReductions, 0).map_err(map_grb_err)?;
-    built.model.optimize().map_err(map_grb_err)?;
+    built.model.set_param(gurobi_rs::param::DualReductions, 0).map_err(map_gurobi_err)?;
+    built.model.optimize().map_err(map_gurobi_err)?;
     compute_iis_resident(&mut built)
 }
 
@@ -212,13 +266,14 @@ pub(crate) fn compute_iis_resident(built: &mut Built) -> Result<Iis, SolverError
         // Dual reductions can leave "infeasible or unbounded". Turn them off just
         // for a disambiguating re-optimize, then restore the saved value so the
         // resident model's parameter state is unchanged for later solves.
-        let saved = built.model.get_param(grb::param::DualReductions).map_err(map_grb_err)?;
-        built.model.set_param(grb::param::DualReductions, 0).map_err(map_grb_err)?;
+        let saved =
+            built.model.get_param(gurobi_rs::param::DualReductions).map_err(map_gurobi_err)?;
+        built.model.set_param(gurobi_rs::param::DualReductions, 0).map_err(map_gurobi_err)?;
         let outcome = (|| {
-            built.model.optimize().map_err(map_grb_err)?;
+            built.model.optimize().map_err(map_gurobi_err)?;
             map_status(&built.model)
         })();
-        built.model.set_param(grb::param::DualReductions, saved).map_err(map_grb_err)?;
+        built.model.set_param(gurobi_rs::param::DualReductions, saved).map_err(map_gurobi_err)?;
         termination = outcome?;
     }
     if !termination.is_infeasible() {
@@ -227,7 +282,13 @@ pub(crate) fn compute_iis_resident(built: &mut Built) -> Result<Iis, SolverError
         )));
     }
 
-    built.model.compute_iis().map_err(map_grb_err)?;
+    built.model.compute_iis().map_err(map_gurobi_err)?;
+    let minimal = built.model.get_attr(attr::IISMinimal).map_err(map_gurobi_err)?;
+    if minimal != 1 {
+        return Err(SolverError::Backend(
+            "Gurobi IIS computation was interrupted or did not produce a minimal subsystem".into(),
+        ));
+    }
     read_iis(built)
 }
 
@@ -238,20 +299,37 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
     let model = &built.model;
     let mut iis = Iis::default();
 
-    for (i, row) in built.constrs.iter().enumerate() {
-        let in_iis = match row {
-            GrbRow::Lin(c) => model.get_obj_attr(attr::IISConstr, c),
-            GrbRow::Quad(q) => model.get_obj_attr(attr::IISQConstr, q),
+    for (i, handle) in built.constrs.iter().enumerate() {
+        let mut in_iis = false;
+        for row in &handle.rows {
+            let selected = match row {
+                GurobiRow::Lin(c) => model.get_obj_attr(attr::IISConstr, c),
+                GurobiRow::Quad(q) => model.get_obj_attr(attr::IISQConstr, q),
+            }
+            .map_err(map_gurobi_err)?;
+            in_iis |= selected != 0;
         }
-        .map_err(map_grb_err)?;
-        if in_iis != 0 {
+        for generated in &handle.generated {
+            let selected = match generated {
+                GeneratedConstraint::Linear(c) => model.get_obj_attr(attr::IISConstr, c),
+                GeneratedConstraint::Quadratic(q) => model.get_obj_attr(attr::IISQConstr, q),
+                GeneratedConstraint::General(g) => model.get_obj_attr(attr::IISGenConstr, g),
+            }
+            .map_err(map_gurobi_err)?;
+            in_iis |= selected != 0;
+        }
+        if in_iis {
             iis.constraints
                 .push(ConstraintId(u32::try_from(i).expect("constraint index fits u32")));
         }
     }
 
-    for (i, (qrow, _)) in built.soc_rows.iter().enumerate() {
-        if model.get_obj_attr(attr::IISQConstr, qrow).map_err(map_grb_err)? != 0 {
+    for (i, handle) in built.soc_rows.iter().enumerate() {
+        let quadratic =
+            model.get_obj_attr(attr::IISQConstr, &handle.quadratic).map_err(map_gurobi_err)?;
+        let sign =
+            model.get_obj_attr(attr::IISConstr, &handle.bound_sign).map_err(map_gurobi_err)?;
+        if quadratic != 0 || sign != 0 {
             iis.soc_constraints
                 .push(SocConstraintId(u32::try_from(i).expect("soc index fits u32")));
         }
@@ -260,10 +338,10 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
     // Only model variables are scanned.
     for (i, v) in built.vars.iter().enumerate() {
         let id = VarId(u32::try_from(i).expect("var index fits u32"));
-        if model.get_obj_attr(attr::IISLB, v).map_err(map_grb_err)? != 0 {
+        if model.get_obj_attr(attr::IISLB, v).map_err(map_gurobi_err)? != 0 {
             iis.var_bounds.push((id, VarBoundKind::Lower));
         }
-        if model.get_obj_attr(attr::IISUB, v).map_err(map_grb_err)? != 0 {
+        if model.get_obj_attr(attr::IISUB, v).map_err(map_gurobi_err)? != 0 {
             iis.var_bounds.push((id, VarBoundKind::Upper));
         }
     }
@@ -274,11 +352,10 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
 /// Add one Gurobi variable per model variable, in `VarId` order, applying its
 /// domain, bounds, and any warm-start value.
 fn add_variables(
-    grb_model: &mut grb::Model,
+    gurobi_model: &mut gurobi_rs::Model,
     vars: &[Variable],
-) -> Result<Vec<grb::Var>, SolverError> {
-    let mut gurobi_vars = Vec::with_capacity(vars.len());
-    for v in vars {
+) -> Result<Vec<gurobi_rs::Var>, SolverError> {
+    let specs = vars.iter().map(|v| {
         let vtype = match v.domain {
             Domain::Real => VarType::Continuous,
             Domain::Integer => VarType::Integer,
@@ -289,89 +366,168 @@ fn add_variables(
         // For a semi-continuous/semi-integer variable the gap floor (`threshold`)
         // is Gurobi's lower bound: the value is 0 or in `[lb, ub]`.
         let floor = v.domain.semi_threshold().unwrap_or(v.lb);
-        // `add_var!` expands the f64 bounds with an `as f64` cast.
-        #[expect(clippy::unnecessary_cast)]
-        let gvar = add_var!(grb_model, vtype, bounds: floor..v.ub, name: v.name.as_str())
-            .map_err(map_grb_err)?;
-        gurobi_vars.push(gvar);
-        if let Some(val) = v.initial {
-            grb_model.set_obj_attr(attr::Start, &gvar, val).map_err(map_grb_err)?;
-        }
-    }
-    Ok(gurobi_vars)
+        gurobi_rs::VarSpec::new(v.name.as_str(), vtype, 0.0, floor, v.ub, [])
+    });
+    gurobi_model.add_vars(specs).map_err(map_gurobi_err)
+}
+
+fn apply_initial_values(
+    gurobi_model: &gurobi_rs::Model,
+    vars: &[Variable],
+    gurobi_vars: &[gurobi_rs::Var],
+) -> Result<(), SolverError> {
+    let starts = vars
+        .iter()
+        .zip(gurobi_vars.iter().copied())
+        .filter_map(|(v, var)| v.initial.map(|value| (var, value)));
+    gurobi_model.set_obj_attr_batch(attr::Start, starts).map_err(map_gurobi_err)
 }
 
 /// Gurobi's handle for an added constraint, kept so its dual can be queried
 /// after the solve (`Pi` for linear rows, `QCPi` for quadratic rows).
-pub(crate) enum GrbRow {
-    Lin(grb::Constr),
-    Quad(grb::QConstr),
+pub(crate) enum GurobiRow {
+    Lin(gurobi_rs::Constr),
+    Quad(gurobi_rs::QConstr),
+}
+
+/// All native rows and generated definitions associated with one original
+/// algebraic constraint. A nonlinear range may have two comparison rows.
+pub(crate) struct ConstraintHandle {
+    pub rows: Vec<GurobiRow>,
+    pub generated: Vec<GeneratedConstraint>,
+}
+
+/// The native rows associated with one explicit second-order cone.
+///
+/// Squaring `||terms|| <= bound` also requires the generated `bound >= 0`
+/// side row. Both rows belong to the original cone for IIS reporting.
+pub(crate) struct SocHandle {
+    pub quadratic: gurobi_rs::QConstr,
+    pub bound_sign: gurobi_rs::Constr,
+    pub bound: LinearTerms,
 }
 
 /// Add every model constraint, returning the per-constraint row handle.
 /// Each constraint takes the linear fast path when its LHS is linear
 /// and falls back to the general lowering otherwise.
+#[expect(clippy::too_many_lines)]
 fn add_constraints(
     arena: &ExprArena,
     constraints: &[Constraint],
-    grb_model: &mut grb::Model,
-    gurobi_vars: &[grb::Var],
+    gurobi_model: &mut gurobi_rs::Model,
+    gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
-) -> Result<Vec<GrbRow>, SolverError> {
-    // One `GrbRow` per oximo constraint keeps `gurobi_constrs` 1:1 with
-    // `ConstraintId`, which `collect_solution` relies on to key duals. A
-    // two-sided range becomes a single native `add_range` row.
-    let mut gurobi_constrs: Vec<GrbRow> = Vec::with_capacity(constraints.len());
-    for c in constraints {
-        let name = c.name.as_str();
+) -> Result<Vec<ConstraintHandle>, SolverError> {
+    struct PendingSingle {
+        index: usize,
+        name: String,
+        expr: LinExpr,
+        sense: Sense,
+        rhs: f64,
+    }
+    struct PendingRange {
+        index: usize,
+        name: String,
+        expr: LinExpr,
+        lower: f64,
+        upper: f64,
+    }
+
+    let mut slots: Vec<Option<ConstraintHandle>> = (0..constraints.len()).map(|_| None).collect();
+    let mut singles = Vec::new();
+    let mut ranges = Vec::new();
+    let mut nonlinear = Vec::new();
+
+    for (index, c) in constraints.iter().enumerate() {
         if let Some((sense, rhs)) = c.as_single() {
             if let Some(t) = extract_linear(arena, c.lhs) {
-                let adjusted_rhs = rhs - t.constant;
                 let mut expr = LinExpr::new();
-                for (v, co) in t.coeffs {
-                    expr.add_term(co, gurobi_vars[v.index()]);
+                for (v, coeff) in t.coeffs {
+                    expr.add_term(coeff, gurobi_vars[v.index()]);
                 }
-                let constr = match sense {
-                    Sense::Le => grb_model.add_constr(name, c!(expr <= adjusted_rhs)),
-                    Sense::Ge => grb_model.add_constr(name, c!(expr >= adjusted_rhs)),
-                    Sense::Eq => grb_model.add_constr(name, c!(expr == adjusted_rhs)),
-                }
-                .map_err(map_grb_err)?;
-                gurobi_constrs.push(GrbRow::Lin(constr));
-            } else {
-                let row = add_nonlinear_constraint(
-                    arena,
-                    c.lhs,
+                singles.push(PendingSingle {
+                    index,
+                    name: c.name.to_string(),
+                    expr,
                     sense,
-                    rhs,
-                    name,
-                    grb_model,
-                    gurobi_vars,
-                    aux_counter,
-                )?;
-                gurobi_constrs.push(row);
+                    rhs: rhs - t.constant,
+                });
+            } else {
+                nonlinear.push(index);
             }
-        } else {
-            // Genuine two-sided range. Gurobi's `add_range` is linear-only.
-            let Some(t) = extract_linear(arena, c.lhs) else {
-                return Err(SolverError::Backend(format!(
-                    "Gurobi does not support a two-sided range on a nonlinear constraint ('{}')",
-                    c.name
-                )));
-            };
-            let lower = c.lower - t.constant;
-            let upper = c.upper - t.constant;
+        } else if let Some(t) = extract_linear(arena, c.lhs) {
             let mut expr = LinExpr::new();
-            for (v, co) in t.coeffs {
-                expr.add_term(co, gurobi_vars[v.index()]);
+            for (v, coeff) in t.coeffs {
+                expr.add_term(coeff, gurobi_vars[v.index()]);
             }
-            #[expect(clippy::unnecessary_cast)]
-            let (_slack, constr) =
-                grb_model.add_range(name, c!(expr in lower..upper)).map_err(map_grb_err)?;
-            gurobi_constrs.push(GrbRow::Lin(constr));
+            ranges.push(PendingRange {
+                index,
+                name: c.name.to_string(),
+                expr,
+                lower: c.lower - t.constant,
+                upper: c.upper - t.constant,
+            });
+        } else {
+            nonlinear.push(index);
         }
     }
-    Ok(gurobi_constrs)
+
+    let single_batch: Vec<_> = singles
+        .iter()
+        .map(|p| {
+            let expr = p.expr.clone();
+            let ineq = match p.sense {
+                Sense::Le => c!(expr <= p.rhs),
+                Sense::Ge => c!(expr >= p.rhs),
+                Sense::Eq => c!(expr == p.rhs),
+            };
+            (p.name.clone(), ineq)
+        })
+        .collect();
+    let single_handles = gurobi_model
+        .add_constrs(single_batch.iter().map(|(name, expr)| (name, expr.clone())))
+        .map_err(map_gurobi_err)?;
+    for (pending, handle) in singles.into_iter().zip(single_handles) {
+        slots[pending.index] =
+            Some(ConstraintHandle { rows: vec![GurobiRow::Lin(handle)], generated: Vec::new() });
+    }
+
+    let range_batch: Vec<_> = ranges
+        .iter()
+        .map(|p| {
+            (p.name.clone(), RangeExpr { expr: p.expr.clone().into(), lb: p.lower, ub: p.upper })
+        })
+        .collect();
+    let range_handles = gurobi_model
+        .add_ranges(range_batch.iter().map(|(name, expr)| (name, expr.clone())))
+        .map_err(map_gurobi_err)?;
+    for (pending, handle) in ranges.into_iter().zip(range_handles.1) {
+        slots[pending.index] =
+            Some(ConstraintHandle { rows: vec![GurobiRow::Lin(handle)], generated: Vec::new() });
+    }
+
+    for index in nonlinear {
+        let c = &constraints[index];
+        let (rows, generated) = add_nonlinear_constraint(
+            arena,
+            c.lhs,
+            c.as_single(),
+            c.lower,
+            c.upper,
+            c.name.as_str(),
+            gurobi_model,
+            gurobi_vars,
+            aux_counter,
+        )?;
+        slots[index] = Some(ConstraintHandle { rows, generated });
+    }
+
+    slots
+        .into_iter()
+        .map(|slot| {
+            slot.ok_or_else(|| SolverError::Backend("internal constraint batching error".into()))
+        })
+        .collect()
 }
 
 /// Lower each explicit SOC constraint `||terms||_2 <= bound` to the quadratic
@@ -385,9 +541,9 @@ fn add_soc_rows(
     arena: &ExprArena,
     vars: &[Variable],
     socs: &[SocConstraint],
-    grb_model: &mut grb::Model,
-    gurobi_vars: &[grb::Var],
-) -> Result<Vec<(grb::QConstr, LinearTerms)>, SolverError> {
+    gurobi_model: &mut gurobi_rs::Model,
+    gurobi_vars: &[gurobi_rs::Var],
+) -> Result<Vec<SocHandle>, SolverError> {
     let mut rows = Vec::with_capacity(socs.len());
     for (i, s) in socs.iter().enumerate() {
         let mut q = QuadExpr::new();
@@ -405,21 +561,28 @@ fn add_soc_rows(
                 .unwrap_or_else(|| "<nonlinear>".into()),
         })?;
         add_squared_affine(&mut q, &b, -1.0, gurobi_vars);
-        let qrow = grb_model.add_qconstr(s.name.as_str(), c!(q <= 0.0)).map_err(map_grb_err)?;
+        let qrow =
+            gurobi_model.add_qconstr(s.name.as_str(), c!(q <= 0.0)).map_err(map_gurobi_err)?;
 
         let mut e = LinExpr::new();
         for &(v, co) in &b.coeffs {
             e.add_term(co, gurobi_vars[v.index()]);
         }
         let sign_name = format!("{}_sign", s.name);
-        grb_model.add_constr(&sign_name, c!(e >= -b.constant)).map_err(map_grb_err)?;
-        rows.push((qrow, b));
+        let sign_row =
+            gurobi_model.add_constr(&sign_name, c!(e >= -b.constant)).map_err(map_gurobi_err)?;
+        rows.push(SocHandle { quadratic: qrow, bound_sign: sign_row, bound: b });
     }
     Ok(rows)
 }
 
 /// Expand `sign * (a'x + c)^2` into `q`.
-fn add_squared_affine(q: &mut QuadExpr, t: &LinearTerms, sign: f64, gurobi_vars: &[grb::Var]) {
+fn add_squared_affine(
+    q: &mut QuadExpr,
+    t: &LinearTerms,
+    sign: f64,
+    gurobi_vars: &[gurobi_rs::Var],
+) {
     for (i, &(vi, ci)) in t.coeffs.iter().enumerate() {
         q.add_qterm(sign * ci * ci, gurobi_vars[vi.index()], gurobi_vars[vi.index()]);
         for &(vj, cj) in &t.coeffs[i + 1..] {
@@ -438,54 +601,88 @@ fn add_squared_affine(q: &mut QuadExpr, t: &LinearTerms, sign: f64, gurobi_vars:
 fn add_nonlinear_constraint(
     arena: &ExprArena,
     lhs: ExprId,
-    sense: Sense,
-    rhs: f64,
+    single: Option<(Sense, f64)>,
+    lower_bound: f64,
+    upper: f64,
     name: &str,
-    grb_model: &mut grb::Model,
-    gurobi_vars: &[grb::Var],
+    gurobi_model: &mut gurobi_rs::Model,
+    gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
-) -> Result<GrbRow, SolverError> {
-    let mut ctx = LoweringCtx { model: grb_model, gurobi_vars, aux_counter: *aux_counter };
+) -> Result<(Vec<GurobiRow>, Vec<GeneratedConstraint>), SolverError> {
+    let mut ctx = LoweringCtx {
+        model: gurobi_model,
+        gurobi_vars,
+        aux_counter: *aux_counter,
+        generated: Vec::new(),
+    };
     let lowered = lower(arena, lhs, &mut ctx)?;
     *aux_counter = ctx.aux_counter;
-    let row = match lowered {
-        LoweredExpr::Linear(e) => GrbRow::Lin(
-            match sense {
-                Sense::Le => grb_model.add_constr(name, c!(e <= rhs)),
-                Sense::Ge => grb_model.add_constr(name, c!(e >= rhs)),
-                Sense::Eq => grb_model.add_constr(name, c!(e == rhs)),
+    let generated = std::mem::take(&mut ctx.generated);
+    drop(ctx);
+    let rows = add_comparison_rows(gurobi_model, name, &lowered, single, lower_bound, upper)?;
+    Ok((rows, generated))
+}
+
+fn add_comparison_rows(
+    model: &mut gurobi_rs::Model,
+    name: &str,
+    value: &LoweredExpr,
+    single: Option<(Sense, f64)>,
+    lower: f64,
+    upper: f64,
+) -> Result<Vec<GurobiRow>, SolverError> {
+    let senses = single.map_or_else(
+        || vec![(Sense::Ge, lower), (Sense::Le, upper)],
+        |(sense, rhs)| vec![(sense, rhs)],
+    );
+    senses
+        .into_iter()
+        .enumerate()
+        .map(|(i, (sense, rhs))| {
+            let row_name =
+                if i == 0 && single.is_some() { name.to_string() } else { format!("{name}_{i}") };
+            match value {
+                LoweredExpr::Linear(e) => {
+                    let row = match sense {
+                        Sense::Le => model.add_constr(&row_name, c!(e.clone() <= rhs)),
+                        Sense::Ge => model.add_constr(&row_name, c!(e.clone() >= rhs)),
+                        Sense::Eq => model.add_constr(&row_name, c!(e.clone() == rhs)),
+                    }
+                    .map_err(map_gurobi_err)?;
+                    Ok(GurobiRow::Lin(row))
+                }
+                LoweredExpr::Quadratic(e) => {
+                    let row = match sense {
+                        Sense::Le => model.add_qconstr(&row_name, c!(e.clone() <= rhs)),
+                        Sense::Ge => model.add_qconstr(&row_name, c!(e.clone() >= rhs)),
+                        Sense::Eq => model.add_qconstr(&row_name, c!(e.clone() == rhs)),
+                    }
+                    .map_err(map_gurobi_err)?;
+                    Ok(GurobiRow::Quad(row))
+                }
+                LoweredExpr::Var(v) => {
+                    let row = match sense {
+                        Sense::Le => model.add_constr(&row_name, c!(v <= rhs)),
+                        Sense::Ge => model.add_constr(&row_name, c!(v >= rhs)),
+                        Sense::Eq => model.add_constr(&row_name, c!(v == rhs)),
+                    }
+                    .map_err(map_gurobi_err)?;
+                    Ok(GurobiRow::Lin(row))
+                }
             }
-            .map_err(map_grb_err)?,
-        ),
-        LoweredExpr::Quadratic(e) => GrbRow::Quad(
-            match sense {
-                Sense::Le => grb_model.add_qconstr(name, c!(e <= rhs)),
-                Sense::Ge => grb_model.add_qconstr(name, c!(e >= rhs)),
-                Sense::Eq => grb_model.add_qconstr(name, c!(e == rhs)),
-            }
-            .map_err(map_grb_err)?,
-        ),
-        LoweredExpr::Var(v) => GrbRow::Lin(
-            match sense {
-                Sense::Le => grb_model.add_constr(name, c!(v <= rhs)),
-                Sense::Ge => grb_model.add_constr(name, c!(v >= rhs)),
-                Sense::Eq => grb_model.add_constr(name, c!(v == rhs)),
-            }
-            .map_err(map_grb_err)?,
-        ),
-    };
-    Ok(row)
+        })
+        .collect()
 }
 
 fn set_objective(
     arena: &ExprArena,
     obj_expr: ExprId,
     sense: ObjectiveSense,
-    grb_model: &mut grb::Model,
-    gurobi_vars: &[grb::Var],
+    gurobi_model: &mut gurobi_rs::Model,
+    gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
 ) -> Result<f64, SolverError> {
-    let grb_sense = match sense {
+    let gurobi_sense = match sense {
         ObjectiveSense::Minimize => ModelSense::Minimize,
         ObjectiveSense::Maximize => ModelSense::Maximize,
     };
@@ -497,13 +694,20 @@ fn set_objective(
         // Gurobi's set_objective absorbs LinExpr offsets into ObjCon, so we do
         // not need to track the constant separately.
         e.add_constant(t.constant);
-        grb_model.set_objective(e, grb_sense).map_err(map_grb_err)?;
+        gurobi_model.set_objective(e, gurobi_sense).map_err(map_gurobi_err)?;
         return Ok(0.0);
     }
-    let mut ctx = LoweringCtx { model: grb_model, gurobi_vars, aux_counter: *aux_counter };
+    let mut ctx = LoweringCtx {
+        model: gurobi_model,
+        gurobi_vars,
+        aux_counter: *aux_counter,
+        generated: Vec::new(),
+    };
     let lowered = lower(arena, obj_expr, &mut ctx)?;
     *aux_counter = ctx.aux_counter;
-    grb_model.set_objective(lowered.into_expr_for_objective(), grb_sense).map_err(map_grb_err)?;
+    gurobi_model
+        .set_objective(lowered.into_expr_for_objective(), gurobi_sense)
+        .map_err(map_gurobi_err)?;
     Ok(0.0)
 }
 
@@ -527,10 +731,10 @@ type Collected = (
 
 fn collect_solution(
     kind: ModelKind,
-    model: &mut grb::Model,
-    vars: &[grb::Var],
-    constrs: &[GrbRow],
-    soc_rows: &[(grb::QConstr, LinearTerms)],
+    model: &mut gurobi_rs::Model,
+    vars: &[gurobi_rs::Var],
+    constrs: &[ConstraintHandle],
+    soc_rows: &[SocHandle],
     obj_constant: f64,
 ) -> Collected {
     // A primal point exists only when Gurobi actually stored one. `SolCount` is
@@ -558,13 +762,21 @@ fn collect_solution(
 
     let mut dual = FxHashMap::default();
     dual.reserve(constrs.len());
-    for (i, row) in constrs.iter().enumerate() {
-        let pi = match row {
-            GrbRow::Lin(c) => model.get_obj_attr(attr::Pi, c),
-            GrbRow::Quad(q) => model.get_obj_attr(attr::QCPi, q),
-        };
-        if let Ok(pi) = pi {
-            dual.insert(ConstraintId(u32::try_from(i).unwrap()), pi);
+    for (i, handle) in constrs.iter().enumerate() {
+        let mut value = 0.0;
+        let mut available = false;
+        for row in &handle.rows {
+            let pi = match row {
+                GurobiRow::Lin(c) => model.get_obj_attr(attr::Pi, c),
+                GurobiRow::Quad(q) => model.get_obj_attr(attr::QCPi, q),
+            };
+            if let Ok(pi) = pi {
+                value += pi;
+                available = true;
+            }
+        }
+        if available {
+            dual.insert(ConstraintId(u32::try_from(i).unwrap()), value);
         }
     }
 
@@ -574,10 +786,11 @@ fn collect_solution(
     let mut soc_dual = FxHashMap::default();
     soc_dual.reserve(soc_rows.len());
     let primal = &solutions[0].primal;
-    for (i, (qrow, bound)) in soc_rows.iter().enumerate() {
-        if let Ok(pi) = model.get_obj_attr(attr::QCPi, qrow) {
-            let b_val = bound.constant
-                + bound
+    for (i, handle) in soc_rows.iter().enumerate() {
+        if let Ok(pi) = model.get_obj_attr(attr::QCPi, &handle.quadratic) {
+            let b_val = handle.bound.constant
+                + handle
+                    .bound
                     .coeffs
                     .iter()
                     .map(|&(v, c)| c * primal.get(&v).copied().unwrap_or(0.0))
@@ -591,8 +804,8 @@ fn collect_solution(
 
 /// Collect the `n` pooled primal points, best first.
 fn collect_pool(
-    model: &mut grb::Model,
-    vars: &[grb::Var],
+    model: &mut gurobi_rs::Model,
+    vars: &[gurobi_rs::Var],
     obj_constant: f64,
     n: i32,
 ) -> Vec<SolutionPoint> {
@@ -611,7 +824,7 @@ fn collect_pool(
     // `SolutionNumber` selects which one `Xn` / `PoolObjVal` report.
     let mut out = Vec::with_capacity(usize::try_from(n).unwrap_or(0));
     for k in 0..n {
-        if model.set_param(grb::param::SolutionNumber, k).is_err() {
+        if model.set_param(gurobi_rs::param::SolutionNumber, k).is_err() {
             break;
         }
         let Ok(vals) = model.get_obj_attr_batch(attr::Xn, vars.iter().copied()) else {
@@ -633,8 +846,8 @@ fn index_map(vals: &[f64]) -> FxHashMap<VarId, f64> {
     map
 }
 
-fn map_status(model: &grb::Model) -> Result<TerminationStatus, SolverError> {
-    let status = model.get_attr(attr::Status).map_err(map_grb_err)?;
+fn map_status(model: &gurobi_rs::Model) -> Result<TerminationStatus, SolverError> {
+    let status = model.get_attr(attr::Status).map_err(map_gurobi_err)?;
     Ok(match status {
         Status::Optimal => TerminationStatus::Optimal,
         Status::Infeasible => TerminationStatus::Infeasible,
@@ -644,10 +857,18 @@ fn map_status(model: &grb::Model) -> Result<TerminationStatus, SolverError> {
         Status::TimeLimit => TerminationStatus::TimeLimit,
         Status::IterationLimit => TerminationStatus::IterationLimit,
         Status::NodeLimit => TerminationStatus::NodeLimit,
+        Status::Interrupted
+        | Status::CutOff
+        | Status::SolutionLimit
+        | Status::UserObjLimit
+        | Status::WorkLimit
+        | Status::MemLimit => TerminationStatus::Interrupted,
+        Status::LocallyOptimal => TerminationStatus::LocallyOptimal,
+        Status::LocallyInfeasible => TerminationStatus::Other("LocallyInfeasible".into()),
         // Gurobi could not meet optimality tolerances but holds a feasible point.
         Status::SubOptimal => TerminationStatus::Feasible,
         Status::Loaded => TerminationStatus::NotSolved,
-        _ => TerminationStatus::Other(format!("Status: {status:?}")),
+        Status::InProgress => TerminationStatus::Other("Status: InProgress".into()),
     })
 }
 

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -787,17 +787,19 @@ fn collect_solution(
     // Available only under `QCPDual=1`.
     let mut soc_dual = FxHashMap::default();
     soc_dual.reserve(soc_rows.len());
-    let primal = &solutions[0].primal;
-    for (i, handle) in soc_rows.iter().enumerate() {
-        if let Ok(pi) = model.get_obj_attr(attr::QCPi, &handle.quadratic) {
-            let b_val = handle.bound.constant
-                + handle
-                    .bound
-                    .coeffs
-                    .iter()
-                    .map(|&(v, c)| c * primal.get(&v).copied().unwrap_or(0.0))
-                    .sum::<f64>();
-            soc_dual.insert(SocConstraintId(u32::try_from(i).unwrap()), 2.0 * b_val * pi.abs());
+    if let Some(first) = solutions.first() {
+        let primal = &first.primal;
+        for (i, handle) in soc_rows.iter().enumerate() {
+            if let Ok(pi) = model.get_obj_attr(attr::QCPi, &handle.quadratic) {
+                let b_val = handle.bound.constant
+                    + handle
+                        .bound
+                        .coeffs
+                        .iter()
+                        .map(|&(v, c)| c * primal.get(&v).copied().unwrap_or(0.0))
+                        .sum::<f64>();
+                soc_dual.insert(SocConstraintId(u32::try_from(i).unwrap()), 2.0 * b_val * pi.abs());
+            }
         }
     }
 
@@ -814,12 +816,7 @@ fn collect_pool(
     // Single point (and the only path for LP/continuous models):
     // read the incumbent directly via `X` / `ObjVal`.
     if n <= 1 {
-        let primal = model
-            .get_obj_attr_batch(attr::X, vars.iter().copied())
-            .map(|v| index_map(&v))
-            .unwrap_or_default();
-        let objective = model.get_attr(attr::ObjVal).ok().map(|v| v + obj_constant);
-        return vec![SolutionPoint { primal, objective }];
+        return vec![collect_incumbent(model, vars, obj_constant)];
     }
 
     // A MIP solution pool. Gurobi sorts it best-first.
@@ -835,7 +832,23 @@ fn collect_pool(
         let objective = model.get_attr(attr::PoolObjVal).ok().map(|v| v + obj_constant);
         out.push(SolutionPoint { primal: index_map(&vals), objective });
     }
+    if out.is_empty() {
+        out.push(collect_incumbent(model, vars, obj_constant));
+    }
     out
+}
+
+fn collect_incumbent(
+    model: &mut gurobi_rs::Model,
+    vars: &[gurobi_rs::Var],
+    obj_constant: f64,
+) -> SolutionPoint {
+    let primal = model
+        .get_obj_attr_batch(attr::X, vars.iter().copied())
+        .map(|v| index_map(&v))
+        .unwrap_or_default();
+    let objective = model.get_attr(attr::ObjVal).ok().map(|v| v + obj_constant);
+    SolutionPoint { primal, objective }
 }
 
 /// Map a dense per-variable value array (in `VarId` order) to a sparse map.

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -451,18 +451,24 @@ fn add_constraints(
             } else {
                 nonlinear.push(index);
             }
-        } else if let Some(t) = extract_linear(arena, c.lhs) {
-            let mut expr = LinExpr::new();
-            for (v, coeff) in t.coeffs {
-                expr.add_term(coeff, gurobi_vars[v.index()]);
+        } else if c.is_range() {
+            if let Some(t) = extract_linear(arena, c.lhs) {
+                let mut expr = LinExpr::new();
+                for (v, coeff) in t.coeffs {
+                    expr.add_term(coeff, gurobi_vars[v.index()]);
+                }
+                ranges.push(PendingRange {
+                    index,
+                    name: c.name.to_string(),
+                    expr,
+                    lower: c.lower - t.constant,
+                    upper: c.upper - t.constant,
+                });
+            } else {
+                nonlinear.push(index);
             }
-            ranges.push(PendingRange {
-                index,
-                name: c.name.to_string(),
-                expr,
-                lower: c.lower - t.constant,
-                upper: c.upper - t.constant,
-            });
+        } else if c.lower.is_infinite() && c.upper.is_infinite() {
+            slots[index] = Some(ConstraintHandle { rows: Vec::new(), generated: Vec::new() });
         } else {
             nonlinear.push(index);
         }
@@ -627,10 +633,10 @@ fn add_comparison_rows(
     lower: f64,
     upper: f64,
 ) -> Result<Vec<GurobiRow>, SolverError> {
-    let senses = single.map_or_else(
-        || vec![(Sense::Ge, lower), (Sense::Le, upper)],
-        |(sense, rhs)| vec![(sense, rhs)],
-    );
+    let senses = single
+        .map_or_else(|| vec![(Sense::Ge, lower), (Sense::Le, upper)], |pair| vec![pair])
+        .into_iter()
+        .filter(|(_, rhs)| rhs.is_finite());
     senses
         .into_iter()
         .enumerate()

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -492,37 +492,46 @@ fn add_constraints(
         }
     }
 
+    let mut single_names = Vec::with_capacity(singles.len());
+    let mut single_indices = Vec::with_capacity(singles.len());
     let single_batch: Vec<_> = singles
-        .iter()
+        .into_iter()
         .map(|p| {
-            let expr = p.expr.clone();
-            let ineq = match p.sense {
+            single_names.push(p.name);
+            single_indices.push(p.index);
+            let expr = p.expr;
+            match p.sense {
                 Sense::Le => c!(expr <= p.rhs),
                 Sense::Ge => c!(expr >= p.rhs),
                 Sense::Eq => c!(expr == p.rhs),
-            };
-            (p.name.clone(), ineq)
+            }
         })
         .collect();
+    let single_batch_iter = single_batch.into_iter();
     let single_handles = gurobi_model
-        .add_constrs(single_batch.iter().map(|(name, expr)| (name, expr.clone())))
+        .add_constrs(single_names.iter().zip(single_batch_iter))
         .map_err(map_gurobi_err)?;
-    for (pending, handle) in singles.into_iter().zip(single_handles) {
-        slots[pending.index] =
+    for (index, handle) in single_indices.into_iter().zip(single_handles) {
+        slots[index] =
             Some(ConstraintHandle { rows: vec![GurobiRow::Lin(handle)], generated: Vec::new() });
     }
 
+    let mut range_names = Vec::with_capacity(ranges.len());
+    let mut range_indices = Vec::with_capacity(ranges.len());
     let range_batch: Vec<_> = ranges
-        .iter()
+        .into_iter()
         .map(|p| {
-            (p.name.clone(), RangeExpr { expr: p.expr.clone().into(), lb: p.lower, ub: p.upper })
+            range_names.push(p.name);
+            range_indices.push(p.index);
+            RangeExpr { expr: p.expr.into(), lb: p.lower, ub: p.upper }
         })
         .collect();
+    let range_batch_iter = range_batch.into_iter();
     let range_handles = gurobi_model
-        .add_ranges(range_batch.iter().map(|(name, expr)| (name, expr.clone())))
+        .add_ranges(range_names.iter().zip(range_batch_iter))
         .map_err(map_gurobi_err)?;
-    for (pending, handle) in ranges.into_iter().zip(range_handles.1) {
-        slots[pending.index] =
+    for (index, handle) in range_indices.into_iter().zip(range_handles.1) {
+        slots[index] =
             Some(ConstraintHandle { rows: vec![GurobiRow::Lin(handle)], generated: Vec::new() });
     }
 

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -51,6 +51,7 @@ pub(crate) struct Built {
     pub model: gurobi_rs::Model,
     pub vars: Vec<gurobi_rs::Var>,
     pub constrs: Vec<ConstraintHandle>,
+    pub objective_generated: Vec<GeneratedConstraint>,
     pub soc_rows: Vec<SocHandle>,
     pub obj_constant: f64,
     pub has_semi: bool,
@@ -94,7 +95,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
         add_constraints(&arena, constraints, &mut gurobi_model, &gurobi_vars, &mut aux_counter)?;
     let soc_rows = add_soc_rows(&arena, &vars, &socs, &mut gurobi_model, &gurobi_vars)?;
 
-    let obj_constant = match objective.as_ref() {
+    let (obj_constant, objective_generated) = match objective.as_ref() {
         Some(o) => set_objective(
             &arena,
             o.expr,
@@ -103,7 +104,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
             &gurobi_vars,
             &mut aux_counter,
         )?,
-        None => 0.0,
+        None => (0.0, Vec::new()),
     };
 
     // Warm starts are assigned only after the full structural model has been
@@ -122,6 +123,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
         model: gurobi_model,
         vars: gurobi_vars,
         constrs: gurobi_constrs,
+        objective_generated,
         soc_rows,
         obj_constant,
         has_semi,
@@ -306,17 +308,20 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
             in_iis |= selected != 0;
         }
         for generated in &handle.generated {
-            let selected = match generated {
-                GeneratedConstraint::Linear(c) => model.get_obj_attr(attr::IISConstr, c),
-                GeneratedConstraint::Quadratic(q) => model.get_obj_attr(attr::IISQConstr, q),
-                GeneratedConstraint::General(g) => model.get_obj_attr(attr::IISGenConstr, g),
-            }
-            .map_err(map_gurobi_err)?;
-            in_iis |= selected != 0;
+            in_iis |= generated_selected(model, generated)?;
         }
         if in_iis {
             iis.constraints
                 .push(ConstraintId(u32::try_from(i).expect("constraint index fits u32")));
+        }
+    }
+
+    for generated in &built.objective_generated {
+        if generated_selected(model, generated)? {
+            return Err(SolverError::Backend(
+                "Gurobi IIS includes an objective-generated definition that cannot be mapped to an original model member"
+                    .into(),
+            ));
         }
     }
 
@@ -343,6 +348,19 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
     }
 
     Ok(iis)
+}
+
+fn generated_selected(
+    model: &gurobi_rs::Model,
+    generated: &GeneratedConstraint,
+) -> Result<bool, SolverError> {
+    let selected = match generated {
+        GeneratedConstraint::Linear(c) => model.get_obj_attr(attr::IISConstr, c),
+        GeneratedConstraint::Quadratic(q) => model.get_obj_attr(attr::IISQConstr, q),
+        GeneratedConstraint::General(g) => model.get_obj_attr(attr::IISGenConstr, g),
+    }
+    .map_err(map_gurobi_err)?;
+    Ok(selected != 0)
 }
 
 /// Add one Gurobi variable per model variable, in `VarId` order, applying its
@@ -683,7 +701,7 @@ fn set_objective(
     gurobi_model: &mut gurobi_rs::Model,
     gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
-) -> Result<f64, SolverError> {
+) -> Result<(f64, Vec<GeneratedConstraint>), SolverError> {
     let gurobi_sense = match sense {
         ObjectiveSense::Minimize => ModelSense::Minimize,
         ObjectiveSense::Maximize => ModelSense::Maximize,
@@ -697,7 +715,7 @@ fn set_objective(
         // not need to track the constant separately.
         e.add_constant(t.constant);
         gurobi_model.set_objective(e, gurobi_sense).map_err(map_gurobi_err)?;
-        return Ok(0.0);
+        return Ok((0.0, Vec::new()));
     }
     let mut ctx = LoweringCtx {
         model: gurobi_model,
@@ -707,10 +725,12 @@ fn set_objective(
     };
     let lowered = lower(arena, obj_expr, &mut ctx)?;
     *aux_counter = ctx.aux_counter;
-    gurobi_model
+    ctx.model
         .set_objective(lowered.into_expr_for_objective(), gurobi_sense)
         .map_err(map_gurobi_err)?;
-    Ok(0.0)
+    let generated = std::mem::take(&mut ctx.generated);
+    drop(ctx);
+    Ok((0.0, generated))
 }
 
 /// Build `(solutions, reduced_costs, dual, soc_dual)` from a solved Gurobi

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -638,12 +638,7 @@ fn add_nonlinear_constraint(
     gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
 ) -> Result<(Vec<GurobiRow>, Vec<GeneratedConstraint>), SolverError> {
-    let mut ctx = LoweringCtx {
-        model: gurobi_model,
-        gurobi_vars,
-        aux_counter: *aux_counter,
-        generated: Vec::new(),
-    };
+    let mut ctx = LoweringCtx::new(gurobi_model, gurobi_vars, *aux_counter);
     let lowered = lower(arena, lhs, &mut ctx)?;
     *aux_counter = ctx.aux_counter;
     let generated = std::mem::take(&mut ctx.generated);
@@ -726,12 +721,7 @@ fn set_objective(
         gurobi_model.set_objective(e, gurobi_sense).map_err(map_gurobi_err)?;
         return Ok((0.0, Vec::new()));
     }
-    let mut ctx = LoweringCtx {
-        model: gurobi_model,
-        gurobi_vars,
-        aux_counter: *aux_counter,
-        generated: Vec::new(),
-    };
+    let mut ctx = LoweringCtx::new(gurobi_model, gurobi_vars, *aux_counter);
     let lowered = lower(arena, obj_expr, &mut ctx)?;
     *aux_counter = ctx.aux_counter;
     ctx.model

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -112,14 +112,10 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     apply_initial_values(&gurobi_model, &vars, &gurobi_vars)?;
 
     apply_options(&mut gurobi_model, opts).map_err(map_gurobi_err)?;
-    if nonlinear_kind {
+    if nonlinear_kind && !opts.has_non_convex() {
         // Gurobi requires NonConvex=2 for general nonlinear constraints and
-        // bilinear non-convex objectives. Skip if the user already set it.
-        let current =
-            gurobi_model.get_param(gurobi_rs::param::NonConvex).map_err(map_gurobi_err)?;
-        if current < 2 {
-            gurobi_model.set_param(gurobi_rs::param::NonConvex, 2).map_err(map_gurobi_err)?;
-        }
+        // bilinear non-convex objectives. Preserve an explicit user setting.
+        gurobi_model.set_param(gurobi_rs::param::NonConvex, 2).map_err(map_gurobi_err)?;
     }
 
     Ok(Built {

--- a/crates/oximo-gurobi/tests/callback.rs
+++ b/crates/oximo-gurobi/tests/callback.rs
@@ -2,15 +2,29 @@
 
 use oximo_core::prelude::*;
 use oximo_gurobi::{
-    Callback, CallbackLocation, CallbackMask, CbResult, Gurobi, GurobiOptions, Where,
+    Callback, CallbackLocation, CallbackMask, CbResult, Gurobi, GurobiOptions, GurobiPresolve,
+    Where,
 };
 
 #[derive(Default)]
-struct Counter(usize);
+struct Locations(Vec<CallbackLocation>);
 
-impl Callback for Counter {
-    fn callback(&mut self, _where: Where) -> CbResult {
-        self.0 += 1;
+impl Callback for Locations {
+    fn callback(&mut self, where_: Where) -> CbResult {
+        let location = match where_ {
+            Where::Polling(_) => CallbackLocation::Polling,
+            Where::PreSolve(_) => CallbackLocation::PreSolve,
+            Where::Simplex(_) => CallbackLocation::Simplex,
+            Where::MIP(_) => CallbackLocation::Mip,
+            Where::MIPSol(_) => CallbackLocation::MipSol,
+            Where::MIPNode(_) => CallbackLocation::MipNode,
+            Where::Message(_) => CallbackLocation::Message,
+            Where::Barrier(_) => CallbackLocation::Barrier,
+            Where::MultiObj(_) => CallbackLocation::MultiObj,
+            Where::IIS(_) => CallbackLocation::Iis,
+            _ => return Err(std::io::Error::other("unexpected callback location").into()),
+        };
+        self.0.push(location);
         Ok(())
     }
 }
@@ -22,19 +36,23 @@ fn callback_solve_uses_common_result_collection() {
     constraint!(m, cap, sum!(x[i] for i in 0..4) <= 2.0);
     objective!(m, Max, sum!(x[i] for i in 0..4));
 
-    let mut callback = Counter::default();
+    let mut callback = Locations::default();
     let mut solver = Gurobi;
+    let mask = CallbackMask::from(CallbackLocation::Polling) | CallbackLocation::Mip;
     let result = solver
         .solve_with_callback_filtered(
             &m,
-            &GurobiOptions::default(),
+            &GurobiOptions::default().presolve(GurobiPresolve::Off),
             &mut callback,
-            CallbackMask::from(CallbackLocation::Polling) | CallbackLocation::Mip,
+            mask,
         )
         .expect("callback solve");
 
     assert!(result.has_solution());
-    assert!(callback.0 > 0, "Gurobi did not invoke the callback");
+    assert!(!callback.0.is_empty(), "Gurobi did not invoke the callback");
+    for location in callback.0 {
+        assert!(mask.contains(location), "callback location {location:?} was not selected");
+    }
 }
 
 struct FailingCallback;

--- a/crates/oximo-gurobi/tests/callback.rs
+++ b/crates/oximo-gurobi/tests/callback.rs
@@ -5,6 +5,7 @@ use oximo_gurobi::{
     Callback, CallbackLocation, CallbackMask, CbResult, Gurobi, GurobiOptions, GurobiPresolve,
     Where,
 };
+use oximo_solver::{PersistentSolver, Solver};
 
 #[derive(Default)]
 struct Locations(Vec<CallbackLocation>);
@@ -49,9 +50,9 @@ fn callback_solve_uses_common_result_collection() {
         .expect("callback solve");
 
     assert!(result.has_solution());
-    assert!(!callback.0.is_empty(), "Gurobi did not invoke the callback");
-    for location in callback.0 {
-        assert!(mask.contains(location), "callback location {location:?} was not selected");
+    assert!(callback.0.contains(&CallbackLocation::Mip), "Gurobi did not invoke a MIP callback");
+    for location in &callback.0 {
+        assert!(mask.contains(*location), "callback location {location:?} was not selected");
     }
 }
 
@@ -75,4 +76,28 @@ fn callback_errors_are_solver_errors() {
         .solve_with_callback(&m, &GurobiOptions::default(), &mut callback)
         .expect_err("callback should fail");
     assert!(error.to_string().contains("Problem with callback"), "{error}");
+}
+
+#[test]
+fn persistent_callback_error_clears_and_rebuilds_resident_model() {
+    let m = Model::new("persistent_callback_error");
+    variable!(m, x, Bin);
+    objective!(m, Max, x);
+
+    let opts = GurobiOptions::default().presolve(GurobiPresolve::Off);
+    let mut solver = Gurobi.persistent();
+    let first = solver.solve(&m, &opts).expect("initial persistent solve");
+    assert!(first.has_solution());
+
+    let mut callback = FailingCallback;
+    let error =
+        solver.solve_with_callback(&m, &opts, &mut callback).expect_err("callback should fail");
+    assert!(error.to_string().contains("Problem with callback"), "{error}");
+
+    let cleared = solver.compute_iis().expect_err("callback failure should clear resident state");
+    assert!(cleared.to_string().contains("no resident model"), "{cleared}");
+
+    let recovered =
+        solver.solve(&m, &opts).expect("persistent solve should rebuild after callback failure");
+    assert!(recovered.has_solution());
 }

--- a/crates/oximo-gurobi/tests/callback.rs
+++ b/crates/oximo-gurobi/tests/callback.rs
@@ -1,0 +1,60 @@
+//! Live callback-surface tests for the Gurobi 13 backend.
+
+use oximo_core::prelude::*;
+use oximo_gurobi::{
+    Callback, CallbackLocation, CallbackMask, CbResult, Gurobi, GurobiOptions, Where,
+};
+
+#[derive(Default)]
+struct Counter(usize);
+
+impl Callback for Counter {
+    fn callback(&mut self, _where: Where) -> CbResult {
+        self.0 += 1;
+        Ok(())
+    }
+}
+
+#[test]
+fn callback_solve_uses_common_result_collection() {
+    let m = Model::new("callback");
+    variable!(m, x[i in 0..4], Bin);
+    constraint!(m, cap, sum!(x[i] for i in 0..4) <= 2.0);
+    objective!(m, Max, sum!(x[i] for i in 0..4));
+
+    let mut callback = Counter::default();
+    let mut solver = Gurobi;
+    let result = solver
+        .solve_with_callback_filtered(
+            &m,
+            &GurobiOptions::default(),
+            &mut callback,
+            CallbackMask::from(CallbackLocation::Polling) | CallbackLocation::Mip,
+        )
+        .expect("callback solve");
+
+    assert!(result.has_solution());
+    assert!(callback.0 > 0, "Gurobi did not invoke the callback");
+}
+
+struct FailingCallback;
+
+impl Callback for FailingCallback {
+    fn callback(&mut self, _where: Where) -> CbResult {
+        Err(std::io::Error::other("callback failure").into())
+    }
+}
+
+#[test]
+fn callback_errors_are_solver_errors() {
+    let m = Model::new("callback_error");
+    variable!(m, x, Bin);
+    objective!(m, Max, x);
+
+    let mut callback = FailingCallback;
+    let mut solver = Gurobi;
+    let error = solver
+        .solve_with_callback(&m, &GurobiOptions::default(), &mut callback)
+        .expect_err("callback should fail");
+    assert!(error.to_string().contains("Problem with callback"), "{error}");
+}

--- a/crates/oximo-gurobi/tests/gurobi13_api.rs
+++ b/crates/oximo-gurobi/tests/gurobi13_api.rs
@@ -1,0 +1,28 @@
+use oximo_gurobi::{GRB_METHOD_PDHG, GurobiOptions, Opcode, Status};
+
+#[test]
+fn exposes_gurobi13_symbols_and_method_option() {
+    let _options = GurobiOptions::default()
+        .method(GRB_METHOD_PDHG)
+        .nl_bar_iter_limit(100)
+        .nl_bar_c_feas_tol(1e-6)
+        .nl_bar_d_feas_tol(1e-6)
+        .nl_bar_p_feas_tol(1e-6)
+        .pdhg_abs_tol(1e-6)
+        .pdhg_conv_tol(1e-6)
+        .pdhg_rel_tol(1e-6)
+        .pdhg_iter_limit(1000.0)
+        .pdhg_gpu(1)
+        .no_rel_heur_solutions(10)
+        .inherit_params(1)
+        .fix_vars_in_indicators(1)
+        .start_time_limit(1.0)
+        .start_work_limit(1.0)
+        .improve_start_work(1.0)
+        .master_knapsack_cuts(1)
+        .obj_pass_number(1)
+        .optimality_target(1);
+    assert_eq!(Status::LocallyOptimal as i32, 18);
+    assert_eq!(Status::LocallyInfeasible as i32, 19);
+    assert_eq!(Opcode::SignPow as i32, 19);
+}

--- a/crates/oximo-gurobi/tests/nonlinear.rs
+++ b/crates/oximo-gurobi/tests/nonlinear.rs
@@ -2,7 +2,7 @@
 
 use oximo_core::prelude::*;
 use oximo_gurobi::{Gurobi, GurobiOptions};
-use oximo_solver::Solver;
+use oximo_solver::{InfeasibilityDiagnosis, Solver};
 
 fn close(a: f64, b: f64, tol: f64) -> bool {
     (a - b).abs() < tol
@@ -156,4 +156,15 @@ fn div_by_zero_constant_errors() {
 
     let err = Gurobi.solve(&m, &GurobiOptions::default()).expect_err("expected error");
     assert!(err.to_string().contains("division by zero"), "err = {err}");
+}
+
+#[test]
+fn nonlinear_iis_maps_generated_abs_definition() {
+    let m = Model::new("nl_iis_abs");
+    variable!(m, x);
+    let conflict = constraint!(m, impossible, x.abs() <= -1.0);
+    objective!(m, Min, x);
+
+    let iis = Gurobi.compute_iis(&m, &GurobiOptions::default()).expect("compute nonlinear IIS");
+    assert!(iis.constraints.contains(&conflict));
 }

--- a/crates/oximo-gurobi/tests/soc.rs
+++ b/crates/oximo-gurobi/tests/soc.rs
@@ -4,7 +4,7 @@
 
 use oximo_core::prelude::*;
 use oximo_gurobi::{Gurobi, GurobiOptions};
-use oximo_solver::Solver;
+use oximo_solver::{InfeasibilityDiagnosis, Solver};
 
 fn close(a: f64, b: f64, tol: f64) -> bool {
     (a - b).abs() < tol
@@ -101,4 +101,18 @@ fn soc_with_affine_members() {
     assert!(r.has_solution());
     let obj = r.objective().expect("obj");
     assert!(close(obj, 0.0, 1e-4), "obj = {obj}");
+}
+
+#[test]
+fn soc_iis_maps_the_generated_bound_sign_row() {
+    let m = Model::new("socp_iis_sign");
+    variable!(m, x);
+    variable!(m, t);
+    m.fix(x, 0.0);
+    m.fix(t, -1.0);
+    let cone = m.add_soc_constraint("cone", [x], t);
+    objective!(m, Min, x);
+
+    let iis = Gurobi.compute_iis(&m, &GurobiOptions::default()).expect("compute SOC IIS");
+    assert!(iis.soc_constraints.contains(&cone), "cone missing from IIS: {iis:?}");
 }

--- a/crates/oximo-gurobi/tests/translation.rs
+++ b/crates/oximo-gurobi/tests/translation.rs
@@ -1,0 +1,16 @@
+//! Tests for Gurobi translation metadata and range semantics.
+
+use oximo_core::prelude::*;
+use oximo_gurobi::{Gurobi, GurobiOptions};
+use oximo_solver::Solver;
+
+#[test]
+fn inverted_linear_range_is_reported_as_infeasible() {
+    let m = Model::new("inverted_range");
+    variable!(m, x);
+    constraint!(m, impossible, 2.0 <= x <= 1.0);
+    objective!(m, Min, x);
+
+    let result = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve inverted range");
+    assert!(result.termination.is_infeasible(), "termination = {:?}", result.termination);
+}

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -213,7 +213,7 @@ pub trait Solver {
 | --------------- | ------------------------------------------------------------ | ------- |
 | `highs`         | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
 | `io`            | NL, MPS, and LP file writers                                 | yes     |
-| `gurobi`        | Gurobi solver (requires licensed install)                    | no      |
+| `gurobi`        | Gurobi v13+ solver (requires licensed install)               | no      |
 | `mosek`         | MOSEK 11.2 - convex LP/MIP/QP/QCP/SOCP solver                | no      |
 | `gams`          | GAMS bridge - solve type depends on the selected sub-solver  | no      |
 | `baron`         | BARON - Global non-convex solver (requires licensed install) | no      |

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -25,8 +25,8 @@ pub use oximo_highs::{HighsMethod, HighsOptions, HighsPresolve};
 #[cfg(feature = "gurobi")]
 #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
 pub use oximo_gurobi::{
-    Callback, CallbackLocation, CallbackMask, CbResult, GurobiOptions, GurobiPersistent,
-    GurobiPresolve, Opcode, Status, Where, GRB_METHOD_PDHG,
+    Callback, CallbackLocation, CallbackMask, CbResult, GRB_METHOD_PDHG, GurobiOptions,
+    GurobiPersistent, GurobiPresolve, Opcode, Status, Where,
 };
 
 #[cfg(feature = "mosek")]
@@ -77,8 +77,8 @@ pub mod prelude {
     #[cfg(feature = "gurobi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
     pub use oximo_gurobi::{
-        Callback, CallbackLocation, CallbackMask, CbResult, GurobiOptions, GurobiPersistent,
-        GurobiPresolve, Opcode, Status, Where, GRB_METHOD_PDHG,
+        Callback, CallbackLocation, CallbackMask, CbResult, GRB_METHOD_PDHG, GurobiOptions,
+        GurobiPersistent, GurobiPresolve, Opcode, Status, Where,
     };
 
     #[cfg(feature = "mosek")]

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -24,7 +24,10 @@ pub use oximo_highs::{HighsMethod, HighsOptions, HighsPresolve};
 
 #[cfg(feature = "gurobi")]
 #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
-pub use oximo_gurobi::{GurobiOptions, GurobiPersistent, GurobiPresolve};
+pub use oximo_gurobi::{
+    Callback, CallbackLocation, CallbackMask, CbResult, GurobiOptions, GurobiPersistent,
+    GurobiPresolve, Opcode, Status, Where, GRB_METHOD_PDHG,
+};
 
 #[cfg(feature = "mosek")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mosek")))]
@@ -73,7 +76,10 @@ pub mod prelude {
 
     #[cfg(feature = "gurobi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "gurobi")))]
-    pub use oximo_gurobi::{GurobiOptions, GurobiPersistent, GurobiPresolve};
+    pub use oximo_gurobi::{
+        Callback, CallbackLocation, CallbackMask, CbResult, GurobiOptions, GurobiPersistent,
+        GurobiPresolve, Opcode, Status, Where, GRB_METHOD_PDHG,
+    };
 
     #[cfg(feature = "mosek")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mosek")))]


### PR DESCRIPTION
## Description

This PR switches `grb` (unmaintained) to `gurobi-rs`, adding support for Gurobi v13+ and many improvements.
However, this means we can only use V13+. This is fine with me, at least for now. I am not sure Gurobi has perpetual licenses, and we can always export to `.nl` files if needed.

If we wanted to support previous versions, we could use feature flags, but it is too much work, and I don't think it is worth it for now.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [ ] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [ ] `cargo test --features mosek` passes (requires MOSEK)
- [ ] `cargo test --features baron` passes (requires BARON)