### PR TITLE
oximo-io: avoid objective sense unwrap

### DIFF
--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -671,7 +671,8 @@ fn build_model(
         );
     }
     let e = lower(&m, &vars, obj)?;
-    match p.sense.unwrap() {
+    let sense = p.sense.ok_or_else(|| invalid_lp(1, 1, "missing Minimize or Maximize section"))?;
+    match sense {
         ObjectiveSense::Minimize => m.__minimize(e),
         ObjectiveSense::Maximize => m.__maximize(e),
     }

--- a/crates/oximo-io/tests/lp_reader.rs
+++ b/crates/oximo-io/tests/lp_reader.rs
@@ -206,6 +206,18 @@ fn content_after_end_is_rejected() {
 }
 
 #[test]
+fn missing_objective_sense_is_invalid_lp() {
+    let err = read_lp("Subject To\n c: x <= 1\nEnd\n".as_bytes()).unwrap_err();
+    match err {
+        IoError::InvalidLp { line, column, message } => {
+            assert_eq!((line, column), (1, 1));
+            assert!(message.contains("missing Minimize or Maximize section"));
+        }
+        other => panic!("expected InvalidLp, got {other:?}"),
+    }
+}
+
+#[test]
 fn malformed_input_has_lp_diagnostic() {
     let err =
         read_lp("Minimize\n obj: x\nSubject To\n bad: x <= nope\nEnd\n".as_bytes()).unwrap_err();


### PR DESCRIPTION
Replace the final LP objective-sense `unwrap()` with an `InvalidLp` error path and add coverage for an LP missing its objective section.

Closes #61

Tests:
- `cargo fmt --all -- --check`
- `cargo test -p oximo-io --locked`
- `cargo clippy -p oximo-io --all-targets --locked -- -D warnings`

Validation used Rust 1.89 because current `main` resolves `smol_str 0.3.6`, which requires Rust 1.89 even though the workspace still declares `rust-version = "1.85"`.

AI assistance: used an AI coding assistant for implementation support; I reviewed the diff and test results.
