### PR TITLE
Add MPS reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ pub trait Solver {
 | Feature         | What it adds                                                 | Default |
 | --------------- | ------------------------------------------------------------ | ------- |
 | `highs`         | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
-| `io`            | NL, MPS, and LP file writers                                 | yes     |
+| `io`            | NL, MPS, and LP file readers and writers                     | yes     |
 | `gurobi`        | Gurobi v13+ solver (requires licensed install)               | no      |
 | `mosek`         | MOSEK 11.2 - convex LP/MIP/QP/QCP/SOCP solver                | no      |
 | `gams`          | GAMS bridge - solve type depends on the selected sub-solver  | no      |
@@ -268,7 +268,7 @@ for i in 0..result.result_count() {
 | `oximo-macros`   | `variable!`, `constraint!`, `objective!` and other macros |
 | `oximo-autodiff` | Gradients, sparse Jacobians/Hessians via Enzyme           |
 | `oximo-solver`   | `Solver` trait, `SolverResult`, `SolverOptions`           |
-| `oximo-io`       | MPS, LP and NL writers                                    |
+| `oximo-io`       | MPS, LP and NL readers and writers                        |
 | `oximo-highs`    | HiGHS backend                                             |
 | `oximo-gurobi`   | Gurobi backend                                            |
 | `oximo-mosek`    | MOSEK 11.2 backend                                       |

--- a/crates/oximo-io/Cargo.toml
+++ b/crates/oximo-io/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Model I/O (MPS, LP, NLP writers) for oximo"
+description = "MPS, LP, and NL model readers and writers for oximo"
 readme = "README.md"
 
 [features]

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -54,14 +54,14 @@ println!("{mps}");
 Whitespace-delimited MPS, compatible with conventional fixed-column files whose names do not contain spaces.
 Widely supported by commercial and open-source solvers.
 
-| Feature            | Behavior                                                                                            |
-| ------------------ | --------------------------------------------------------------------------------------------------- |
-| Objective sense    | Written with `OBJSENSE`                                                                             |
-| Linear models      | `ROWS`, `COLUMNS`, `RHS`, `RANGES`, bounds, integer markers, binary and semi domains                |
-| Quadratic import   | `QUADOBJ`, `QMATRIX`, `QCMATRIX`, and `QSECTION`. Gurobi or CPLEX constraint scaling is selectable. |
-| Quadratic export   | `QUADOBJ`/`QCMATRIX` for Gurobi and CPLEX, `QSECTION` for MOSEK                                     |
-| Unsupported import | SOS and indicator sections return `IoError::UnsupportedMps`                                         |
-| Constant terms     | Objective constants use `RHS OBJ`, constraint constants are folded into `RHS`                       |
+| Feature            | Behavior                                                                                                   |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Objective sense    | Written with `OBJSENSE`                                                                                    |
+| Linear models      | `ROWS`, `COLUMNS`, `RHS`, `RANGES`, bounds, integer markers, binary and semi domains                       |
+| Quadratic import   | `QUADOBJ`, `QMATRIX`, `QCMATRIX`, and `QSECTION`. Gurobi, CPLEX or MOSEK constraint scaling is selectable. |
+| Quadratic export   | `QUADOBJ`/`QCMATRIX` for Gurobi and CPLEX, `QSECTION` for MOSEK                                            |
+| Unsupported import | SOS and indicator sections return `IoError::UnsupportedMps`                                                |
+| Constant terms     | Objective constants use `RHS OBJ`, constraint constants are folded into `RHS`                              |
 
 ```rust,ignore
 use oximo_io::{

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -51,18 +51,23 @@ println!("{mps}");
 
 ### MPS
 
-Fixed-format MPS (fixed-column, 10-char field width). Widely supported by commercial and open-source solvers.
+Whitespace-delimited MPS, compatible with conventional fixed-column files whose names do not contain spaces.
+Widely supported by commercial and open-source solvers.
 
-| Feature           | Behavior                                                                                                                       |
-|-------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| Objective row     | Named `OBJ`, maximization models are negated with a `* sense: maximize` comment so re-importers can recover the original sense |
-| Integer variables | Wrapped in `INTORG`/`INTEND` markers                                                                                           |
-| Semicont variables| `LO` (threshold) + upper-bound semi marker: `SC` for semi-continuous, `SI` for semi-integer                                    |
-| Bounds            | `FR` (free), `MI`+`UP` (lower=-inf), `LO`/`UP` as needed. Default lb=0 omitted                                                 |
-| Constant terms    | Objective constant written to `RHS OBJ`, constraint constants folded into `RHS`                                                |
+| Feature            | Behavior                                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------- |
+| Objective sense    | Written with `OBJSENSE`                                                                             |
+| Linear models      | `ROWS`, `COLUMNS`, `RHS`, `RANGES`, bounds, integer markers, binary and semi domains                |
+| Quadratic import   | `QUADOBJ`, `QMATRIX`, `QCMATRIX`, and `QSECTION`. Gurobi or CPLEX constraint scaling is selectable. |
+| Quadratic export   | `QUADOBJ`/`QCMATRIX` for Gurobi and CPLEX, `QSECTION` for MOSEK                                     |
+| Unsupported import | SOS and indicator sections return `IoError::UnsupportedMps`                                         |
+| Constant terms     | Objective constants use `RHS OBJ`, constraint constants are folded into `RHS`                       |
 
 ```rust,ignore
-use oximo_io::{write_mps, to_mps_string};
+use oximo_io::{
+    MpsQuadraticFormat, MpsReadOptions, MpsWriteOptions, read_mps_file, read_mps_with,
+    to_mps_string, to_mps_string_with, write_mps,
+};
 use std::fs::File;
 use std::io::BufWriter;
 
@@ -72,6 +77,17 @@ let s = to_mps_string(&model)?;
 // To file
 let mut f = BufWriter::new(File::create("model.mps")?);
 write_mps(&model, &mut f)?;
+
+// Read a file with the default Gurobi quadratic-constraint convention.
+let imported = read_mps_file("model.mps")?;
+
+// Select CPLEX scaling when importing QCMATRIX/QSECTION constraints.
+let options = MpsReadOptions { quadratic_format: MpsQuadraticFormat::Cplex };
+let imported_cplex = read_mps_with(s.as_bytes(), &options)?;
+
+// Export quadratic sections in a solver-compatible dialect.
+let write_options = MpsWriteOptions { quadratic_format: MpsQuadraticFormat::Mosek };
+let quadratic_mps = to_mps_string_with(&model, &write_options)?;
 ```
 
 ### LP (CPLEX LP format)
@@ -79,7 +95,7 @@ write_mps(&model, &mut f)?;
 Human-readable CPLEX LP format. Sections emitted: header comment, `Minimize`/`Maximize`, `Subject To`, `Bounds` (non-default only), `General`, `Binaries`, `Semi-Continuous`, `End`.
 
 | Feature            | Behavior                                                           |
-|--------------------|--------------------------------------------------------------------|
+| ------------------ | ------------------------------------------------------------------ |
 | Objective sense    | `Minimize` / `Maximize` keyword, no negation needed                |
 | Quadratic terms    | CPLEX bracket notation: objective `[Q]/2`, constraints `[q]`       |
 | Integer variables  | `General` section (integer/semi-integer), `Binaries` section       |
@@ -107,7 +123,7 @@ let imported = oximo_io::read_lp(s.as_bytes())?;
 The standard format for sharing nonlinear and mixed-integer models. Unlike MPS/LP, it carries full nonlinear expressions, emitted as prefix (Polish) opcode trees.
 
 | Feature              | Behavior                                                                |
-|----------------------|-------------------------------------------------------------------------|
+| -------------------- | ----------------------------------------------------------------------- |
 | Nonlinear bodies     | Linear part goes to `J`/`G`; nonlinear residual to `C`/`O` opcode trees |
 | Supported operators  | `+ - * /`, negation, `pow`, `abs`, `sin`, `cos`, `exp`, `log` (natural) |
 | Output encoding      | ASCII (default) or binary, via `WriteOptions::format`                   |
@@ -161,7 +177,7 @@ model.
 All functions return `Result<_, IoError>`:
 
 | Variant                       | Cause                                                                      |
-|-------------------------------|----------------------------------------------------------------------------|
+| ----------------------------- | -------------------------------------------------------------------------- |
 | `IoError::NoObjective`        | Model has no objective set                                                 |
 | `IoError::Nonlinear`          | Unsupported nonlinear node in an MPS/LP model (LP accepts degree <= 2)     |
 | `IoError::UnsupportedNode(n)` | Node not representable in the target format, e.g. `Param` in NL            |
@@ -172,6 +188,8 @@ All functions return `Result<_, IoError>`:
 | `IoError::UnsupportedNl`      | Semantics not representable by the core model                              |
 | `IoError::InvalidLp`          | Invalid LP input, with line and column                                     |
 | `IoError::UnsupportedLp`      | LP semantics not representable by oximo's core model                       |
+| `IoError::InvalidMps`         | Invalid MPS input, with line and column                                    |
+| `IoError::UnsupportedMps`     | MPS semantics not representable by oximo's core model                      |
 
 ## License
 

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -81,9 +81,11 @@ write_mps(&model, &mut f)?;
 // Read a file with the default Gurobi quadratic-constraint convention.
 let imported = read_mps_file("model.mps")?;
 
-// Select CPLEX scaling when importing QCMATRIX/QSECTION constraints.
-let options = MpsReadOptions { quadratic_format: MpsQuadraticFormat::Cplex };
-let imported_cplex = read_mps_with(s.as_bytes(), &options)?;
+// Serialize and import with matching CPLEX quadratic conventions.
+let cplex_write_options = MpsWriteOptions { quadratic_format: MpsQuadraticFormat::Cplex };
+let cplex_mps = to_mps_string_with(&model, &cplex_write_options)?;
+let cplex_read_options = MpsReadOptions { quadratic_format: MpsQuadraticFormat::Cplex };
+let imported_cplex = read_mps_with(cplex_mps.as_bytes(), &cplex_read_options)?;
 
 // Export quadratic sections in a solver-compatible dialect.
 let write_options = MpsWriteOptions { quadratic_format: MpsQuadraticFormat::Mosek };

--- a/crates/oximo-io/src/error.rs
+++ b/crates/oximo-io/src/error.rs
@@ -30,4 +30,8 @@ pub enum IoError {
     InvalidLp { line: usize, column: usize, message: String },
     #[error("unsupported LP feature in {section}: {feature}")]
     UnsupportedLp { section: String, feature: String },
+    #[error("invalid MPS file at {line}:{column}: {message}")]
+    InvalidMps { line: usize, column: usize, message: String },
+    #[error("unsupported MPS feature in {section}: {feature}")]
+    UnsupportedMps { section: String, feature: String },
 }

--- a/crates/oximo-io/src/lib.rs
+++ b/crates/oximo-io/src/lib.rs
@@ -8,7 +8,10 @@ pub mod nl;
 
 pub use error::IoError;
 pub use lp::{read_lp, read_lp_file, to_lp_string, write_lp};
-pub use mps::{to_mps_string, write_mps};
+pub use mps::{
+    MpsQuadraticFormat, MpsReadOptions, read_mps, read_mps_file, read_mps_file_with, read_mps_with,
+    to_mps_string, write_mps,
+};
 pub use nl::{
     Complementarity, DefinedVar, ImportedFunction, NlFormat, SuffixData, SuffixFlavour, SuffixKind,
     WriteOptions, read_nl, read_nl_file, to_nl_string, to_nl_string_with, write_nl, write_nl_files,

--- a/crates/oximo-io/src/lib.rs
+++ b/crates/oximo-io/src/lib.rs
@@ -9,8 +9,9 @@ pub mod nl;
 pub use error::IoError;
 pub use lp::{read_lp, read_lp_file, to_lp_string, write_lp};
 pub use mps::{
-    MpsQuadraticFormat, MpsReadOptions, read_mps, read_mps_file, read_mps_file_with, read_mps_with,
-    to_mps_string, write_mps,
+    MpsQuadraticFormat, MpsReadOptions, MpsWriteOptions, read_mps, read_mps_file,
+    read_mps_file_with, read_mps_with, to_mps_string, to_mps_string_with, write_mps,
+    write_mps_with,
 };
 pub use nl::{
     Complementarity, DefinedVar, ImportedFunction, NlFormat, SuffixData, SuffixFlavour, SuffixKind,

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -4,10 +4,12 @@
 //! problems. It is a common lingua franca for exchanging models between tools.
 //!
 //! [`read_mps`] and [`read_mps_file`] import whitespace-delimited MPS files.
-//! [`write_mps`] exports the linear subset to any `std::io::Write`.
+//! [`write_mps`] exports linear and quadratic models to any `std::io::Write`.
 //!
 //! References:
 //! - "MPS file format," lp_solve. <https://lpsolve.sourceforge.net/5.5/mps-format.htm> (accessed May 09, 2026).
+//! - Gurobi, "Model File Formats." <https://docs.gurobi.com/projects/optimizer/en/current/reference/fileformats/modelformats.html>
+//! - IBM ILOG CPLEX, "Quadratically constrained programs (QCP) in MPS files." <https://www.ibm.com/docs/en/cofz/12.9.0?topic=extensions-quadratically-constrained-programs-qcp-in-mps-files>
 
 use std::collections::HashSet;
 use std::fs::File;
@@ -15,7 +17,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 
 use oximo_core::{Constraint, Domain, Model, ModelKind, ObjectiveSense, Sense, var_name};
-use oximo_expr::{Expr, LinearTerms, VarId, describe_nonlinear_term, extract_linear};
+use oximo_expr::{Expr, QuadraticTerms, VarId, describe_nonlinear_term, extract_quadratic};
 use rustc_hash::FxHashMap;
 
 use crate::error::IoError;
@@ -33,12 +35,21 @@ pub enum MpsQuadraticFormat {
     Gurobi,
     /// CPLEX-compatible quadratic-constraint scaling.
     Cplex,
+    /// MOSEK-compatible `QSECTION` layout and scaling.
+    Mosek,
 }
 
 /// Options controlling MPS import.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MpsReadOptions {
     /// How ambiguous quadratic-constraint matrix coefficients are scaled.
+    pub quadratic_format: MpsQuadraticFormat,
+}
+
+/// Options controlling MPS export.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MpsWriteOptions {
+    /// Solver-compatible layout and scaling for quadratic sections.
     pub quadratic_format: MpsQuadraticFormat,
 }
 
@@ -596,7 +607,7 @@ fn quadratic_coefficient(
     objective: bool,
     value: f64,
 ) -> f64 {
-    if objective || format == MpsQuadraticFormat::Cplex {
+    if objective || format != MpsQuadraticFormat::Gurobi {
         if diagonal { value / 2.0 } else { value }
     } else if diagonal {
         value
@@ -892,6 +903,42 @@ fn unique_mps_names<'a>(
         .collect()
 }
 
+fn write_quadratic_section<W: Write>(
+    out: &mut W,
+    header: &str,
+    terms: &QuadraticTerms,
+    variable_names: &[String],
+    format: MpsQuadraticFormat,
+    objective: bool,
+) -> Result<(), IoError> {
+    writeln!(out, "{header}")?;
+    for &(left, right, hessian) in &terms.hessian {
+        let (first, second) = if objective {
+            // Gurobi and MOSEK document lower-triangular objective records.
+            // CPLEX's QUADOBJ convention uses the upper triangle.
+            if format == MpsQuadraticFormat::Cplex && left.index() > right.index() {
+                (right, left)
+            } else {
+                (left, right)
+            }
+        } else if left.index() <= right.index() {
+            (left, right)
+        } else {
+            (right, left)
+        };
+        let left_name = &variable_names[first.index()];
+        let right_name = &variable_names[second.index()];
+        let coefficient =
+            if objective || format != MpsQuadraticFormat::Gurobi { hessian } else { hessian / 2.0 };
+        writeln!(out, "    {left_name:<10} {right_name:<10} {coefficient}")?;
+        if !objective && format != MpsQuadraticFormat::Mosek && first != second {
+            // Gurobi and CPLEX require QCMATRIX to contain a symmetric Q.
+            writeln!(out, "    {right_name:<10} {left_name:<10} {coefficient}")?;
+        }
+    }
+    Ok(())
+}
+
 fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
     for column in &data.columns {
         if column.lower > column.upper {
@@ -995,9 +1042,10 @@ pub fn read_mps_file_with(
 
 /// Write `model` to `out` in fixed-format MPS.
 ///
-/// MPS only represents linear LP / MILP. Nonlinear expressions in the
-/// objective or constraints raise [`IoError::Nonlinear`], second-order cone
-/// constraints [`IoError::Conic`]. The objective row is named `OBJ`.
+/// MPS represents linear and quadratic LP/MILP/QP/QCP models. Higher-degree
+/// or otherwise nonlinear expressions in the objective or constraints raise
+/// [`IoError::Nonlinear`]. Second-order cone constraints raise [`IoError::Conic`].
+/// The objective row is named `OBJ`.
 /// Variable and constraint names have whitespace replaced by underscores and
 /// are made unique within their respective MPS namespaces. The generated
 /// objective row reserves the name `OBJ`.
@@ -1006,8 +1054,25 @@ pub fn read_mps_file_with(
 ///
 /// Returns [`IoError`] if there is an error writing the MPS data or if the model contains unsupported features.
 ///
-#[expect(clippy::too_many_lines)]
 pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
+    write_mps_with(model, out, &MpsWriteOptions::default())
+}
+
+/// Write `model` to `out` with explicit quadratic MPS options.
+///
+/// `Gurobi` and `Cplex` emit `QUADOBJ` plus `QCMATRIX` sections. `Mosek` emits
+/// `QSECTION` sections for the objective and quadratic constraints.
+///
+/// # Errors
+///
+/// Returns [`IoError`] if the model contains unsupported expressions or writing
+/// the output fails.
+#[expect(clippy::too_many_lines)]
+pub fn write_mps_with<W: Write>(
+    model: &Model,
+    out: &mut W,
+    options: &MpsWriteOptions,
+) -> Result<(), IoError> {
     if model.num_soc_constraints() > 0
         || matches!(model.kind(), ModelKind::SOCP | ModelKind::MISOCP)
     {
@@ -1021,17 +1086,18 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     let variable_names = unique_mps_names(vars.iter().map(|v| v.name.as_str()), "C", []);
     let row_names = unique_mps_names(constraints.iter().map(|c| c.name.as_str()), "R", ["OBJ"]);
 
-    let obj_terms = extract_linear(&arena, objective.expr).ok_or_else(|| IoError::Nonlinear {
-        location: "the objective".into(),
-        term: describe_nonlinear_term(&arena, objective.expr, &|v| var_name(&vars, v))
-            .unwrap_or_else(|| "<nonlinear>".into()),
-    })?;
+    let obj_terms =
+        extract_quadratic(&arena, objective.expr).ok_or_else(|| IoError::Nonlinear {
+            location: "the objective".into(),
+            term: describe_nonlinear_term(&arena, objective.expr, &|v| var_name(&vars, v))
+                .unwrap_or_else(|| "<nonlinear>".into()),
+        })?;
 
-    // Pre-compute constraint linear terms once, reused for COLUMNS and RHS.
-    let con_terms: Vec<LinearTerms> = constraints
+    // Pre-compute quadratic terms once, reused for COLUMNS, RHS, and quadratic sections.
+    let con_terms: Vec<QuadraticTerms> = constraints
         .iter()
         .map(|c| {
-            extract_linear(&arena, c.lhs).ok_or_else(|| IoError::Nonlinear {
+            extract_quadratic(&arena, c.lhs).ok_or_else(|| IoError::Nonlinear {
                 location: format!("constraint {:?}", c.name),
                 term: describe_nonlinear_term(&arena, c.lhs, &|v| var_name(&vars, v))
                     .unwrap_or_else(|| "<nonlinear>".into()),
@@ -1041,11 +1107,11 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
 
     // Build column index: VarId to [(row_name, coef)] in row order (OBJ first, then constraints).
     let mut col_index: FxHashMap<VarId, Vec<(&str, f64)>> = FxHashMap::default();
-    for (v, c) in &obj_terms.coeffs {
+    for (v, c) in &obj_terms.linear {
         col_index.entry(*v).or_default().push(("OBJ", *c));
     }
     for (row_name, terms) in row_names.iter().zip(con_terms.iter()) {
-        for (v, coef) in &terms.coeffs {
+        for (v, coef) in &terms.linear {
             col_index.entry(*v).or_default().push((row_name.as_str(), *coef));
         }
     }
@@ -1187,6 +1253,41 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         }
     }
 
+    if !obj_terms.hessian.is_empty() {
+        let header = if options.quadratic_format == MpsQuadraticFormat::Mosek {
+            "QSECTION OBJ"
+        } else {
+            "QUADOBJ"
+        };
+        write_quadratic_section(
+            out,
+            header,
+            &obj_terms,
+            &variable_names,
+            options.quadratic_format,
+            true,
+        )?;
+    }
+    for (row_name, terms) in row_names.iter().zip(con_terms.iter()) {
+        if terms.hessian.is_empty() {
+            continue;
+        }
+        let header = match options.quadratic_format {
+            MpsQuadraticFormat::Mosek => format!("QSECTION {row_name}"),
+            MpsQuadraticFormat::Gurobi | MpsQuadraticFormat::Cplex => {
+                format!("QCMATRIX {row_name}")
+            }
+        };
+        write_quadratic_section(
+            out,
+            &header,
+            terms,
+            &variable_names,
+            options.quadratic_format,
+            false,
+        )?;
+    }
+
     writeln!(out, "ENDATA")?;
     Ok(())
 }
@@ -1201,7 +1302,21 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
 ///
 /// Panics if the MPS writer internal buffer does not produce valid UTF-8 data.
 pub fn to_mps_string(model: &Model) -> Result<String, IoError> {
+    to_mps_string_with(model, &MpsWriteOptions::default())
+}
+
+/// Convenience: render the MPS into a `String` with explicit export options.
+///
+/// # Errors
+///
+/// Returns [`IoError`] if the model contains unsupported expressions or writing
+/// the output fails.
+///
+/// # Panics
+///
+/// Panics if the MPS writer produces non-UTF-8 output.
+pub fn to_mps_string_with(model: &Model, options: &MpsWriteOptions) -> Result<String, IoError> {
     let mut buf = Vec::new();
-    write_mps(model, &mut buf)?;
+    write_mps_with(model, &mut buf, options)?;
     Ok(String::from_utf8(buf).expect("MPS writer emits ASCII"))
 }

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -89,6 +89,12 @@ struct ParsedColumn {
     marker_placement: MarkerPlacement,
 }
 
+#[derive(Default)]
+struct QuadraticTriangle {
+    upper: Option<f64>,
+    lower: Option<f64>,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum MarkerPlacement {
     #[default]
@@ -178,6 +184,7 @@ struct ParsedMps {
     column_index: FxHashMap<String, usize>,
     objective_linear: Vec<f64>,
     objective_quadratic: FxHashMap<(usize, usize), f64>,
+    quadratic_triangles: FxHashMap<(Option<usize>, usize, usize), QuadraticTriangle>,
     objective_constant: f64,
     intorg: bool,
     rhs_vector: Option<String>,
@@ -205,6 +212,7 @@ impl ParsedMps {
             column_index: FxHashMap::default(),
             objective_linear: Vec::new(),
             objective_quadratic: FxHashMap::default(),
+            quadratic_triangles: FxHashMap::default(),
             objective_constant: 0.0,
             intorg: false,
             rhs_vector: None,
@@ -660,9 +668,6 @@ fn parse_quadratic_record(
     let right = data.column_index.get(items[1].text).copied().ok_or_else(|| {
         invalid_mps(line, items[1].column, format!("unknown column {:?}", items[1].text))
     })?;
-    if matches!(section, Section::QMatrix | Section::QcMatrix(_)) && left > right {
-        return Ok(());
-    }
     let pair = if left <= right { (left, right) } else { (right, left) };
     let value = parse_number(&items[2], line)?;
     let objective = match section {
@@ -671,17 +676,54 @@ fn parse_quadratic_record(
         Section::QcMatrix(_) => false,
         _ => unreachable!("quadratic parser called outside quadratic section"),
     };
+    let row = if objective {
+        None
+    } else {
+        let (Section::QcMatrix(row_name) | Section::QSec(row_name)) = section else {
+            unreachable!()
+        };
+        Some(data.row_index.get(row_name).copied().ok_or_else(|| {
+            invalid_mps(line, 1, format!("quadratic section names unknown row {row_name:?}"))
+        })?)
+    };
     let coefficient =
         quadratic_coefficient(options.quadratic_format, left == right, objective, value);
+    let mut store_coefficient = true;
+    if matches!(section, Section::QMatrix | Section::QcMatrix(_)) && left != right {
+        let triangle = data.quadratic_triangles.entry((row, pair.0, pair.1)).or_default();
+        let first_record = triangle.upper.is_none() && triangle.lower.is_none();
+        let side = if left < right { &mut triangle.upper } else { &mut triangle.lower };
+        let same_side = side.is_some();
+        *side = Some(side.take().unwrap_or(0.0) + coefficient);
+        store_coefficient = first_record || same_side;
+    }
+    if !store_coefficient {
+        return Ok(());
+    }
     if objective {
         *data.objective_quadratic.entry(pair).or_insert(0.0) += coefficient;
         return Ok(());
     }
-    let (Section::QcMatrix(row_name) | Section::QSec(row_name)) = section else { unreachable!() };
-    let row = data.row_index.get(row_name).copied().ok_or_else(|| {
-        invalid_mps(line, 1, format!("quadratic section names unknown row {row_name:?}"))
-    })?;
-    *data.rows[row].quadratic.entry(pair).or_insert(0.0) += coefficient;
+    *data.rows[row.expect("quadratic constraint row")].quadratic.entry(pair).or_insert(0.0) +=
+        coefficient;
+    Ok(())
+}
+
+fn validate_quadratic_triangles(data: &ParsedMps, line: usize) -> Result<(), IoError> {
+    for ((_, left, right), triangle) in &data.quadratic_triangles {
+        if let (Some(upper), Some(lower)) = (triangle.upper, triangle.lower)
+            && upper != lower
+        {
+            return Err(invalid_mps(
+                line,
+                1,
+                format!(
+                    "asymmetric quadratic matrix entries for columns {:?} and {:?}",
+                    data.columns[*left].name, data.columns[*right].name
+                ),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -867,6 +909,7 @@ fn parse_mps<R: BufRead>(
     if data.seen_sections & SEEN_END == 0 {
         return Err(invalid_mps(last_line, 1, "missing ENDATA"));
     }
+    validate_quadratic_triangles(&data, last_line)?;
     build_mps_model(data)
 }
 

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -605,6 +605,20 @@ fn quadratic_coefficient(
     }
 }
 
+fn qsection_targets_objective(data: &ParsedMps, name: &str, line: usize) -> Result<bool, IoError> {
+    if name == "OBJ" {
+        if data.objective_row.as_deref() != Some("OBJ") && data.row_index.contains_key("OBJ") {
+            return Err(invalid_mps(
+                line,
+                1,
+                "QSECTION OBJ is ambiguous because OBJ is also a constraint row",
+            ));
+        }
+        return Ok(true);
+    }
+    Ok(data.objective_row.as_deref() == Some(name))
+}
+
 fn parse_quadratic_record(
     data: &mut ParsedMps,
     section: &Section,
@@ -628,7 +642,7 @@ fn parse_quadratic_record(
     let value = parse_number(&items[2], line)?;
     let objective = match section {
         Section::QuadObj | Section::QMatrix => true,
-        Section::QSec(name) => data.objective_row.as_deref() == Some(name.as_str()),
+        Section::QSec(name) => qsection_targets_objective(data, name, line)?,
         Section::QcMatrix(_) => false,
         _ => unreachable!("quadratic parser called outside quadratic section"),
     };
@@ -654,7 +668,7 @@ fn begin_quadratic_section(
     let source = section.name();
     let objective = match section {
         Section::QuadObj | Section::QMatrix => true,
-        Section::QSec(name) => data.objective_row.as_deref() == Some(name.as_str()),
+        Section::QSec(name) => qsection_targets_objective(data, name, line)?,
         Section::QcMatrix(_) => false,
         _ => return Ok(()),
     };

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -562,7 +562,12 @@ fn parse_bound(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result
             column.upper = value;
             column.lower_explicit = true;
         }
-        ("UP", Some(value)) => column.upper = value,
+        ("UP", Some(value)) => {
+            if value < 0.0 && !column.lower_explicit {
+                column.lower = f64::NEG_INFINITY;
+            }
+            column.upper = value;
+        }
         ("LO", Some(value)) => {
             column.lower = value;
             column.lower_explicit = true;

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -526,15 +526,24 @@ fn parse_ranges(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Resul
 }
 
 fn parse_bound(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
-    if items.len() != 3 && items.len() != 4 {
-        return Err(invalid_mps(line, 1, "BOUNDS records require three or four fields"));
+    if !(2..=4).contains(&items.len()) {
+        return Err(invalid_mps(line, 1, "BOUNDS records require two to four fields"));
     }
-    select_vector(&mut data.bounds_vector, Some(&items[1]), "BOUNDS")?;
-    let column_index = data.column_index.get(items[2].text).copied().ok_or_else(|| {
-        invalid_mps(line, items[2].column, format!("unknown column {:?}", items[2].text))
-    })?;
     let bound_type = items[0].text.to_ascii_uppercase();
-    let value = items.get(3).map(|field| parse_number(field, line)).transpose()?;
+    let requires_value =
+        matches!(bound_type.as_str(), "FX" | "UP" | "LO" | "LI" | "UI" | "SC" | "SI");
+    let (vector, column_field, value_field) = match (items.len(), requires_value) {
+        (2, _) => (None, &items[1], None),
+        (3, true) => (None, &items[1], Some(&items[2])),
+        (3, false) => (Some(&items[1]), &items[2], None),
+        (4, _) => (Some(&items[1]), &items[2], Some(&items[3])),
+        _ => unreachable!(),
+    };
+    select_vector(&mut data.bounds_vector, vector, "BOUNDS")?;
+    let column_index = data.column_index.get(column_field.text).copied().ok_or_else(|| {
+        invalid_mps(line, column_field.column, format!("unknown column {:?}", column_field.text))
+    })?;
+    let value = value_field.map(|field| parse_number(field, line)).transpose()?;
     let column = &mut data.columns[column_index];
     if column.default_bounds && column.kind == ColumnKind::Integer {
         column.upper = f64::INFINITY;

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -831,6 +831,32 @@ fn expression<'a>(
     expr
 }
 
+fn unique_mps_names<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+    fallback_prefix: &str,
+    reserved: impl IntoIterator<Item = &'a str>,
+) -> Vec<String> {
+    let mut used: HashSet<String> = reserved.into_iter().map(str::to_owned).collect();
+    names
+        .into_iter()
+        .enumerate()
+        .map(|(index, name)| {
+            let base: String =
+                name.chars().map(|ch| if ch.is_whitespace() { '_' } else { ch }).collect();
+            let base =
+                if base.is_empty() { format!("{fallback_prefix}{}", index + 1) } else { base };
+            let mut candidate = base.clone();
+            let mut suffix = 1;
+            while used.contains(&candidate) {
+                candidate = format!("{base}_{suffix}");
+                suffix += 1;
+            }
+            used.insert(candidate.clone());
+            candidate
+        })
+        .collect()
+}
+
 fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
     for column in &data.columns {
         if column.lower > column.upper {
@@ -941,7 +967,9 @@ pub fn read_mps_file_with(
 /// MPS only represents linear LP / MILP. Nonlinear expressions in the
 /// objective or constraints raise [`IoError::Nonlinear`], second-order cone
 /// constraints [`IoError::Conic`]. The objective row is named `OBJ`.
-/// Constraint rows take their oximo names.
+/// Variable and constraint names have whitespace replaced by underscores and
+/// are made unique within their respective MPS namespaces. The generated
+/// objective row reserves the name `OBJ`.
 ///
 /// # Errors
 ///
@@ -959,6 +987,8 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     let model_constraints = model.constraints();
     let constraints = model_constraints.algebraic();
     let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
+    let variable_names = unique_mps_names(vars.iter().map(|v| v.name.as_str()), "C", []);
+    let row_names = unique_mps_names(constraints.iter().map(|c| c.name.as_str()), "R", ["OBJ"]);
 
     let obj_terms = extract_linear(&arena, objective.expr).ok_or_else(|| IoError::Nonlinear {
         location: "the objective".into(),
@@ -983,9 +1013,9 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     for (v, c) in &obj_terms.coeffs {
         col_index.entry(*v).or_default().push(("OBJ", *c));
     }
-    for (constr, terms) in constraints.iter().zip(con_terms.iter()) {
+    for (row_name, terms) in row_names.iter().zip(con_terms.iter()) {
         for (v, coef) in &terms.coeffs {
-            col_index.entry(*v).or_default().push((constr.name.as_str(), *coef));
+            col_index.entry(*v).or_default().push((row_name.as_str(), *coef));
         }
     }
 
@@ -1011,7 +1041,7 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
 
     writeln!(out, "ROWS")?;
     writeln!(out, " N  OBJ")?;
-    for c in constraints {
+    for (c, row_name) in constraints.iter().zip(row_names.iter()) {
         let tag = match c.as_single() {
             Some((Sense::Le, _)) => 'L',
             Some((Sense::Ge, _)) => 'G',
@@ -1022,12 +1052,12 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
             // `N` row (no RHS) rather than an `L` row with a `+inf` bound.
             None => 'N',
         };
-        writeln!(out, " {tag}  {}", c.name)?;
+        writeln!(out, " {tag}  {row_name}")?;
     }
 
     writeln!(out, "COLUMNS")?;
     let mut int_open = false;
-    for v in vars.iter() {
+    for (v, column_name) in vars.iter().zip(variable_names.iter()) {
         // Binary and semi-integer columns carry their integrality via bounds.
         let needs_marker = matches!(v.domain, Domain::Integer);
         if needs_marker && !int_open {
@@ -1039,10 +1069,10 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         }
         if let Some(entries) = col_index.get(&v.id) {
             for (row_name, coef) in entries {
-                writeln!(out, "    {:<10}{:<10}{}", v.name, row_name, coef)?;
+                writeln!(out, "    {column_name:<10} {row_name:<10} {coef}")?;
             }
         } else {
-            writeln!(out, "    {:<10}{:<10}0", v.name, "OBJ")?;
+            writeln!(out, "    {column_name:<10} {:<10} 0", "OBJ")?;
         }
     }
     if int_open {
@@ -1054,7 +1084,7 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     if obj_constant != 0.0 {
         writeln!(out, "    RHS       OBJ       {}", -obj_constant)?;
     }
-    for (c, t) in constraints.iter().zip(con_terms.iter()) {
+    for ((c, row_name), t) in constraints.iter().zip(row_names.iter()).zip(con_terms.iter()) {
         // A range row's RHS is its upper bound (it is an `L` row), the `RANGES`
         // section then widens it down to the lower bound.
         let rhs = match c.as_single() {
@@ -1065,63 +1095,63 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         };
         let adjusted = rhs - t.constant;
         if adjusted != 0.0 {
-            writeln!(out, "    RHS       {:<10}{}", c.name, adjusted)?;
+            writeln!(out, "    RHS       {row_name:<10} {adjusted}")?;
         }
     }
 
     if constraints.iter().any(Constraint::is_range) {
         writeln!(out, "RANGES")?;
-        for c in constraints {
+        for (c, row_name) in constraints.iter().zip(row_names.iter()) {
             if c.is_range() {
-                writeln!(out, "    RNG       {:<10}{}", c.name, c.upper - c.lower)?;
+                writeln!(out, "    RNG       {row_name:<10} {}", c.upper - c.lower)?;
             }
         }
     }
 
     writeln!(out, "BOUNDS")?;
-    for v in vars.iter() {
+    for (v, column_name) in vars.iter().zip(variable_names.iter()) {
         let lb = v.lb;
         let ub = v.ub;
         if matches!(v.domain, Domain::Binary) {
-            writeln!(out, " BV BND       {}", v.name)?;
+            writeln!(out, " BV BND       {column_name}")?;
             if lb != 0.0 {
-                writeln!(out, " LO BND       {:<10}{}", v.name, lb)?;
+                writeln!(out, " LO BND       {column_name:<10} {lb}")?;
             }
             if (ub - 1.0).abs() >= f64::EPSILON {
-                writeln!(out, " UP BND       {:<10}{}", v.name, ub)?;
+                writeln!(out, " UP BND       {column_name:<10} {ub}")?;
             }
             continue;
         }
         if let Some(thr) = v.domain.semi_threshold() {
-            writeln!(out, " LO BND       {:<10}{}", v.name, thr)?;
+            writeln!(out, " LO BND       {column_name:<10} {thr}")?;
             let semi_ub = if ub.is_finite() { ub } else { 1e30 };
             // `is_integer()` distinguishes the two semi domains here.
             let code = if v.domain.is_integer() { "SI" } else { "SC" };
-            writeln!(out, " {code} BND       {:<10}{}", v.name, semi_ub)?;
+            writeln!(out, " {code} BND       {column_name:<10} {semi_ub}")?;
             continue;
         }
         if lb.is_finite() && (lb - ub).abs() < f64::EPSILON {
-            writeln!(out, " FX BND       {:<10}{lb}", v.name)?;
+            writeln!(out, " FX BND       {column_name:<10} {lb}")?;
             continue;
         }
         let infinite_lo = lb == f64::NEG_INFINITY;
         let infinite_hi = ub == f64::INFINITY;
         match (infinite_lo, infinite_hi) {
-            (true, true) => writeln!(out, " FR BND       {}", v.name)?,
+            (true, true) => writeln!(out, " FR BND       {column_name}")?,
             (true, false) => {
-                writeln!(out, " MI BND       {}", v.name)?;
-                writeln!(out, " UP BND       {:<10}{}", v.name, ub)?;
+                writeln!(out, " MI BND       {column_name}")?;
+                writeln!(out, " UP BND       {column_name:<10} {ub}")?;
             }
             (false, true) => {
                 if lb != 0.0 {
-                    writeln!(out, " LO BND       {:<10}{}", v.name, lb)?;
+                    writeln!(out, " LO BND       {column_name:<10} {lb}")?;
                 }
             }
             (false, false) => {
                 if lb != 0.0 {
-                    writeln!(out, " LO BND       {:<10}{}", v.name, lb)?;
+                    writeln!(out, " LO BND       {column_name:<10} {lb}")?;
                 }
-                writeln!(out, " UP BND       {:<10}{}", v.name, ub)?;
+                writeln!(out, " UP BND       {column_name:<10} {ub}")?;
             }
         }
     }

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -950,8 +950,16 @@ fn unique_mps_names<'a>(
         .into_iter()
         .enumerate()
         .map(|(index, name)| {
-            let base: String =
-                name.chars().map(|ch| if ch.is_whitespace() { '_' } else { ch }).collect();
+            let base: String = name
+                .chars()
+                .map(|ch| {
+                    if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '-') {
+                        ch
+                    } else {
+                        '_'
+                    }
+                })
+                .collect();
             let base =
                 if base.is_empty() { format!("{fallback_prefix}{}", index + 1) } else { base };
             let mut candidate = base.clone();

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -932,10 +932,11 @@ fn expression<'a>(
             expr = expr + coefficient * variables[column];
         }
     }
+    let mut quadratic: Vec<_> =
+        quadratic.into_iter().filter(|(_, coefficient)| *coefficient != 0.0).collect();
+    quadratic.sort_unstable_by_key(|((left, right), _)| (*left, *right));
     for ((left, right), coefficient) in quadratic {
-        if coefficient != 0.0 {
-            expr = expr + coefficient * variables[left] * variables[right];
-        }
+        expr = expr + coefficient * variables[left] * variables[right];
     }
     expr
 }

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -1030,10 +1030,14 @@ fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
             ColumnKind::SemiContinuous => Domain::SemiContinuous { threshold: column.lower },
             ColumnKind::SemiInteger => Domain::SemiInteger { threshold: column.lower },
         };
+        let model_lower = match column.kind {
+            ColumnKind::SemiContinuous | ColumnKind::SemiInteger => 0.0,
+            _ => column.lower,
+        };
         variables.push(
             model
                 .__var(column.name.clone())
-                .bounds(column.lower, column.upper)
+                .bounds(model_lower, column.upper)
                 .domain(domain)
                 .build(),
         );

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -1,24 +1,940 @@
 //! MPS file format import and export.
 //!
-//! MPS is a widely supported text format for linear optimization problems. It can
-//! represent LP and MILP models, but not nonlinear or conic problems. The format is
-//! somewhat idiosyncratic and has some limitations (e.g. only one objective row
-//! named `OBJ`, no native support for free variables), but is a common lingua franca for
-//! exchanging linear models between tools.
+//! MPS is a widely supported text format for linear and quadratic optimization
+//! problems. It is a common lingua franca for exchanging models between tools.
 //!
-//! This module provides functions to write an oximo [`Model`] to MPS format.
-//! The main function is [`write_mps`], which writes to any `std::io::Write`.
+//! [`read_mps`] and [`read_mps_file`] import whitespace-delimited MPS files.
+//! [`write_mps`] exports the linear subset to any `std::io::Write`.
 //!
 //! References:
 //! - "MPS file format," lp_solve. <https://lpsolve.sourceforge.net/5.5/mps-format.htm> (accessed May 09, 2026).
 
-use std::io::Write;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 
-use oximo_core::{Constraint, Model, ModelKind, ObjectiveSense, Sense, var_name};
-use oximo_expr::{LinearTerms, VarId, describe_nonlinear_term, extract_linear};
+use oximo_core::{Constraint, Domain, Model, ModelKind, ObjectiveSense, Sense, var_name};
+use oximo_expr::{Expr, LinearTerms, VarId, describe_nonlinear_term, extract_linear};
 use rustc_hash::FxHashMap;
 
 use crate::error::IoError;
+
+/// Coefficient convention used by quadratic-constraint MPS sections.
+///
+/// Objective sections always use the conventional `0.5 * x' Q x` scaling.
+/// Gurobi-style `QCMATRIX` and constraint `QSECTION` records instead encode
+/// polynomial coefficients directly, whereas CPLEX-style records use the
+/// objective/Hessian convention.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MpsQuadraticFormat {
+    /// Gurobi-compatible quadratic-constraint scaling.
+    #[default]
+    Gurobi,
+    /// CPLEX-compatible quadratic-constraint scaling.
+    Cplex,
+}
+
+/// Options controlling MPS import.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MpsReadOptions {
+    /// How ambiguous quadratic-constraint matrix coefficients are scaled.
+    pub quadratic_format: MpsQuadraticFormat,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RowKind {
+    Free,
+    Greater,
+    Less,
+    Equal,
+}
+
+struct ParsedRow {
+    name: String,
+    kind: RowKind,
+    lower: f64,
+    upper: f64,
+    linear: FxHashMap<usize, f64>,
+    quadratic: FxHashMap<(usize, usize), f64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ColumnKind {
+    Continuous,
+    Integer,
+    Binary,
+    SemiContinuous,
+    SemiInteger,
+}
+
+struct ParsedColumn {
+    name: String,
+    lower: f64,
+    upper: f64,
+    kind: ColumnKind,
+    default_bounds: bool,
+    lower_explicit: bool,
+    marker_placement: MarkerPlacement,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum MarkerPlacement {
+    #[default]
+    Unseen,
+    Outside,
+    Inside,
+    Mixed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+enum SectionRank {
+    Name,
+    ObjSense,
+    Rows,
+    Columns,
+    Rhs,
+    Ranges,
+    Bounds,
+    Quadratic,
+    End,
+}
+
+#[derive(Clone, Debug)]
+enum Section {
+    Name,
+    ObjSense,
+    Rows,
+    Columns,
+    Rhs,
+    Ranges,
+    Bounds,
+    QuadObj,
+    QMatrix,
+    QcMatrix(String),
+    QSec(String),
+    End,
+}
+
+impl Section {
+    fn rank(&self) -> SectionRank {
+        match self {
+            Self::Name => SectionRank::Name,
+            Self::ObjSense => SectionRank::ObjSense,
+            Self::Rows => SectionRank::Rows,
+            Self::Columns => SectionRank::Columns,
+            Self::Rhs => SectionRank::Rhs,
+            Self::Ranges => SectionRank::Ranges,
+            Self::Bounds => SectionRank::Bounds,
+            Self::QuadObj | Self::QMatrix | Self::QcMatrix(_) | Self::QSec(_) => {
+                SectionRank::Quadratic
+            }
+            Self::End => SectionRank::End,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Name => "NAME",
+            Self::ObjSense => "OBJSENSE",
+            Self::Rows => "ROWS",
+            Self::Columns => "COLUMNS",
+            Self::Rhs => "RHS",
+            Self::Ranges => "RANGES",
+            Self::Bounds => "BOUNDS",
+            Self::QuadObj => "QUADOBJ",
+            Self::QMatrix => "QMATRIX",
+            Self::QcMatrix(_) => "QCMATRIX",
+            Self::QSec(_) => "QSECTION",
+            Self::End => "ENDATA",
+        }
+    }
+}
+
+struct Field<'a> {
+    text: &'a str,
+    column: usize,
+}
+
+struct ParsedMps {
+    name: String,
+    objective_row: Option<String>,
+    sense: Option<ObjectiveSense>,
+    legacy_sense: Option<ObjectiveSense>,
+    rows: Vec<ParsedRow>,
+    row_index: FxHashMap<String, usize>,
+    columns: Vec<ParsedColumn>,
+    column_index: FxHashMap<String, usize>,
+    objective_linear: Vec<f64>,
+    objective_quadratic: FxHashMap<(usize, usize), f64>,
+    objective_constant: f64,
+    intorg: bool,
+    rhs_vector: Option<String>,
+    range_vector: Option<String>,
+    bounds_vector: Option<String>,
+    objective_quadratic_source: Option<&'static str>,
+    quadratic_rows: HashSet<String>,
+    seen_sections: u8,
+}
+
+const SEEN_ROWS: u8 = 1;
+const SEEN_COLUMNS: u8 = 2;
+const SEEN_END: u8 = 4;
+
+impl ParsedMps {
+    fn new(fallback_name: &str) -> Self {
+        Self {
+            name: fallback_name.to_owned(),
+            objective_row: None,
+            sense: None,
+            legacy_sense: None,
+            rows: Vec::new(),
+            row_index: FxHashMap::default(),
+            columns: Vec::new(),
+            column_index: FxHashMap::default(),
+            objective_linear: Vec::new(),
+            objective_quadratic: FxHashMap::default(),
+            objective_constant: 0.0,
+            intorg: false,
+            rhs_vector: None,
+            range_vector: None,
+            bounds_vector: None,
+            objective_quadratic_source: None,
+            quadratic_rows: HashSet::new(),
+            seen_sections: 0,
+        }
+    }
+
+    fn add_column(&mut self, name: &str, inside_marker: bool) -> usize {
+        let index = if let Some(index) = self.column_index.get(name) {
+            *index
+        } else {
+            let index = self.columns.len();
+            self.columns.push(ParsedColumn {
+                name: name.to_owned(),
+                lower: 0.0,
+                upper: f64::INFINITY,
+                kind: ColumnKind::Continuous,
+                default_bounds: true,
+                lower_explicit: false,
+                marker_placement: MarkerPlacement::Unseen,
+            });
+            self.column_index.insert(name.to_owned(), index);
+            self.objective_linear.push(0.0);
+            index
+        };
+        let column = &mut self.columns[index];
+        if inside_marker {
+            column.marker_placement = match column.marker_placement {
+                MarkerPlacement::Unseen | MarkerPlacement::Inside => MarkerPlacement::Inside,
+                MarkerPlacement::Outside | MarkerPlacement::Mixed => MarkerPlacement::Mixed,
+            };
+            column.kind = ColumnKind::Integer;
+            if column.default_bounds {
+                column.upper = 1.0;
+            }
+        } else {
+            column.marker_placement = match column.marker_placement {
+                MarkerPlacement::Unseen | MarkerPlacement::Outside => MarkerPlacement::Outside,
+                MarkerPlacement::Inside | MarkerPlacement::Mixed => MarkerPlacement::Mixed,
+            };
+        }
+        index
+    }
+}
+
+fn invalid_mps(line: usize, column: usize, message: impl Into<String>) -> IoError {
+    IoError::InvalidMps { line, column, message: message.into() }
+}
+
+fn fields(line: &str) -> Vec<Field<'_>> {
+    let mut out = Vec::new();
+    let mut start = None;
+    for (offset, ch) in line.char_indices() {
+        if ch.is_whitespace() {
+            if let Some(begin) = start.take() {
+                out.push(Field { text: &line[begin..offset], column: begin + 1 });
+            }
+        } else if start.is_none() {
+            start = Some(offset);
+        }
+    }
+    if let Some(begin) = start {
+        out.push(Field { text: &line[begin..], column: begin + 1 });
+    }
+    out
+}
+
+fn parse_number(field: &Field<'_>, line: usize) -> Result<f64, IoError> {
+    let normalized;
+    let text = if field.text.contains(['d', 'D']) {
+        normalized = field.text.replace(['d', 'D'], "E");
+        normalized.as_str()
+    } else {
+        field.text
+    };
+    let value = text
+        .parse::<f64>()
+        .map_err(|_| invalid_mps(line, field.column, format!("invalid number {:?}", field.text)))?;
+    if !value.is_finite() {
+        return Err(invalid_mps(line, field.column, "numeric fields must be finite"));
+    }
+    Ok(value)
+}
+
+fn objective_sense(field: &Field<'_>, line: usize) -> Result<ObjectiveSense, IoError> {
+    match field.text.to_ascii_uppercase().as_str() {
+        "MIN" | "MINIMIZE" => Ok(ObjectiveSense::Minimize),
+        "MAX" | "MAXIMIZE" => Ok(ObjectiveSense::Maximize),
+        _ => Err(invalid_mps(line, field.column, "objective sense must be MIN or MAX")),
+    }
+}
+
+fn parse_legacy_sense(line: &str) -> Option<ObjectiveSense> {
+    let comment = line.trim_start_matches('*').trim();
+    let value = comment.strip_prefix("sense:").or_else(|| comment.strip_prefix("SENSE:"))?;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "minimize" | "min" => Some(ObjectiveSense::Minimize),
+        "maximize" | "max" => Some(ObjectiveSense::Maximize),
+        _ => None,
+    }
+}
+
+fn header(items: &[Field<'_>], current: &Section) -> Option<Section> {
+    let first = items.first()?.text.to_ascii_uppercase();
+    match (first.as_str(), items.len()) {
+        ("NAME", _) if matches!(current, Section::Name) => Some(Section::Name),
+        ("OBJSENSE", 1 | 2) => Some(Section::ObjSense),
+        ("ROWS", 1) => Some(Section::Rows),
+        ("COLUMNS", 1) => Some(Section::Columns),
+        ("RHS", 1) => Some(Section::Rhs),
+        ("RANGES", 1) => Some(Section::Ranges),
+        ("BOUNDS", 1) => Some(Section::Bounds),
+        ("QUADOBJ", 1) => Some(Section::QuadObj),
+        ("QMATRIX", 1) => Some(Section::QMatrix),
+        ("QCMATRIX", 2) => Some(Section::QcMatrix(items[1].text.to_owned())),
+        ("QSECTION", 2) => Some(Section::QSec(items[1].text.to_owned())),
+        ("ENDATA", 1) => Some(Section::End),
+        _ => None,
+    }
+}
+
+fn select_vector(
+    selected: &mut Option<String>,
+    candidate: Option<&Field<'_>>,
+    section: &str,
+) -> Result<(), IoError> {
+    let Some(candidate) = candidate else { return Ok(()) };
+    if let Some(existing) = selected {
+        if existing != candidate.text {
+            return Err(IoError::UnsupportedMps {
+                section: section.into(),
+                feature: format!(
+                    "multiple data vectors ({existing:?} and {:?}) are not supported",
+                    candidate.text
+                ),
+            });
+        }
+    } else {
+        *selected = Some(candidate.text.to_owned());
+    }
+    Ok(())
+}
+
+fn parse_row(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
+    if items.len() < 2 {
+        return Err(invalid_mps(line, 1, "ROWS records require a sense and row name"));
+    }
+    let name = items[1].text;
+    if data.objective_row.as_deref() == Some(name) || data.row_index.contains_key(name) {
+        return Err(invalid_mps(line, items[1].column, format!("duplicate row name {name:?}")));
+    }
+    let kind = match items[0].text.to_ascii_uppercase().as_str() {
+        "N" => RowKind::Free,
+        "G" => RowKind::Greater,
+        "L" => RowKind::Less,
+        "E" => RowKind::Equal,
+        _ => {
+            return Err(invalid_mps(line, items[0].column, "row sense must be N, G, L, or E"));
+        }
+    };
+    if kind == RowKind::Free && data.objective_row.is_none() {
+        data.objective_row = Some(name.to_owned());
+        return Ok(());
+    }
+    let (lower, upper) = match kind {
+        RowKind::Free => (f64::NEG_INFINITY, f64::INFINITY),
+        RowKind::Greater => (0.0, f64::INFINITY),
+        RowKind::Less => (f64::NEG_INFINITY, 0.0),
+        RowKind::Equal => (0.0, 0.0),
+    };
+    let index = data.rows.len();
+    data.rows.push(ParsedRow {
+        name: name.to_owned(),
+        kind,
+        lower,
+        upper,
+        linear: FxHashMap::default(),
+        quadratic: FxHashMap::default(),
+    });
+    data.row_index.insert(name.to_owned(), index);
+    Ok(())
+}
+
+fn parse_coefficient(
+    data: &mut ParsedMps,
+    column: usize,
+    row: &Field<'_>,
+    value: &Field<'_>,
+    line: usize,
+) -> Result<(), IoError> {
+    let value = parse_number(value, line)?;
+    if data.objective_row.as_deref() == Some(row.text) {
+        data.objective_linear[column] += value;
+        return Ok(());
+    }
+    let row_index = data.row_index.get(row.text).copied().ok_or_else(|| {
+        invalid_mps(line, row.column, format!("unknown ROWS name {:?}", row.text))
+    })?;
+    *data.rows[row_index].linear.entry(column).or_insert(0.0) += value;
+    Ok(())
+}
+
+fn unquote_marker(value: &str) -> String {
+    value.trim_matches(|c| c == '\'' || c == '"').to_ascii_uppercase()
+}
+
+fn parse_columns(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
+    if items.len() == 3 && unquote_marker(items[1].text) == "MARKER" {
+        match unquote_marker(items[2].text).as_str() {
+            "INTORG" if !data.intorg => data.intorg = true,
+            "INTEND" if data.intorg => data.intorg = false,
+            "INTORG" => return Err(invalid_mps(line, items[2].column, "nested INTORG marker")),
+            "INTEND" => {
+                return Err(invalid_mps(line, items[2].column, "INTEND without INTORG"));
+            }
+            _ => return Err(invalid_mps(line, items[2].column, "unknown MARKER value")),
+        }
+        return Ok(());
+    }
+    if items.len() != 3 && items.len() != 5 {
+        return Err(invalid_mps(line, 1, "COLUMNS records require three or five fields"));
+    }
+    let column = data.add_column(items[0].text, data.intorg);
+    let column_data = &data.columns[column];
+    if column_data.marker_placement == MarkerPlacement::Mixed {
+        return Err(invalid_mps(
+            line,
+            items[0].column,
+            format!("integer column {:?} also appears outside INTORG/INTEND", items[0].text),
+        ));
+    }
+    parse_coefficient(data, column, &items[1], &items[2], line)?;
+    if items.len() == 5 {
+        parse_coefficient(data, column, &items[3], &items[4], line)?;
+    }
+    Ok(())
+}
+
+fn parse_rhs_value(
+    data: &mut ParsedMps,
+    row: &Field<'_>,
+    value: &Field<'_>,
+    line: usize,
+) -> Result<(), IoError> {
+    let value = parse_number(value, line)?;
+    if data.objective_row.as_deref() == Some(row.text) {
+        data.objective_constant = -value;
+        return Ok(());
+    }
+    let index = data.row_index.get(row.text).copied().ok_or_else(|| {
+        invalid_mps(line, row.column, format!("unknown ROWS name {:?}", row.text))
+    })?;
+    let parsed_row = &mut data.rows[index];
+    match parsed_row.kind {
+        RowKind::Greater => parsed_row.lower = value,
+        RowKind::Less => parsed_row.upper = value,
+        RowKind::Equal => {
+            parsed_row.lower = value;
+            parsed_row.upper = value;
+        }
+        RowKind::Free => {
+            return Err(invalid_mps(line, row.column, "a free N row cannot have an RHS"));
+        }
+    }
+    Ok(())
+}
+
+fn parse_rhs(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
+    let (vector, pairs): (Option<&Field<'_>>, &[Field<'_>]) = match items.len() {
+        2 | 4 => (None, items),
+        3 | 5 => (Some(&items[0]), &items[1..]),
+        _ => return Err(invalid_mps(line, 1, "RHS records require two to five fields")),
+    };
+    select_vector(&mut data.rhs_vector, vector, "RHS")?;
+    for pair in pairs.chunks_exact(2) {
+        parse_rhs_value(data, &pair[0], &pair[1], line)?;
+    }
+    Ok(())
+}
+
+fn parse_range_value(
+    data: &mut ParsedMps,
+    row: &Field<'_>,
+    value: &Field<'_>,
+    line: usize,
+) -> Result<(), IoError> {
+    let value = parse_number(value, line)?;
+    let index = data.row_index.get(row.text).copied().ok_or_else(|| {
+        invalid_mps(line, row.column, format!("unknown ROWS name {:?}", row.text))
+    })?;
+    let parsed_row = &mut data.rows[index];
+    match parsed_row.kind {
+        RowKind::Greater => parsed_row.upper = parsed_row.lower + value.abs(),
+        RowKind::Less => parsed_row.lower = parsed_row.upper - value.abs(),
+        RowKind::Equal if value >= 0.0 => parsed_row.upper = parsed_row.lower + value,
+        RowKind::Equal => parsed_row.lower = parsed_row.upper + value,
+        RowKind::Free => {
+            return Err(invalid_mps(line, row.column, "a free N row cannot have a range"));
+        }
+    }
+    Ok(())
+}
+
+fn parse_ranges(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
+    let (vector, pairs): (Option<&Field<'_>>, &[Field<'_>]) = match items.len() {
+        2 | 4 => (None, items),
+        3 | 5 => (Some(&items[0]), &items[1..]),
+        _ => return Err(invalid_mps(line, 1, "RANGES records require two to five fields")),
+    };
+    select_vector(&mut data.range_vector, vector, "RANGES")?;
+    for pair in pairs.chunks_exact(2) {
+        parse_range_value(data, &pair[0], &pair[1], line)?;
+    }
+    Ok(())
+}
+
+fn parse_bound(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
+    if items.len() != 3 && items.len() != 4 {
+        return Err(invalid_mps(line, 1, "BOUNDS records require three or four fields"));
+    }
+    select_vector(&mut data.bounds_vector, Some(&items[1]), "BOUNDS")?;
+    let column_index = data.column_index.get(items[2].text).copied().ok_or_else(|| {
+        invalid_mps(line, items[2].column, format!("unknown column {:?}", items[2].text))
+    })?;
+    let bound_type = items[0].text.to_ascii_uppercase();
+    let value = items.get(3).map(|field| parse_number(field, line)).transpose()?;
+    let column = &mut data.columns[column_index];
+    if column.default_bounds && column.kind == ColumnKind::Integer {
+        column.upper = f64::INFINITY;
+    }
+    column.default_bounds = false;
+    match (bound_type.as_str(), value) {
+        ("PL", None) => column.upper = f64::INFINITY,
+        ("MI", None) => {
+            column.lower = f64::NEG_INFINITY;
+            column.lower_explicit = true;
+        }
+        ("FR", None | Some(_)) => {
+            column.lower = f64::NEG_INFINITY;
+            column.upper = f64::INFINITY;
+            column.lower_explicit = true;
+        }
+        ("BV", None | Some(_)) => {
+            column.lower = 0.0;
+            column.upper = 1.0;
+            column.kind = ColumnKind::Binary;
+            column.lower_explicit = true;
+        }
+        ("FX", Some(value)) => {
+            column.lower = value;
+            column.upper = value;
+            column.lower_explicit = true;
+        }
+        ("UP", Some(value)) => column.upper = value,
+        ("LO", Some(value)) => {
+            column.lower = value;
+            column.lower_explicit = true;
+        }
+        ("LI", Some(value)) => {
+            column.lower = value;
+            column.kind = ColumnKind::Integer;
+            column.lower_explicit = true;
+        }
+        ("UI", Some(value)) => {
+            column.upper = value;
+            column.kind = ColumnKind::Integer;
+        }
+        ("SC", Some(value)) => {
+            if !column.lower_explicit {
+                column.lower = 1.0;
+            }
+            column.upper = value;
+            column.kind = ColumnKind::SemiContinuous;
+        }
+        ("SI", Some(value)) => {
+            if !column.lower_explicit {
+                column.lower = 1.0;
+            }
+            column.upper = value;
+            column.kind = ColumnKind::SemiInteger;
+        }
+        _ => {
+            return Err(invalid_mps(
+                line,
+                items[0].column,
+                format!("invalid {bound_type} bound record"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn quadratic_coefficient(
+    format: MpsQuadraticFormat,
+    diagonal: bool,
+    objective: bool,
+    value: f64,
+) -> f64 {
+    if objective || format == MpsQuadraticFormat::Cplex {
+        if diagonal { value / 2.0 } else { value }
+    } else if diagonal {
+        value
+    } else {
+        2.0 * value
+    }
+}
+
+fn parse_quadratic_record(
+    data: &mut ParsedMps,
+    section: &Section,
+    items: &[Field<'_>],
+    line: usize,
+    options: MpsReadOptions,
+) -> Result<(), IoError> {
+    if items.len() != 3 {
+        return Err(invalid_mps(line, 1, "quadratic records require three fields"));
+    }
+    let left = data.column_index.get(items[0].text).copied().ok_or_else(|| {
+        invalid_mps(line, items[0].column, format!("unknown column {:?}", items[0].text))
+    })?;
+    let right = data.column_index.get(items[1].text).copied().ok_or_else(|| {
+        invalid_mps(line, items[1].column, format!("unknown column {:?}", items[1].text))
+    })?;
+    if matches!(section, Section::QMatrix | Section::QcMatrix(_)) && left > right {
+        return Ok(());
+    }
+    let pair = if left <= right { (left, right) } else { (right, left) };
+    let value = parse_number(&items[2], line)?;
+    let objective = match section {
+        Section::QuadObj | Section::QMatrix => true,
+        Section::QSec(name) => data.objective_row.as_deref() == Some(name.as_str()),
+        Section::QcMatrix(_) => false,
+        _ => unreachable!("quadratic parser called outside quadratic section"),
+    };
+    let coefficient =
+        quadratic_coefficient(options.quadratic_format, left == right, objective, value);
+    if objective {
+        *data.objective_quadratic.entry(pair).or_insert(0.0) += coefficient;
+        return Ok(());
+    }
+    let (Section::QcMatrix(row_name) | Section::QSec(row_name)) = section else { unreachable!() };
+    let row = data.row_index.get(row_name).copied().ok_or_else(|| {
+        invalid_mps(line, 1, format!("quadratic section names unknown row {row_name:?}"))
+    })?;
+    *data.rows[row].quadratic.entry(pair).or_insert(0.0) += coefficient;
+    Ok(())
+}
+
+fn begin_quadratic_section(
+    data: &mut ParsedMps,
+    section: &Section,
+    line: usize,
+) -> Result<(), IoError> {
+    let source = section.name();
+    let objective = match section {
+        Section::QuadObj | Section::QMatrix => true,
+        Section::QSec(name) => data.objective_row.as_deref() == Some(name.as_str()),
+        Section::QcMatrix(_) => false,
+        _ => return Ok(()),
+    };
+    if objective {
+        if let Some(existing) = data.objective_quadratic_source {
+            return Err(invalid_mps(
+                line,
+                1,
+                format!("objective quadratic data already supplied by {existing}"),
+            ));
+        }
+        data.objective_quadratic_source = Some(source);
+        return Ok(());
+    }
+    let (Section::QcMatrix(row_name) | Section::QSec(row_name)) = section else { unreachable!() };
+    if !data.row_index.contains_key(row_name) {
+        return Err(invalid_mps(
+            line,
+            1,
+            format!("quadratic section names unknown row {row_name:?}"),
+        ));
+    }
+    if !data.quadratic_rows.insert(row_name.clone()) {
+        return Err(invalid_mps(
+            line,
+            1,
+            format!("duplicate quadratic section for row {row_name:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn check_section_transition(
+    previous: &Section,
+    next: &Section,
+    line: usize,
+) -> Result<(), IoError> {
+    if next.rank() < previous.rank() {
+        return Err(invalid_mps(
+            line,
+            1,
+            format!("{} section appears after {}", next.name(), previous.name()),
+        ));
+    }
+    if next.rank() == previous.rank()
+        && !matches!(next.rank(), SectionRank::Quadratic)
+        && !matches!((previous, next), (Section::Name, Section::Name))
+    {
+        return Err(invalid_mps(line, 1, format!("duplicate {} section", next.name())));
+    }
+    Ok(())
+}
+
+fn parse_mps(text: &str, fallback_name: &str, options: MpsReadOptions) -> Result<Model, IoError> {
+    let mut data = ParsedMps::new(fallback_name);
+    let mut section = Section::Name;
+    let mut saw_name = false;
+    for (offset, raw_line) in text.lines().enumerate() {
+        let line_no = offset + 1;
+        let line = raw_line.trim_end_matches('\r');
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with('*') {
+            if data.sense.is_none() {
+                data.legacy_sense = parse_legacy_sense(trimmed).or(data.legacy_sense);
+            }
+            continue;
+        }
+        if data.seen_sections & SEEN_END != 0 {
+            return Err(invalid_mps(line_no, 1, "content after ENDATA"));
+        }
+        let items = fields(line);
+        if let Some(first) = items.first() {
+            let keyword = first.text.to_ascii_uppercase();
+            if items.len() == 1 && matches!(keyword.as_str(), "SOS" | "INDICATORS") {
+                return Err(IoError::UnsupportedMps {
+                    section: keyword,
+                    feature: "not represented by oximo-core".into(),
+                });
+            }
+        }
+        if let Some(next) = header(&items, &section) {
+            if matches!(next, Section::Name) {
+                if saw_name {
+                    return Err(invalid_mps(line_no, 1, "duplicate NAME section"));
+                }
+                saw_name = true;
+                if items.len() > 1 {
+                    data.name =
+                        items[1..].iter().map(|field| field.text).collect::<Vec<_>>().join(" ");
+                }
+                continue;
+            }
+            if !saw_name {
+                return Err(invalid_mps(line_no, 1, "the first data line must be NAME"));
+            }
+            check_section_transition(&section, &next, line_no)?;
+            if data.intorg && !matches!(next, Section::Columns) {
+                return Err(invalid_mps(line_no, 1, "missing INTEND marker before COLUMNS ends"));
+            }
+            match &next {
+                Section::ObjSense if items.len() == 2 => {
+                    data.sense = Some(objective_sense(&items[1], line_no)?);
+                }
+                Section::Rows => data.seen_sections |= SEEN_ROWS,
+                Section::Columns => data.seen_sections |= SEEN_COLUMNS,
+                Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
+                    begin_quadratic_section(&mut data, &next, line_no)?;
+                }
+                Section::End => data.seen_sections |= SEEN_END,
+                _ => {}
+            }
+            section = next;
+            continue;
+        }
+        if !saw_name {
+            return Err(invalid_mps(line_no, 1, "the first data line must be NAME"));
+        }
+        match &section {
+            Section::ObjSense => {
+                if items.len() != 1 {
+                    return Err(invalid_mps(line_no, 1, "OBJSENSE data requires one field"));
+                }
+                data.sense = Some(objective_sense(&items[0], line_no)?);
+            }
+            Section::Rows => parse_row(&mut data, &items, line_no)?,
+            Section::Columns => parse_columns(&mut data, &items, line_no)?,
+            Section::Rhs => parse_rhs(&mut data, &items, line_no)?,
+            Section::Ranges => parse_ranges(&mut data, &items, line_no)?,
+            Section::Bounds => parse_bound(&mut data, &items, line_no)?,
+            Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
+                parse_quadratic_record(&mut data, &section, &items, line_no, options)?;
+            }
+            Section::Name => return Err(invalid_mps(line_no, 1, "expected NAME header")),
+            Section::End => unreachable!(),
+        }
+    }
+    let last_line = text.lines().count().max(1);
+    if data.intorg {
+        return Err(invalid_mps(last_line, 1, "missing INTEND marker"));
+    }
+    if data.seen_sections & SEEN_ROWS == 0 {
+        return Err(invalid_mps(last_line, 1, "missing ROWS section"));
+    }
+    if data.seen_sections & SEEN_COLUMNS == 0 {
+        return Err(invalid_mps(last_line, 1, "missing COLUMNS section"));
+    }
+    if data.seen_sections & SEEN_END == 0 {
+        return Err(invalid_mps(last_line, 1, "missing ENDATA"));
+    }
+    build_mps_model(data)
+}
+
+fn expression<'a>(
+    model: &'a Model,
+    variables: &[Expr<'a>],
+    linear: impl IntoIterator<Item = (usize, f64)>,
+    quadratic: impl IntoIterator<Item = ((usize, usize), f64)>,
+    constant: f64,
+) -> Expr<'a> {
+    let mut expr = model.__constant(constant);
+    for (column, coefficient) in linear {
+        if coefficient != 0.0 {
+            expr = expr + coefficient * variables[column];
+        }
+    }
+    for ((left, right), coefficient) in quadratic {
+        if coefficient != 0.0 {
+            expr = expr + coefficient * variables[left] * variables[right];
+        }
+    }
+    expr
+}
+
+fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
+    for column in &data.columns {
+        if column.lower > column.upper {
+            return Err(invalid_mps(
+                1,
+                1,
+                format!("inconsistent bounds for column {:?}", column.name),
+            ));
+        }
+        if matches!(column.kind, ColumnKind::SemiContinuous | ColumnKind::SemiInteger)
+            && (!column.lower.is_finite() || column.lower < 0.0)
+        {
+            return Err(invalid_mps(
+                1,
+                1,
+                format!("invalid semi-domain threshold for column {:?}", column.name),
+            ));
+        }
+    }
+    for row in &data.rows {
+        if row.lower > row.upper {
+            return Err(invalid_mps(1, 1, format!("inconsistent range for row {:?}", row.name)));
+        }
+    }
+    let model = Model::new(data.name);
+    let mut variables = Vec::with_capacity(data.columns.len());
+    for column in &data.columns {
+        let domain = match column.kind {
+            ColumnKind::Continuous => Domain::Real,
+            ColumnKind::Integer => Domain::Integer,
+            ColumnKind::Binary => Domain::Binary,
+            ColumnKind::SemiContinuous => Domain::SemiContinuous { threshold: column.lower },
+            ColumnKind::SemiInteger => Domain::SemiInteger { threshold: column.lower },
+        };
+        variables.push(
+            model
+                .__var(column.name.clone())
+                .bounds(column.lower, column.upper)
+                .domain(domain)
+                .build(),
+        );
+    }
+    for row in data.rows {
+        let expr = expression(&model, &variables, row.linear, row.quadratic, 0.0);
+        model.__add_constraint_interval(row.name, expr, row.lower, row.upper);
+    }
+    let objective = expression(
+        &model,
+        &variables,
+        data.objective_linear.into_iter().enumerate(),
+        data.objective_quadratic,
+        data.objective_constant,
+    );
+    match data.sense.or(data.legacy_sense).unwrap_or(ObjectiveSense::Minimize) {
+        ObjectiveSense::Minimize => model.__minimize(objective),
+        ObjectiveSense::Maximize => model.__maximize(objective),
+    }
+    Ok(model)
+}
+
+/// Read an MPS byte stream with default options.
+///
+/// # Errors
+///
+/// Returns [`IoError`] for I/O failures, malformed syntax, or unsupported sections.
+pub fn read_mps<R: Read>(input: R) -> Result<Model, IoError> {
+    read_mps_with(input, &MpsReadOptions::default())
+}
+
+/// Read an MPS byte stream with explicit import options.
+///
+/// # Errors
+///
+/// Returns [`IoError`] for I/O failures, malformed syntax, or unsupported sections.
+pub fn read_mps_with<R: Read>(mut input: R, options: &MpsReadOptions) -> Result<Model, IoError> {
+    let mut text = String::new();
+    input.read_to_string(&mut text)?;
+    parse_mps(&text, "mps_model", *options)
+}
+
+/// Read an MPS file with default options.
+///
+/// # Errors
+///
+/// Returns [`IoError`] for I/O failures, malformed syntax, or unsupported sections.
+pub fn read_mps_file(path: impl AsRef<Path>) -> Result<Model, IoError> {
+    read_mps_file_with(path, &MpsReadOptions::default())
+}
+
+/// Read an MPS file with explicit import options.
+///
+/// # Errors
+///
+/// Returns [`IoError`] for I/O failures, malformed syntax, or unsupported sections.
+pub fn read_mps_file_with(
+    path: impl AsRef<Path>,
+    options: &MpsReadOptions,
+) -> Result<Model, IoError> {
+    let path = path.as_ref();
+    let mut text = String::new();
+    File::open(path)?.read_to_string(&mut text)?;
+    let fallback = path.file_stem().and_then(|name| name.to_str()).unwrap_or("mps_model");
+    parse_mps(&text, fallback, *options)
+}
 
 /// Write `model` to `out` in fixed-format MPS.
 ///
@@ -73,8 +989,6 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         }
     }
 
-    // Per the MPS spec, max problems are negated, since most solvers assume
-    // minimization. Tag the sense in a comment so re-importers can recover it.
     writeln!(out, "* OXIMO MPS export")?;
     writeln!(
         out,
@@ -85,6 +999,15 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
         }
     )?;
     writeln!(out, "NAME          {}", model.name)?;
+    writeln!(out, "OBJSENSE")?;
+    writeln!(
+        out,
+        " {}",
+        match objective.sense {
+            ObjectiveSense::Minimize => "MIN",
+            ObjectiveSense::Maximize => "MAX",
+        }
+    )?;
 
     writeln!(out, "ROWS")?;
     writeln!(out, " N  OBJ")?;
@@ -105,8 +1028,8 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     writeln!(out, "COLUMNS")?;
     let mut int_open = false;
     for v in vars.iter() {
-        // Semi-integer columns carry their integrality via the `SI` bound
-        let needs_marker = v.domain.is_integer() && v.domain.semi_threshold().is_none();
+        // Binary and semi-integer columns carry their integrality via bounds.
+        let needs_marker = matches!(v.domain, Domain::Integer);
         if needs_marker && !int_open {
             writeln!(out, "    MARKER                 'MARKER'                 'INTORG'")?;
             int_open = true;
@@ -118,6 +1041,8 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
             for (row_name, coef) in entries {
                 writeln!(out, "    {:<10}{:<10}{}", v.name, row_name, coef)?;
             }
+        } else {
+            writeln!(out, "    {:<10}{:<10}0", v.name, "OBJ")?;
         }
     }
     if int_open {
@@ -157,6 +1082,16 @@ pub fn write_mps<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     for v in vars.iter() {
         let lb = v.lb;
         let ub = v.ub;
+        if matches!(v.domain, Domain::Binary) {
+            writeln!(out, " BV BND       {}", v.name)?;
+            if lb != 0.0 {
+                writeln!(out, " LO BND       {:<10}{}", v.name, lb)?;
+            }
+            if (ub - 1.0).abs() >= f64::EPSILON {
+                writeln!(out, " UP BND       {:<10}{}", v.name, ub)?;
+            }
+            continue;
+        }
         if let Some(thr) = v.domain.semi_threshold() {
             writeln!(out, " LO BND       {:<10}{}", v.name, thr)?;
             let semi_ub = if ub.is_finite() { ub } else { 1e30 };

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -195,6 +195,7 @@ struct ParsedMps {
     seen_sections: u8,
 }
 
+const MPS_INFINITY_SENTINEL: f64 = 1e30;
 const SEEN_ROWS: u8 = 1;
 const SEEN_COLUMNS: u8 = 2;
 const SEEN_END: u8 = 4;
@@ -551,7 +552,12 @@ fn parse_bound(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result
     let column_index = data.column_index.get(column_field.text).copied().ok_or_else(|| {
         invalid_mps(line, column_field.column, format!("unknown column {:?}", column_field.text))
     })?;
-    let value = value_field.map(|field| parse_number(field, line)).transpose()?;
+    let value = value_field
+        .map(|field| {
+            parse_number(field, line)
+                .map(|value| if value >= MPS_INFINITY_SENTINEL { f64::INFINITY } else { value })
+        })
+        .transpose()?;
     let column = &mut data.columns[column_index];
     if column.default_bounds && column.kind == ColumnKind::Integer {
         column.upper = f64::INFINITY;
@@ -1282,7 +1288,7 @@ pub fn write_mps_with<W: Write>(
         }
         if let Some(thr) = v.domain.semi_threshold() {
             writeln!(out, " LO BND       {column_name:<10} {thr}")?;
-            let semi_ub = if ub.is_finite() { ub } else { 1e30 };
+            let semi_ub = if ub.is_finite() { ub } else { MPS_INFINITY_SENTINEL };
             // `is_integer()` distinguishes the two semi domains here.
             let code = if v.domain.is_integer() { "SI" } else { "SC" };
             writeln!(out, " {code} BND       {column_name:<10} {semi_ub}")?;

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashSet;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 
 use oximo_core::{Constraint, Domain, Model, ModelKind, ObjectiveSense, Sense, var_name};
@@ -722,93 +722,114 @@ fn check_section_transition(
     Ok(())
 }
 
-fn parse_mps(text: &str, fallback_name: &str, options: MpsReadOptions) -> Result<Model, IoError> {
+fn parse_mps_line(
+    data: &mut ParsedMps,
+    section: &mut Section,
+    saw_name: &mut bool,
+    line: &str,
+    line_no: usize,
+    options: MpsReadOptions,
+) -> Result<(), IoError> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    if trimmed.starts_with('*') {
+        if data.sense.is_none() {
+            data.legacy_sense = parse_legacy_sense(trimmed).or(data.legacy_sense);
+        }
+        return Ok(());
+    }
+    if data.seen_sections & SEEN_END != 0 {
+        return Err(invalid_mps(line_no, 1, "content after ENDATA"));
+    }
+    let items = fields(line);
+    if let Some(first) = items.first() {
+        let keyword = first.text.to_ascii_uppercase();
+        if items.len() == 1 && matches!(keyword.as_str(), "SOS" | "INDICATORS") {
+            return Err(IoError::UnsupportedMps {
+                section: keyword,
+                feature: "not represented by oximo-core".into(),
+            });
+        }
+    }
+    if let Some(next) = header(&items, section) {
+        if matches!(next, Section::Name) {
+            if *saw_name {
+                return Err(invalid_mps(line_no, 1, "duplicate NAME section"));
+            }
+            *saw_name = true;
+            if items.len() > 1 {
+                data.name = items[1..].iter().map(|field| field.text).collect::<Vec<_>>().join(" ");
+            }
+            return Ok(());
+        }
+        if !*saw_name {
+            return Err(invalid_mps(line_no, 1, "the first data line must be NAME"));
+        }
+        check_section_transition(section, &next, line_no)?;
+        if data.intorg && !matches!(next, Section::Columns) {
+            return Err(invalid_mps(line_no, 1, "missing INTEND marker before COLUMNS ends"));
+        }
+        match &next {
+            Section::ObjSense if items.len() == 2 => {
+                data.sense = Some(objective_sense(&items[1], line_no)?);
+            }
+            Section::Rows => data.seen_sections |= SEEN_ROWS,
+            Section::Columns => data.seen_sections |= SEEN_COLUMNS,
+            Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
+                begin_quadratic_section(data, &next, line_no)?;
+            }
+            Section::End => data.seen_sections |= SEEN_END,
+            _ => {}
+        }
+        *section = next;
+        return Ok(());
+    }
+    if !*saw_name {
+        return Err(invalid_mps(line_no, 1, "the first data line must be NAME"));
+    }
+    match section {
+        Section::ObjSense => {
+            if items.len() != 1 {
+                return Err(invalid_mps(line_no, 1, "OBJSENSE data requires one field"));
+            }
+            data.sense = Some(objective_sense(&items[0], line_no)?);
+        }
+        Section::Rows => parse_row(data, &items, line_no)?,
+        Section::Columns => parse_columns(data, &items, line_no)?,
+        Section::Rhs => parse_rhs(data, &items, line_no)?,
+        Section::Ranges => parse_ranges(data, &items, line_no)?,
+        Section::Bounds => parse_bound(data, &items, line_no)?,
+        Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
+            parse_quadratic_record(data, section, &items, line_no, options)?;
+        }
+        Section::Name => return Err(invalid_mps(line_no, 1, "expected NAME header")),
+        Section::End => unreachable!(),
+    }
+    Ok(())
+}
+
+fn parse_mps<R: BufRead>(
+    mut input: R,
+    fallback_name: &str,
+    options: MpsReadOptions,
+) -> Result<Model, IoError> {
     let mut data = ParsedMps::new(fallback_name);
     let mut section = Section::Name;
     let mut saw_name = false;
-    for (offset, raw_line) in text.lines().enumerate() {
-        let line_no = offset + 1;
-        let line = raw_line.trim_end_matches('\r');
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
+    let mut line_buffer = String::new();
+    let mut last_line = 0;
+    loop {
+        line_buffer.clear();
+        if input.read_line(&mut line_buffer)? == 0 {
+            break;
         }
-        if trimmed.starts_with('*') {
-            if data.sense.is_none() {
-                data.legacy_sense = parse_legacy_sense(trimmed).or(data.legacy_sense);
-            }
-            continue;
-        }
-        if data.seen_sections & SEEN_END != 0 {
-            return Err(invalid_mps(line_no, 1, "content after ENDATA"));
-        }
-        let items = fields(line);
-        if let Some(first) = items.first() {
-            let keyword = first.text.to_ascii_uppercase();
-            if items.len() == 1 && matches!(keyword.as_str(), "SOS" | "INDICATORS") {
-                return Err(IoError::UnsupportedMps {
-                    section: keyword,
-                    feature: "not represented by oximo-core".into(),
-                });
-            }
-        }
-        if let Some(next) = header(&items, &section) {
-            if matches!(next, Section::Name) {
-                if saw_name {
-                    return Err(invalid_mps(line_no, 1, "duplicate NAME section"));
-                }
-                saw_name = true;
-                if items.len() > 1 {
-                    data.name =
-                        items[1..].iter().map(|field| field.text).collect::<Vec<_>>().join(" ");
-                }
-                continue;
-            }
-            if !saw_name {
-                return Err(invalid_mps(line_no, 1, "the first data line must be NAME"));
-            }
-            check_section_transition(&section, &next, line_no)?;
-            if data.intorg && !matches!(next, Section::Columns) {
-                return Err(invalid_mps(line_no, 1, "missing INTEND marker before COLUMNS ends"));
-            }
-            match &next {
-                Section::ObjSense if items.len() == 2 => {
-                    data.sense = Some(objective_sense(&items[1], line_no)?);
-                }
-                Section::Rows => data.seen_sections |= SEEN_ROWS,
-                Section::Columns => data.seen_sections |= SEEN_COLUMNS,
-                Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
-                    begin_quadratic_section(&mut data, &next, line_no)?;
-                }
-                Section::End => data.seen_sections |= SEEN_END,
-                _ => {}
-            }
-            section = next;
-            continue;
-        }
-        if !saw_name {
-            return Err(invalid_mps(line_no, 1, "the first data line must be NAME"));
-        }
-        match &section {
-            Section::ObjSense => {
-                if items.len() != 1 {
-                    return Err(invalid_mps(line_no, 1, "OBJSENSE data requires one field"));
-                }
-                data.sense = Some(objective_sense(&items[0], line_no)?);
-            }
-            Section::Rows => parse_row(&mut data, &items, line_no)?,
-            Section::Columns => parse_columns(&mut data, &items, line_no)?,
-            Section::Rhs => parse_rhs(&mut data, &items, line_no)?,
-            Section::Ranges => parse_ranges(&mut data, &items, line_no)?,
-            Section::Bounds => parse_bound(&mut data, &items, line_no)?,
-            Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
-                parse_quadratic_record(&mut data, &section, &items, line_no, options)?;
-            }
-            Section::Name => return Err(invalid_mps(line_no, 1, "expected NAME header")),
-            Section::End => unreachable!(),
-        }
+        last_line += 1;
+        let line = line_buffer.trim_end_matches(['\r', '\n']);
+        parse_mps_line(&mut data, &mut section, &mut saw_name, line, last_line, options)?;
     }
-    let last_line = text.lines().count().max(1);
+    let last_line = last_line.max(1);
     if data.intorg {
         return Err(invalid_mps(last_line, 1, "missing INTEND marker"));
     }
@@ -945,10 +966,8 @@ pub fn read_mps<R: Read>(input: R) -> Result<Model, IoError> {
 /// # Errors
 ///
 /// Returns [`IoError`] for I/O failures, malformed syntax, or unsupported sections.
-pub fn read_mps_with<R: Read>(mut input: R, options: &MpsReadOptions) -> Result<Model, IoError> {
-    let mut text = String::new();
-    input.read_to_string(&mut text)?;
-    parse_mps(&text, "mps_model", *options)
+pub fn read_mps_with<R: Read>(input: R, options: &MpsReadOptions) -> Result<Model, IoError> {
+    parse_mps(BufReader::new(input), "mps_model", *options)
 }
 
 /// Read an MPS file with default options.
@@ -970,10 +989,8 @@ pub fn read_mps_file_with(
     options: &MpsReadOptions,
 ) -> Result<Model, IoError> {
     let path = path.as_ref();
-    let mut text = String::new();
-    File::open(path)?.read_to_string(&mut text)?;
     let fallback = path.file_stem().and_then(|name| name.to_str()).unwrap_or("mps_model");
-    parse_mps(&text, fallback, *options)
+    parse_mps(BufReader::new(File::open(path)?), fallback, *options)
 }
 
 /// Write `model` to `out` in fixed-format MPS.

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -712,7 +712,7 @@ fn parse_quadratic_record(
 fn validate_quadratic_triangles(data: &ParsedMps, line: usize) -> Result<(), IoError> {
     for ((_, left, right), triangle) in &data.quadratic_triangles {
         if let (Some(upper), Some(lower)) = (triangle.upper, triangle.lower)
-            && upper != lower
+            && upper.total_cmp(&lower).is_ne()
         {
             return Err(invalid_mps(
                 line,

--- a/crates/oximo-io/src/nl/analyze.rs
+++ b/crates/oximo-io/src/nl/analyze.rs
@@ -274,7 +274,7 @@ pub mod benchmark_support {
         let constraints = model_constraints.algebraic();
         let objective = model.try_objective().map_err(|_| IoError::NoObjective)?;
         let arena_ref = &*arena;
-        let analysis = build(arena_ref, &vars, &constraints, &objective, parallel)?;
+        let analysis = build(arena_ref, &vars, constraints, &objective, parallel)?;
         Ok(analysis.cons.len()
             + analysis.jacobian_nnz()
             + analysis.obj_vars.len()

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io::{self, Read};
 
 use oximo_core::prelude::*;
@@ -273,21 +274,43 @@ fn writer_round_trips_quadratic_objective_and_constraints_for_mps_dialects() {
         let actual_constraint = quadratic_terms(&imported, false);
         assert_eq!(actual_objective.hessian.len(), expected_objective.hessian.len());
         assert_eq!(actual_constraint.hessian.len(), expected_constraint.hessian.len());
-        for (actual, expected) in actual_objective.hessian.iter().zip(&expected_objective.hessian) {
-            assert_eq!(actual.0, expected.0);
-            assert_eq!(actual.1, expected.1);
+        let actual_objective_hessian: HashMap<_, _> = actual_objective
+            .hessian
+            .into_iter()
+            .map(|(row, col, value)| ((row, col), value))
+            .collect();
+        let expected_objective_hessian: HashMap<_, _> = expected_objective
+            .hessian
+            .iter()
+            .map(|&(row, col, value)| ((row, col), value))
+            .collect();
+        for (pair, expected) in &expected_objective_hessian {
+            let actual = actual_objective_hessian
+                .get(pair)
+                .unwrap_or_else(|| panic!("{format:?} objective is missing Hessian pair {pair:?}"));
             assert!(
-                close(actual.2, expected.2),
-                "{format:?} objective: actual={actual:?} expected={expected:?}"
+                close(*actual, *expected),
+                "{format:?} objective: pair={pair:?} actual={actual} expected={expected}"
             );
         }
-        for (actual, expected) in actual_constraint.hessian.iter().zip(&expected_constraint.hessian)
-        {
-            assert_eq!(actual.0, expected.0);
-            assert_eq!(actual.1, expected.1);
+
+        let actual_constraint_hessian: HashMap<_, _> = actual_constraint
+            .hessian
+            .into_iter()
+            .map(|(row, col, value)| ((row, col), value))
+            .collect();
+        let expected_constraint_hessian: HashMap<_, _> = expected_constraint
+            .hessian
+            .iter()
+            .map(|&(row, col, value)| ((row, col), value))
+            .collect();
+        for (pair, expected) in &expected_constraint_hessian {
+            let actual = actual_constraint_hessian.get(pair).unwrap_or_else(|| {
+                panic!("{format:?} constraint is missing Hessian pair {pair:?}")
+            });
             assert!(
-                close(actual.2, expected.2),
-                "{format:?} constraint: actual={actual:?} expected={expected:?}"
+                close(*actual, *expected),
+                "{format:?} constraint: pair={pair:?} actual={actual} expected={expected}"
             );
         }
     }

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -141,6 +141,34 @@ fn writer_round_trips_max_binary_semi_range_and_unused_variables() {
 }
 
 #[test]
+fn writer_sanitizes_and_uniquifies_mps_names() {
+    let model = Model::new("name roundtrip");
+    let spaced = model.__var("x one").build();
+    let tabbed = model.__var("x\tone").build();
+    let underscored = model.__var("x_one").build();
+    let unnamed = model.__var("").build();
+    model.__add_constraint("OBJ", spaced.le(1.0));
+    model.__add_constraint("limit one", tabbed.ge(2.0));
+    model.__add_constraint("limit_one", underscored.eq(3.0));
+    model.__add_constraint("", unnamed.le(4.0));
+    model.__minimize(spaced + tabbed + underscored + unnamed);
+
+    let text = to_mps_string(&model).expect("write MPS");
+    let imported = read_mps(text.as_bytes()).expect("read sanitized MPS");
+
+    let variable_names: Vec<_> =
+        imported.variables().iter().map(|variable| variable.name.to_string()).collect();
+    assert_eq!(variable_names, ["x_one", "x_one_1", "x_one_2", "C4"]);
+    let constraint_names: Vec<_> = imported
+        .constraints()
+        .algebraic()
+        .iter()
+        .map(|constraint| constraint.name.to_string())
+        .collect();
+    assert_eq!(constraint_names, ["OBJ_1", "limit_one", "limit_one_1", "R4"]);
+}
+
+#[test]
 fn reads_quadratic_objective_matrix_once() {
     let text = r"
 NAME qp

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -68,6 +68,33 @@ ENDATA
 }
 
 #[test]
+fn upstream_stacked_data_fixture_with_tabs_and_extra_row_fields() {
+    let text = "NAME stacked\nROWS\n N OBJ metadata\n L limit metadata\nCOLUMNS\n x\tOBJ\t1\tlimit\t2\n y\tOBJ\t-1\tlimit\t3\nRHS\n rhs\tOBJ\t4\tlimit\t7\nENDATA\n";
+    let model = read_mps(text.as_bytes()).expect("stacked upstream fixture");
+
+    assert_eq!(model.num_variables(), 2);
+    assert_eq!(model.num_constraints(), 1);
+    let objective = quadratic_terms(&model, true);
+    assert_eq!(objective.linear.len(), 2);
+    assert!(close(objective.constant, -4.0));
+    let constraints = model.constraints();
+    let row = &constraints.algebraic()[0];
+    assert!(row.lower.is_infinite() && row.lower.is_sign_negative());
+    assert!(close(row.upper, 7.0));
+}
+
+#[test]
+fn upstream_integer_default_bounds_reset_on_explicit_bound() {
+    let text = "NAME integer\nROWS\n N OBJ\nCOLUMNS\n marker 'MARKER' 'INTORG'\n x OBJ 1\n marker 'MARKER' 'INTEND'\n y OBJ 1\nBOUNDS\n LO BND x 2\nENDATA\n";
+    let model = read_mps(text.as_bytes()).expect("integer default bounds fixture");
+    let x = &model.variables()[0];
+    assert!(matches!(x.domain, Domain::Integer));
+    assert!(close(x.lb, 2.0));
+    assert!(x.ub.is_infinite() && x.ub.is_sign_positive());
+    assert!(matches!(model.variables()[1].domain, Domain::Real));
+}
+
+#[test]
 fn legacy_sense_is_fallback_and_objsense_takes_precedence() {
     let legacy = "* sense: maximize\nNAME old\nROWS\n N obj\nCOLUMNS\n x obj 1\nENDATA\n";
     let model = read_mps(legacy.as_bytes()).expect("legacy sense");

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -182,6 +182,26 @@ ENDATA
 }
 
 #[test]
+fn semi_domain_infinite_upper_bound_uses_mps_sentinel() {
+    let source = Model::new("semi");
+    let s = source.__var("s").domain(Domain::SemiContinuous { threshold: 2.0 }).build();
+    source.__minimize(s);
+    let written = to_mps_string(&source).expect("write sentinel semi upper bound");
+    let sentinel = format!("{}", 1e30);
+    assert!(written.contains("SC BND") && written.contains(&sentinel));
+
+    let model = read_mps(written.as_bytes()).expect("read sentinel semi upper bound");
+    let variable = &model.variables()[0];
+    assert!(matches!(variable.domain, Domain::SemiContinuous { threshold: 2.0 }));
+    assert!(close(variable.lb, 0.0));
+    assert!(variable.ub.is_infinite() && variable.ub.is_sign_positive());
+
+    let finite = "NAME finite\nROWS\n N obj\nCOLUMNS\n s obj 1\nBOUNDS\n LO BND s 2\n SC BND s 1e29\nENDATA\n";
+    let model = read_mps(finite.as_bytes()).expect("finite semi upper bound");
+    assert!(close(model.variables()[0].ub, 1e29));
+}
+
+#[test]
 fn writer_round_trips_max_binary_semi_range_and_unused_variables() {
     let model = Model::new("roundtrip");
     variable!(model, x <= 8.0);

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -123,6 +123,29 @@ fn legacy_sense_is_fallback_and_objsense_takes_precedence() {
 }
 
 #[test]
+fn reads_named_and_unnamed_bounds_without_name_lookup() {
+    let text = r"
+NAME bounds
+ROWS
+ N obj
+COLUMNS
+ x obj 1
+ y obj 1
+BOUNDS
+ FR x
+ FR x y
+ UP x 4
+ENDATA
+";
+    let model = read_mps(text.as_bytes()).expect("named and unnamed bounds");
+    let vars = model.variables();
+    assert!(vars[0].lb.is_infinite() && vars[0].lb.is_sign_negative());
+    assert!(close(vars[0].ub, 4.0));
+    assert!(vars[1].lb.is_infinite() && vars[1].lb.is_sign_negative());
+    assert!(vars[1].ub.is_infinite() && vars[1].ub.is_sign_positive());
+}
+
+#[test]
 fn reads_bound_types_and_semi_domains() {
     let text = r"
 NAME domains

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -296,7 +296,7 @@ fn writer_round_trips_quadratic_objective_and_constraints_for_mps_dialects() {
 #[test]
 fn writer_sanitizes_and_uniquifies_mps_names() {
     let model = Model::new("name roundtrip");
-    let spaced = model.__var("x one").build();
+    let spaced = model.__var("*comment").build();
     let tabbed = model.__var("x\tone").build();
     let underscored = model.__var("x_one").build();
     let unnamed = model.__var("").build();
@@ -311,7 +311,7 @@ fn writer_sanitizes_and_uniquifies_mps_names() {
 
     let variable_names: Vec<_> =
         imported.variables().iter().map(|variable| variable.name.to_string()).collect();
-    assert_eq!(variable_names, ["x_one", "x_one_1", "x_one_2", "C4"]);
+    assert_eq!(variable_names, ["_comment", "x_one", "x_one_1", "C4"]);
     let constraint_names: Vec<_> = imported
         .constraints()
         .algebraic()

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -95,6 +95,22 @@ fn upstream_integer_default_bounds_reset_on_explicit_bound() {
 }
 
 #[test]
+fn negative_upper_bound_without_lower_bound_is_unbounded_below() {
+    let initial =
+        "NAME negative_up\nROWS\n N OBJ\nCOLUMNS\n x OBJ 1\nBOUNDS\n UP BND x -2\nENDATA\n";
+    let model = read_mps(initial.as_bytes()).expect("negative initial upper bound");
+    let variable = &model.variables()[0];
+    assert!(variable.lb.is_infinite() && variable.lb.is_sign_negative());
+    assert!(close(variable.ub, -2.0));
+
+    let explicit = "NAME explicit_lo\nROWS\n N OBJ\nCOLUMNS\n x OBJ 1\nBOUNDS\n LO BND x -5\n UP BND x -2\nENDATA\n";
+    let model = read_mps(explicit.as_bytes()).expect("explicit lower bound");
+    let variable = &model.variables()[0];
+    assert!(close(variable.lb, -5.0));
+    assert!(close(variable.ub, -2.0));
+}
+
+#[test]
 fn legacy_sense_is_fallback_and_objsense_takes_precedence() {
     let legacy = "* sense: maximize\nNAME old\nROWS\n N obj\nCOLUMNS\n x obj 1\nENDATA\n";
     let model = read_mps(legacy.as_bytes()).expect("legacy sense");

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -235,14 +235,36 @@ ENDATA
 
 #[test]
 fn qsection_supports_objective_and_constraint_targets() {
-    let objective = "NAME q\nROWS\n N cost\nCOLUMNS\n x cost 0\nQSECTION cost\n x x 6\nENDATA\n";
-    let model = read_mps(objective.as_bytes()).expect("objective QSECTION");
+    let declared = "NAME q\nROWS\n N cost\nCOLUMNS\n x cost 0\nQSECTION cost\n x x 6\nENDATA\n";
+    let model = read_mps(declared.as_bytes()).expect("declared objective QSECTION");
     assert!(close(quadratic_terms(&model, true).hessian[0].2, 6.0));
+
+    let obj_alias = "NAME q\nROWS\n N cost\nCOLUMNS\n x cost 0\nQSECTION OBJ\n x x 8\nENDATA\n";
+    let model = read_mps(obj_alias.as_bytes()).expect("OBJ objective QSECTION");
+    assert!(close(quadratic_terms(&model, true).hessian[0].2, 8.0));
 
     let constraint =
         "NAME q\nROWS\n N obj\n L row\nCOLUMNS\n x row 0\nQSECTION row\n x x 3\nENDATA\n";
     let model = read_mps(constraint.as_bytes()).expect("constraint QSECTION");
     assert!(close(quadratic_terms(&model, false).hessian[0].2, 6.0));
+}
+
+#[test]
+fn qsection_obj_rejects_ambiguous_and_duplicate_objective_targets() {
+    let ambiguous =
+        "NAME q\nROWS\n N cost\n L OBJ\nCOLUMNS\n x cost 0 OBJ 0\nQSECTION OBJ\n x x 1\nENDATA\n";
+    let error = read_mps(ambiguous.as_bytes()).expect_err("ambiguous OBJ target");
+    assert!(matches!(
+        error,
+        IoError::InvalidMps { message, .. } if message.contains("ambiguous")
+    ));
+
+    let duplicate = "NAME q\nROWS\n N cost\nCOLUMNS\n x cost 0\nQSECTION cost\n x x 1\nQSECTION OBJ\n x x 1\nENDATA\n";
+    let error = read_mps(duplicate.as_bytes()).expect_err("duplicate objective QSECTION");
+    assert!(matches!(
+        error,
+        IoError::InvalidMps { message, .. } if message.contains("already supplied")
+    ));
 }
 
 #[test]

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -3,8 +3,8 @@ use std::io::{self, Read};
 use oximo_core::prelude::*;
 use oximo_expr::extract_quadratic;
 use oximo_io::{
-    IoError, MpsQuadraticFormat, MpsReadOptions, read_mps, read_mps_file, read_mps_with,
-    to_mps_string,
+    IoError, MpsQuadraticFormat, MpsReadOptions, MpsWriteOptions, read_mps, read_mps_file,
+    read_mps_with, to_mps_string, to_mps_string_with,
 };
 
 fn close(left: f64, right: f64) -> bool {
@@ -165,6 +165,71 @@ fn writer_round_trips_max_binary_semi_range_and_unused_variables() {
     let constraints = imported.constraints();
     assert_eq!((constraints.algebraic()[0].lower, constraints.algebraic()[0].upper), (1.0, 6.0));
     assert!(close(quadratic_terms(&imported, true).constant, 4.0));
+}
+
+#[test]
+fn writer_round_trips_quadratic_objective_and_constraints_for_mps_dialects() {
+    let model = Model::new("quadratic roundtrip");
+    let x = model.__var("x").bounds(-2.0, 4.0).build();
+    let y = model.__var("y").bounds(-3.0, 5.0).build();
+    model.__add_constraint("q", (x * x + 2.0 * x * y + y * y).le(10.0));
+    model.__minimize(3.0 * x * x + 4.0 * x * y + y * y + x);
+
+    let expected_objective = quadratic_terms(&model, true);
+    let expected_constraint = quadratic_terms(&model, false);
+    for format in [MpsQuadraticFormat::Gurobi, MpsQuadraticFormat::Cplex, MpsQuadraticFormat::Mosek]
+    {
+        let options = MpsWriteOptions { quadratic_format: format };
+        let text = to_mps_string_with(&model, &options).expect("write quadratic MPS");
+        let expected_header = match format {
+            MpsQuadraticFormat::Mosek => "QSECTION",
+            MpsQuadraticFormat::Gurobi | MpsQuadraticFormat::Cplex => "QUADOBJ",
+        };
+        assert!(text.contains(expected_header), "{text}");
+        if format == MpsQuadraticFormat::Gurobi {
+            assert!(
+                text.contains("y          x"),
+                "Gurobi QUADOBJ must use lower triangle:\n{text}"
+            );
+            assert!(text.matches("x          y").count() >= 1);
+            assert!(text.matches("y          x").count() >= 1);
+        } else if format == MpsQuadraticFormat::Cplex {
+            assert!(
+                text.contains("x          y"),
+                "CPLEX QUADOBJ must use upper triangle:\n{text}"
+            );
+            assert!(text.matches("x          y").count() >= 1);
+            assert!(text.matches("y          x").count() >= 1);
+        } else {
+            assert!(
+                text.contains("y          x"),
+                "MOSEK QSECTION must use lower triangle:\n{text}"
+            );
+        }
+        let imported = read_mps_with(text.as_bytes(), &MpsReadOptions { quadratic_format: format })
+            .expect("read quadratic MPS");
+        let actual_objective = quadratic_terms(&imported, true);
+        let actual_constraint = quadratic_terms(&imported, false);
+        assert_eq!(actual_objective.hessian.len(), expected_objective.hessian.len());
+        assert_eq!(actual_constraint.hessian.len(), expected_constraint.hessian.len());
+        for (actual, expected) in actual_objective.hessian.iter().zip(&expected_objective.hessian) {
+            assert_eq!(actual.0, expected.0);
+            assert_eq!(actual.1, expected.1);
+            assert!(
+                close(actual.2, expected.2),
+                "{format:?} objective: actual={actual:?} expected={expected:?}"
+            );
+        }
+        for (actual, expected) in actual_constraint.hessian.iter().zip(&expected_constraint.hessian)
+        {
+            assert_eq!(actual.0, expected.0);
+            assert_eq!(actual.1, expected.1);
+            assert!(
+                close(actual.2, expected.2),
+                "{format:?} constraint: actual={actual:?} expected={expected:?}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -334,6 +334,27 @@ fn reads_quadobj_triangular_objective() {
 }
 
 #[test]
+fn preserves_lower_triangle_records_in_qmatrix_and_qcmatrix() {
+    let objective = "NAME qp\nROWS\n N obj\nCOLUMNS\n x obj 0\n y obj 0\nQMATRIX\n y x 3\nENDATA\n";
+    let model = read_mps(objective.as_bytes()).expect("lower QMATRIX record");
+    let q = quadratic_terms(&model, true);
+    assert!(q.hessian.iter().any(|(row, col, value)| row != col && close(*value, 3.0)));
+
+    let constraint = "NAME qcp\nROWS\n N obj\n L q\nCOLUMNS\n x q 0\n y q 0\nRHS\n rhs q 1\nQCMATRIX q\n y x 2\nENDATA\n";
+    let model = read_mps(constraint.as_bytes()).expect("lower QCMATRIX record");
+    let q = quadratic_terms(&model, false);
+    assert!(q.hessian.iter().any(|(row, col, value)| row != col && close(*value, 4.0)));
+}
+
+#[test]
+fn rejects_asymmetric_qmatrix_triangle_values() {
+    let text =
+        "NAME qp\nROWS\n N obj\nCOLUMNS\n x obj 0\n y obj 0\nQMATRIX\n x y 2\n y x 3\nENDATA\n";
+    let error = read_mps(text.as_bytes()).expect_err("asymmetric QMATRIX");
+    assert!(matches!(error, IoError::InvalidMps { message, .. } if message.contains("asymmetric")));
+}
+
+#[test]
 fn quadratic_constraint_scaling_is_configurable() {
     let text = r"
 NAME qcp

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -174,10 +174,10 @@ ENDATA
     assert!(matches!(vars[1].domain, Domain::Integer));
     assert_eq!((vars[1].lb, vars[1].ub), (-2.0, 7.0));
     assert!(matches!(vars[2].domain, Domain::SemiContinuous { threshold: 2.0 }));
-    assert_eq!(vars[2].lb, 0.0);
+    assert!(close(vars[2].lb, 0.0));
     assert!(close(vars[2].ub, 10.0));
     assert!(matches!(vars[3].domain, Domain::SemiInteger { threshold: 1.0 }));
-    assert_eq!(vars[3].lb, 0.0);
+    assert!(close(vars[3].lb, 0.0));
     assert_eq!((vars[4].lb, vars[4].ub), (4.0, 4.0));
 }
 

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -1,0 +1,278 @@
+use std::io::{self, Read};
+
+use oximo_core::prelude::*;
+use oximo_expr::extract_quadratic;
+use oximo_io::{
+    IoError, MpsQuadraticFormat, MpsReadOptions, read_mps, read_mps_file, read_mps_with,
+    to_mps_string,
+};
+
+fn close(left: f64, right: f64) -> bool {
+    (left - right).abs() < 1e-12
+}
+
+fn quadratic_terms(model: &Model, objective: bool) -> oximo_expr::QuadraticTerms {
+    let arena = model.arena();
+    let expr = if objective {
+        model.try_objective().expect("objective").expr
+    } else {
+        model.constraints().algebraic()[0].lhs
+    };
+    extract_quadratic(&arena, expr).expect("quadratic expression")
+}
+
+#[test]
+fn reads_linear_milp_ranges_defaults_and_duplicate_coefficients() {
+    let text = r"
+* comment
+NAME mixed
+OBJSENSE MAX
+ROWS
+ N obj
+ L cap
+ G floor
+ N free_row
+COLUMNS
+ marker 'MARKER' 'INTORG'
+ x obj 1D0 cap 2
+ x obj 2
+ marker 'MARKER' 'INTEND'
+ y floor 1 free_row -1
+RHS
+ rhs cap 10 floor 3
+ rhs obj -5
+RANGES
+ rng cap 4
+BOUNDS
+ FR bnd y
+ENDATA
+";
+    let model = read_mps(text.as_bytes()).expect("MPS should parse");
+    assert_eq!(model.name, "mixed");
+    assert_eq!(model.num_variables(), 2);
+    assert_eq!(model.num_constraints(), 3);
+    assert_eq!(model.try_objective().expect("objective").sense, ObjectiveSense::Maximize);
+    assert!(matches!(model.variables()[0].domain, Domain::Integer));
+    assert!(close(model.variables()[0].lb, 0.0));
+    assert!(close(model.variables()[0].ub, 1.0));
+    assert!(model.variables()[1].lb.is_infinite() && model.variables()[1].lb.is_sign_negative());
+
+    let objective = quadratic_terms(&model, true);
+    assert_eq!(objective.linear, vec![(model.variables()[0].id, 3.0)]);
+    assert!(close(objective.constant, 5.0));
+    let constraints = model.constraints();
+    assert!(close(constraints.algebraic()[0].lower, 6.0));
+    assert!(close(constraints.algebraic()[0].upper, 10.0));
+    assert!(constraints.algebraic()[2].lower.is_infinite());
+    assert!(constraints.algebraic()[2].upper.is_infinite());
+}
+
+#[test]
+fn legacy_sense_is_fallback_and_objsense_takes_precedence() {
+    let legacy = "* sense: maximize\nNAME old\nROWS\n N obj\nCOLUMNS\n x obj 1\nENDATA\n";
+    let model = read_mps(legacy.as_bytes()).expect("legacy sense");
+    assert_eq!(model.try_objective().expect("objective").sense, ObjectiveSense::Maximize);
+
+    let standard =
+        "* sense: maximize\nNAME current\nOBJSENSE MIN\nROWS\n N obj\nCOLUMNS\n x obj 1\nENDATA\n";
+    let model = read_mps(standard.as_bytes()).expect("standard sense");
+    assert_eq!(model.try_objective().expect("objective").sense, ObjectiveSense::Minimize);
+}
+
+#[test]
+fn reads_bound_types_and_semi_domains() {
+    let text = r"
+NAME domains
+ROWS
+ N obj
+COLUMNS
+ a obj 1
+ b obj 1
+ c obj 1
+ d obj 1
+ e obj 1
+BOUNDS
+ BV bnd a
+ LI bnd b -2
+ UI bnd b 7
+ LO bnd c 2
+ SC bnd c 10
+ LO bnd d 1
+ SI bnd d 5
+ FX bnd e 4
+ENDATA
+";
+    let model = read_mps(text.as_bytes()).expect("domains");
+    let vars = model.variables();
+    assert!(matches!(vars[0].domain, Domain::Binary));
+    assert!(matches!(vars[1].domain, Domain::Integer));
+    assert_eq!((vars[1].lb, vars[1].ub), (-2.0, 7.0));
+    assert!(matches!(vars[2].domain, Domain::SemiContinuous { threshold: 2.0 }));
+    assert!(close(vars[2].ub, 10.0));
+    assert!(matches!(vars[3].domain, Domain::SemiInteger { threshold: 1.0 }));
+    assert_eq!((vars[4].lb, vars[4].ub), (4.0, 4.0));
+}
+
+#[test]
+fn writer_round_trips_max_binary_semi_range_and_unused_variables() {
+    let model = Model::new("roundtrip");
+    variable!(model, x <= 8.0);
+    variable!(model, b, Binary);
+    variable!(model, s <= 10.0, SemiCont(2.0));
+    variable!(model, unused);
+    let _ = unused;
+    model.__add_constraint_interval("range", x + b, 1.0, 6.0);
+    objective!(model, Max, 2.0 * x + b + s + 4.0);
+
+    let text = to_mps_string(&model).expect("write MPS");
+    assert!(text.contains("OBJSENSE\n MAX"), "{text}");
+    assert!(text.lines().any(|line| line.contains("BV BND") && line.contains('b')), "{text}");
+    assert!(text.lines().any(|line| line.contains("unused") && line.contains("OBJ")), "{text}");
+
+    let imported = read_mps(text.as_bytes()).expect("read writer output");
+    assert_eq!(imported.num_variables(), 4);
+    assert_eq!(imported.variables()[3].name, "unused");
+    assert!(matches!(imported.variables()[1].domain, Domain::Binary));
+    assert!(matches!(imported.variables()[2].domain, Domain::SemiContinuous { threshold: 2.0 }));
+    assert_eq!(imported.try_objective().expect("objective").sense, ObjectiveSense::Maximize);
+    let constraints = imported.constraints();
+    assert_eq!((constraints.algebraic()[0].lower, constraints.algebraic()[0].upper), (1.0, 6.0));
+    assert!(close(quadratic_terms(&imported, true).constant, 4.0));
+}
+
+#[test]
+fn reads_quadratic_objective_matrix_once() {
+    let text = r"
+NAME qp
+ROWS
+ N obj
+COLUMNS
+ x obj 1
+ y obj 1
+QMATRIX
+ x x 10
+ x y 2
+ y x 2
+ y y 2
+ENDATA
+";
+    let model = read_mps(text.as_bytes()).expect("QMATRIX");
+    let q = quadratic_terms(&model, true);
+    assert_eq!(q.hessian.len(), 3);
+    assert!(q.hessian.iter().any(|(_, _, value)| close(*value, 10.0)));
+    assert!(q.hessian.iter().any(|(row, col, value)| row != col && close(*value, 2.0)));
+    assert!(q.hessian.iter().any(|(row, col, value)| row == col && close(*value, 2.0)));
+}
+
+#[test]
+fn reads_quadobj_triangular_objective() {
+    let text =
+        "NAME qp\nROWS\n N obj\nCOLUMNS\n x obj 0\n y obj 0\nQUADOBJ\n x x 8\n x y 3\nENDATA\n";
+    let model = read_mps(text.as_bytes()).expect("QUADOBJ");
+    let q = quadratic_terms(&model, true);
+    assert!(q.hessian.iter().any(|(row, col, value)| row == col && close(*value, 8.0)));
+    assert!(q.hessian.iter().any(|(row, col, value)| row != col && close(*value, 3.0)));
+}
+
+#[test]
+fn quadratic_constraint_scaling_is_configurable() {
+    let text = r"
+NAME qcp
+ROWS
+ N obj
+ L q
+COLUMNS
+ x q 1
+ y q 1
+RHS
+ rhs q 1
+QCMATRIX q
+ x x 10
+ x y 2
+ y x 2
+ y y 2
+ENDATA
+";
+    let gurobi = read_mps(text.as_bytes()).expect("Gurobi scaling");
+    let gurobi_q = quadratic_terms(&gurobi, false);
+    assert!(gurobi_q.hessian.iter().any(|(row, col, value)| row == col && close(*value, 20.0)));
+    assert!(gurobi_q.hessian.iter().any(|(row, col, value)| row != col && close(*value, 4.0)));
+
+    let options = MpsReadOptions { quadratic_format: MpsQuadraticFormat::Cplex };
+    let cplex = read_mps_with(text.as_bytes(), &options).expect("CPLEX scaling");
+    let cplex_q = quadratic_terms(&cplex, false);
+    assert!(cplex_q.hessian.iter().any(|(row, col, value)| row == col && close(*value, 10.0)));
+    assert!(cplex_q.hessian.iter().any(|(row, col, value)| row != col && close(*value, 2.0)));
+}
+
+#[test]
+fn qsection_supports_objective_and_constraint_targets() {
+    let objective = "NAME q\nROWS\n N cost\nCOLUMNS\n x cost 0\nQSECTION cost\n x x 6\nENDATA\n";
+    let model = read_mps(objective.as_bytes()).expect("objective QSECTION");
+    assert!(close(quadratic_terms(&model, true).hessian[0].2, 6.0));
+
+    let constraint =
+        "NAME q\nROWS\n N obj\n L row\nCOLUMNS\n x row 0\nQSECTION row\n x x 3\nENDATA\n";
+    let model = read_mps(constraint.as_bytes()).expect("constraint QSECTION");
+    assert!(close(quadratic_terms(&model, false).hessian[0].2, 6.0));
+}
+
+#[test]
+fn feasibility_mps_gets_zero_minimization_objective() {
+    let text = "NAME feasible\nROWS\n G row\nCOLUMNS\n x row 1\nENDATA\n";
+    let model = read_mps(text.as_bytes()).expect("feasibility MPS");
+    assert_eq!(model.try_objective().expect("objective").sense, ObjectiveSense::Minimize);
+    let objective = quadratic_terms(&model, true);
+    assert!(objective.linear.is_empty());
+    assert!(close(objective.constant, 0.0));
+}
+
+#[test]
+fn file_reader_uses_name_then_file_stem_fallback() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let named = dir.path().join("fallback.mps");
+    std::fs::write(&named, "NAME explicit\nROWS\n N obj\nCOLUMNS\n x obj 0\nENDATA\n")
+        .expect("fixture");
+    assert_eq!(read_mps_file(&named).expect("named").name, "explicit");
+
+    std::fs::write(&named, "NAME\nROWS\n N obj\nCOLUMNS\n x obj 0\nENDATA\n").expect("fixture");
+    assert_eq!(read_mps_file(&named).expect("fallback").name, "fallback");
+}
+
+#[test]
+fn rejects_unsupported_sections_and_multiple_vectors() {
+    for section in ["SOS", "INDICATORS"] {
+        let text = format!("NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\n{section}\nENDATA\n");
+        assert!(matches!(read_mps(text.as_bytes()), Err(IoError::UnsupportedMps { .. })));
+    }
+    let vectors = "NAME bad\nROWS\n N obj\n L row\nCOLUMNS\n x row 1\nRHS\n first row 1\n second row 2\nENDATA\n";
+    assert!(matches!(read_mps(vectors.as_bytes()), Err(IoError::UnsupportedMps { .. })));
+}
+
+#[test]
+fn malformed_inputs_return_mps_diagnostics() {
+    for text in [
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x missing 1\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n mark 'MARKER' 'INTORG'\n x obj 1\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj NaN\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 1\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 1\nENDATA\nBOUNDS\n",
+    ] {
+        assert!(matches!(read_mps(text.as_bytes()), Err(IoError::InvalidMps { .. })), "{text}");
+    }
+}
+
+#[test]
+fn stream_and_file_io_errors_are_preserved() {
+    struct FailingReader;
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("read failed"))
+        }
+    }
+
+    assert!(matches!(read_mps(FailingReader), Err(IoError::Io(_))));
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert!(matches!(read_mps_file(dir.path().join("missing.mps")), Err(IoError::Io(_))));
+}

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -174,8 +174,10 @@ ENDATA
     assert!(matches!(vars[1].domain, Domain::Integer));
     assert_eq!((vars[1].lb, vars[1].ub), (-2.0, 7.0));
     assert!(matches!(vars[2].domain, Domain::SemiContinuous { threshold: 2.0 }));
+    assert_eq!(vars[2].lb, 0.0);
     assert!(close(vars[2].ub, 10.0));
     assert!(matches!(vars[3].domain, Domain::SemiInteger { threshold: 1.0 }));
+    assert_eq!(vars[3].lb, 0.0);
     assert_eq!((vars[4].lb, vars[4].ub), (4.0, 4.0));
 }
 

--- a/crates/oximo-io/tests/nonlinear_errors.rs
+++ b/crates/oximo-io/tests/nonlinear_errors.rs
@@ -61,14 +61,10 @@ fn lp_names_the_objective() {
 }
 
 #[test]
-fn mps_names_the_constraint_and_renders_the_term() {
-    match to_mps_string(&bilinear_model()) {
-        Err(IoError::Nonlinear { location, term }) => {
-            assert_eq!(location, "constraint \"capacity\"");
-            assert_eq!(term, "x * y");
-        }
-        other => panic!("expected a Nonlinear error, got {other:?}"),
-    }
+fn mps_writes_quadratic_constraint() {
+    let mps = to_mps_string(&bilinear_model()).expect("quadratic MPS should export");
+    assert!(mps.contains("QCMATRIX capacity"), "{mps}");
+    assert!(mps.contains("x          y          0.5"), "{mps}");
 }
 
 #[test]

--- a/crates/oximo-io/tests/nonlinear_errors.rs
+++ b/crates/oximo-io/tests/nonlinear_errors.rs
@@ -64,7 +64,10 @@ fn lp_names_the_objective() {
 fn mps_writes_quadratic_constraint() {
     let mps = to_mps_string(&bilinear_model()).expect("quadratic MPS should export");
     assert!(mps.contains("QCMATRIX capacity"), "{mps}");
-    assert!(mps.contains("x          y          0.5"), "{mps}");
+    assert!(
+        mps.lines().any(|line| line.split_whitespace().collect::<Vec<_>>() == ["x", "y", "0.5"]),
+        "{mps}"
+    );
 }
 
 #[test]

--- a/crates/oximo-io/tests/range.rs
+++ b/crates/oximo-io/tests/range.rs
@@ -21,12 +21,14 @@ fn range_model() -> Model {
 #[test]
 fn mps_emits_ranges_section() {
     let s = to_mps_string(&range_model()).expect("mps writer");
+    let has =
+        |fields: &[&str]| s.lines().any(|line| line.split_whitespace().eq(fields.iter().copied()));
     // The range is an `L` row whose RHS is the upper bound
-    assert!(s.contains(" L  band"), "{s}");
-    assert!(s.contains("RHS       band      4"), "{s}");
+    assert!(has(&["L", "band"]), "{s}");
+    assert!(has(&["RHS", "band", "4"]), "{s}");
     // widened down to the lower bound by RANGES: R = upper - lower = 3.
     assert!(s.contains("RANGES"), "{s}");
-    assert!(s.contains("RNG       band      3"), "{s}");
+    assert!(has(&["RNG", "band", "3"]), "{s}");
 }
 
 #[test]

--- a/crates/oximo/README.md
+++ b/crates/oximo/README.md
@@ -212,7 +212,7 @@ pub trait Solver {
 | Feature         | What it adds                                                 | Default |
 | --------------- | ------------------------------------------------------------ | ------- |
 | `highs`         | HiGHS - LP/MILP/QP solver (bundled, no install)              | yes     |
-| `io`            | NL, MPS, and LP file writers                                 | yes     |
+| `io`            | NL, MPS, and LP file readers and writers                     | yes     |
 | `gurobi`        | Gurobi v13+ solver (requires licensed install)               | no      |
 | `mosek`         | MOSEK 11.2 - convex LP/MIP/QP/QCP/SOCP solver                | no      |
 | `gams`          | GAMS bridge - solve type depends on the selected sub-solver  | no      |

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -1,6 +1,10 @@
 use oximo::prelude::*;
 use oximo::solvers::Highs;
 
+fn mps_record(text: &str, fields: &[&str]) -> bool {
+    text.lines().any(|line| line.split_whitespace().eq(fields.iter().copied()))
+}
+
 #[test]
 fn lp_canonical() {
     let m = Model::new("transport");
@@ -140,12 +144,12 @@ fn io_linear_writers_fold_param_coefficient() {
     objective!(m, Min, cost * x);
 
     let mps = to_mps_string(&m).unwrap();
-    assert!(mps.contains("x         OBJ       3"), "got:\n{mps}");
+    assert!(mps_record(&mps, &["x", "OBJ", "3"]), "got:\n{mps}");
     assert!(to_lp_string(&m).is_ok());
 
     m.set_param(cost, 5.0);
     let mps2 = to_mps_string(&m).unwrap();
-    assert!(mps2.contains("x         OBJ       5"), "got:\n{mps2}");
+    assert!(mps_record(&mps2, &["x", "OBJ", "5"]), "got:\n{mps2}");
 }
 
 #[cfg(feature = "io")]
@@ -371,18 +375,18 @@ fn mps_coefficients_and_rhs() {
     assert!(s.contains("ENDATA"));
 
     // Objective coefficients
-    assert!(s.contains("x         OBJ       3"));
-    assert!(s.contains("y         OBJ       4"));
+    assert!(mps_record(&s, &["x", "OBJ", "3"]));
+    assert!(mps_record(&s, &["y", "OBJ", "4"]));
 
     // Constraint coefficients
-    assert!(s.contains("x         c1        1"));
-    assert!(s.contains("y         c1        2"));
+    assert!(mps_record(&s, &["x", "c1", "1"]));
+    assert!(mps_record(&s, &["y", "c1", "2"]));
 
     // RHS for c1
-    assert!(s.contains("RHS       c1        14"));
+    assert!(mps_record(&s, &["RHS", "c1", "14"]));
 
     // y upper bound
-    assert!(s.contains("UP BND       y         4"));
+    assert!(mps_record(&s, &["UP", "BND", "y", "4"]));
 
     // Sense comment preserved
     assert!(s.contains("* sense: minimize"));
@@ -400,10 +404,10 @@ fn mps_fixed_variable_emits_fx_bound() {
 
     let s = oximo::io::to_mps_string(&m).unwrap();
 
-    // y is fixed, must appear as FX at col 2, value at col 25
-    assert!(s.contains(" FX BND       y         3.5"), "got:\n{s}");
+    // y is fixed and must appear as an FX bound record.
+    assert!(mps_record(&s, &["FX", "BND", "y", "3.5"]), "got:\n{s}");
     // x is not fixed, no FX line for x
-    assert!(!s.contains(" FX BND       x"), "got:\n{s}");
+    assert!(!mps_record(&s, &["FX", "BND", "x"]), "got:\n{s}");
     // y still appears in COLUMNS (constraint coefficients unchanged)
     assert!(s.contains('y'), "got:\n{s}");
 }
@@ -425,10 +429,10 @@ fn mps_free_and_integer_bounds() {
     assert!(mps.contains("'INTEND'"));
 
     // z is free
-    assert!(mps.contains("FR BND       z"));
+    assert!(mps_record(&mps, &["FR", "BND", "z"]));
 
     // y upper bound
-    assert!(mps.contains("UP BND       y         10"));
+    assert!(mps_record(&mps, &["UP", "BND", "y", "10"]));
 }
 
 #[cfg(feature = "io")]


### PR DESCRIPTION
## Description

This PR adds an MPS reader and also adds QCP/QP features to the MPS writer.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [] `cargo test --features gams` passes (requires GAMS)
- [] `cargo test --features gurobi` passes (requires Gurobi)
- [] `cargo test --features mosek` passes (requires MOSEK)
- [] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/33, https://github.com/oximo-rs/oximo/issues/42