### PR TITLE
Add SOS1 and SOS2 modeling API

### DIFF
--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -46,6 +46,9 @@ pub fn solve(
     opts: &BaronOptions,
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     let sense = model.objective().as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
     let (bar, var_order, con_order, soc_bounds) = build_bar(model, opts)?;
     let run = run_baron(&bar, opts, exec)?;
@@ -215,6 +218,9 @@ fn run_baron(bar: &str, opts: &BaronOptions, exec: Option<&str>) -> Result<Baron
 type BarParts = (String, Vec<VarId>, Vec<ConstraintId>, Vec<LinearTerms>);
 
 fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let arena = model.arena();
     let vars = model.variables();

--- a/crates/oximo-baron/tests/sos.rs
+++ b/crates/oximo-baron/tests/sos.rs
@@ -1,0 +1,16 @@
+use oximo_baron::{Baron, BaronOptions};
+use oximo_core::prelude::*;
+use oximo_solver::{Solver, SolverError};
+
+#[test]
+fn baron_rejects_sos_constraints_before_launching_executable() {
+    let model = Model::new("baron_sos");
+    variable!(model, x);
+    variable!(model, y);
+    sos_constraint!(model, choice, SOS1, [x, y]);
+    let mut solver = Baron::with_exec("definitely-not-a-baron");
+    assert!(matches!(
+        solver.solve(&model, &BaronOptions::default()),
+        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+    ));
+}

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -145,6 +145,9 @@ impl Problem {
 /// domains or a Clarabel setup failure, and [`SolverError::Nonlinear`] if an
 /// expression defeats extraction.
 pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     let problem = build_problem(model)?;
     let settings = build_settings(opts);
     let mut solver = DefaultSolver::new(
@@ -175,6 +178,9 @@ pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, Solv
 ///
 /// Panics if variable or constraint indices overflow `u32`.
 pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     build_problem_with(model, None)
 }
 

--- a/crates/oximo-clarabel/tests/sos.rs
+++ b/crates/oximo-clarabel/tests/sos.rs
@@ -1,0 +1,31 @@
+use oximo_clarabel::{Clarabel, ClarabelOptions};
+use oximo_core::prelude::*;
+use oximo_solver::{PersistentSolver, Solver, SolverError};
+
+fn sos_model() -> Model {
+    let m = Model::new("clarabel_sos");
+    variable!(m, x);
+    variable!(m, y);
+    sos_constraint!(m, choice, SOS1, [x, y]);
+    m
+}
+
+#[test]
+fn clarabel_rejects_sos_constraints() {
+    let model = sos_model();
+    let mut solver = Clarabel;
+    assert!(matches!(
+        solver.solve(&model, &ClarabelOptions::default()),
+        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+    ));
+}
+
+#[test]
+fn clarabel_persistent_rejects_sos_constraints() {
+    let model = sos_model();
+    let mut solver = Clarabel.persistent();
+    assert!(matches!(
+        solver.solve(&model, &ClarabelOptions::default()),
+        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+    ));
+}

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -62,17 +62,19 @@ Names are unique per registry. Registering a duplicate variable or constraint na
 
 ```rust,ignore
 m.num_variables()   // usize
-m.num_constraints() // algebraic + explicit SOC constraints
+m.num_constraints() // algebraic + SOC + SOS constraints
 m.variables()       // Ref<'_, Vec<Variable>>
 m.constraints()     // ModelConstraints<'_>
 m.constraints().algebraic()          // typed algebraic registry
 m.constraints().second_order_cones() // typed explicit-SOC registry
+m.constraints().special_ordered_sets() // typed SOS registry
 m.arena()          // Ref<'_, ExprArena>
 m.kind()           // ModelKind, cached, invalidated on change
 m.try_objective()  // Result<Objective, Error>
 m.variable_id("x") // Option<VarId>
 m.constraint_id("cap")      // Option<ConstraintId> (algebraic)
 m.soc_constraint_id("cone") // Option<SocConstraintId>
+m.sos_constraint_id("choice") // Option<SosConstraintId>
 ```
 
 `ModelConstraints::iter()` visits every declared constraint. Its `algebraic()`
@@ -170,6 +172,32 @@ constraint!(m, lhs >= rhs);                        // anonymous (auto-named _c0,
 constraint!(m, band, 1.0 <= e <= 3.0);             // two-sided range -> one constraint (expr bounds -> band_lo/band_hi)
 constraint!(m, name = format!("c_{k}"), e == rhs); // computed run-time name
 ```
+
+### Special ordered sets
+
+SOS1 and SOS2 constraints apply ordering weights to bare variables. SOS1 allows
+at most one nonzero member. SOS2 allows at most two adjacent nonzero members.
+Weights must be finite and unique within each set.
+
+```rust,ignore
+variable!(m, 0.0 <= choice_a <= 1.0);
+variable!(m, 0.0 <= choice_b <= 1.0);
+variable!(m, 0.0 <= choice_c <= 1.0);
+
+sos_constraint!(m, one_choice, SOS1, [choice_a, choice_b, choice_c]);
+sos_constraint!(m, adjacent_choice, SOS2, [choice_a, choice_b, choice_c]);
+sos_constraint!(m, weighted, SOS2, [
+    (choice_a, 10.0), (choice_b, 20.0), (choice_c, 30.0),
+]);
+```
+
+They are currently passed through only to backends with native SOS support.
+
+The indexed form creates one set for every key in the binder. The binder is
+required because the macro cannot infer an index domain from an `IndexedVar`:
+`choice[i in 0..n]` produces `choice[0]`, ..., `choice[n - 1]`. To create one
+SOS over a dynamically assembled collection, use
+`m.add_sos_constraint_auto_weights("choice", SosType::Sos1, members)`.
 
 ### Indexed family over a set
 

--- a/crates/oximo-core/src/display.rs
+++ b/crates/oximo-core/src/display.rs
@@ -283,6 +283,7 @@ impl fmt::Display for Model {
 mod tests {
     use super::*;
     use crate::constraint::Relate;
+    use crate::sos::SosType;
 
     #[test]
     fn full_model_snapshot() {
@@ -380,6 +381,23 @@ mod tests {
         let id = m.add_soc_constraint("q1", [x, y], t);
         assert_eq!(m.display_soc(id).to_string(), "q1: ||x, y|| <= t");
         assert!(format!("{m}").contains("  q1: ||x, y|| <= t\n"));
+    }
+
+    #[test]
+    fn sos_row_renders_after_soc_in_model_display() {
+        let m = Model::new("t");
+        let x = m.__var("x").build();
+        let y = m.__var("y").build();
+        let t = m.__var("t").lb(0.0).build();
+        m.add_soc_constraint("q1", [x, y], t);
+        let id = m.add_sos_constraint("choice", SosType::Sos1, [(x, 1.0), (y, 2.5)]);
+        m.__minimize(x + y);
+
+        assert_eq!(m.display_sos(id).to_string(), "choice: SOS1 [x: 1, y: 2.5]");
+        let out = format!("{m}");
+        let soc_pos = out.find("  q1: ||x, y|| <= t\n").expect("SOC block");
+        let sos_pos = out.find("  choice: SOS1 [x: 1, y: 2.5]\n").expect("SOS block");
+        assert!(soc_pos < sos_pos, "SOC must render before SOS:\n{out}");
     }
 
     #[test]

--- a/crates/oximo-core/src/display.rs
+++ b/crates/oximo-core/src/display.rs
@@ -13,6 +13,7 @@ use crate::domain::Domain;
 use crate::model::Model;
 use crate::objective::ObjectiveSense;
 use crate::soc::SocConstraintId;
+use crate::sos::SosConstraintId;
 use crate::var::{Variable, var_name};
 
 /// Compact `f64` rendering (shortest round-trip).
@@ -103,6 +104,32 @@ pub struct SocDisplay<'a> {
     id: SocConstraintId,
 }
 
+#[derive(Debug)]
+pub struct SosDisplay<'a> {
+    model: &'a Model,
+    id: SosConstraintId,
+}
+
+impl fmt::Display for SosDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let vars = self.model.variables.borrow();
+        let sos = self.model.sos_constraints.borrow();
+        let c = &sos[self.id.index()];
+        write!(f, "{}: {} [", c.name, c.sos_type.label())?;
+        for (i, member) in c.members.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{}: {}", var_name(&vars, member.variable), fmt_num(member.weight))?;
+        }
+        f.write_str("]")?;
+        if !c.active {
+            f.write_str(" (inactive)")?;
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for SocDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let arena = self.model.arena.borrow();
@@ -183,6 +210,11 @@ impl Model {
     pub fn display_soc(&self, id: SocConstraintId) -> SocDisplay<'_> {
         SocDisplay { model: self, id }
     }
+
+    #[must_use]
+    pub fn display_sos(&self, id: SosConstraintId) -> SosDisplay<'_> {
+        SosDisplay { model: self, id }
+    }
 }
 
 /// Pretty-print the whole model as readable algebra:
@@ -208,15 +240,20 @@ impl fmt::Display for Model {
         }
         let n_constraints = self.constraints.borrow().len();
         let n_socs = self.soc_constraints.borrow().len();
-        if n_constraints + n_socs > 0 {
+        let n_sos = self.sos_constraints.borrow().len();
+        if n_constraints + n_socs + n_sos > 0 {
             let n_constraints = u32::try_from(n_constraints).expect("constraint count fits u32");
             let n_socs = u32::try_from(n_socs).expect("soc count fits u32");
+            let n_sos = u32::try_from(n_sos).expect("sos count fits u32");
             writeln!(f, "s.t.")?;
             for i in 0..n_constraints {
                 writeln!(f, "  {}", self.display_constraint(ConstraintId(i)))?;
             }
             for i in 0..n_socs {
                 writeln!(f, "  {}", self.display_soc(SocConstraintId(i)))?;
+            }
+            for i in 0..n_sos {
+                writeln!(f, "  {}", self.display_sos(SosConstraintId(i)))?;
             }
         }
         {

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -17,11 +17,12 @@ pub mod param;
 pub mod prelude;
 pub mod set;
 pub mod soc;
+pub mod sos;
 pub mod sum;
 pub mod var;
 
 pub use constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
-pub use display::{ConstraintDisplay, ExprDisplay, ObjectiveDisplay, SocDisplay};
+pub use display::{ConstraintDisplay, ExprDisplay, ObjectiveDisplay, SocDisplay, SosDisplay};
 pub use domain::Domain;
 pub use error::{Error, Result};
 pub use indexed::{IndexedParam, IndexedVar};
@@ -32,6 +33,7 @@ pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
 pub use set::{Axis, FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};
 pub use soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
+pub use sos::{SosConstraint, SosConstraintId, SosMember, SosType};
 pub use sum::SumDomain;
 pub use var::{VarBuilder, Variable, var_name};
 
@@ -42,4 +44,6 @@ pub use oximo_expr::{
     render_expr, render_linear_terms,
 };
 
-pub use oximo_macros::{constraint, objective, param, set, soc_constraint, sum, variable};
+pub use oximo_macros::{
+    constraint, objective, param, set, soc_constraint, sos_constraint, sum, variable,
+};

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -14,6 +14,7 @@ use crate::objective::{Objective, ObjectiveSense};
 use crate::param::Parameter;
 use crate::set::{Axis, FromIndexKey, IndexKey, Set};
 use crate::soc::{SocConstraint, SocConstraintId, is_detected_soc};
+use crate::sos::{SosConstraint, SosConstraintId, SosMember, SosType, validate_members};
 use crate::var::{VarBuilder, Variable};
 
 const PAR_KIND_THRESHOLD: usize = 256;
@@ -50,13 +51,14 @@ pub enum ModelKind {
 
 /// A borrowed constraint from a [`Model`].
 ///
-/// Algebraic constraints and explicitly declared second-order-cone constraints
+/// Algebraic, explicitly declared second-order-cone, and SOS constraints
 /// retain their typed IDs and storage. This enum provides a unified inspection
 /// boundary without changing either representation.
 #[derive(Copy, Clone, Debug)]
 pub enum ConstraintRef<'a> {
     Algebraic { id: ConstraintId, constraint: &'a Constraint },
     SecondOrderCone { id: SocConstraintId, constraint: &'a SocConstraint },
+    SpecialOrderedSet { id: SosConstraintId, constraint: &'a SosConstraint },
 }
 
 /// Unified borrowed view of every constraint declared on a [`Model`].
@@ -64,11 +66,12 @@ pub enum ConstraintRef<'a> {
 /// The underlying algebraic and explicit-SOC registries remain separate, so
 /// backends can iterate a homogeneous slice without a per-constraint branch.
 /// [`Self::iter`] visits algebraic constraints in [`ConstraintId`] order,
-/// followed by explicit cones in [`SocConstraintId`] order.
+/// followed by explicit cones and SOS constraints in their respective ID order.
 #[derive(Debug)]
 pub struct ModelConstraints<'a> {
     algebraic: Ref<'a, Vec<Constraint>>,
     second_order_cones: Ref<'a, Vec<SocConstraint>>,
+    special_ordered_sets: Ref<'a, Vec<SosConstraint>>,
 }
 
 impl ModelConstraints<'_> {
@@ -80,6 +83,10 @@ impl ModelConstraints<'_> {
     /// Explicit second-order-cone constraints in [`SocConstraintId`] order.
     pub fn second_order_cones(&self) -> &[SocConstraint] {
         &self.second_order_cones
+    }
+
+    pub fn special_ordered_sets(&self) -> &[SosConstraint] {
+        &self.special_ordered_sets
     }
 
     /// Iterate over all declared constraints without allocating.
@@ -95,16 +102,22 @@ impl ModelConstraints<'_> {
             self.second_order_cones.iter().enumerate().map(|(index, constraint)| {
                 ConstraintRef::SecondOrderCone { id: SocConstraintId(index as u32), constraint }
             });
-        algebraic.chain(second_order_cones)
+        let special_ordered_sets =
+            self.special_ordered_sets.iter().enumerate().map(|(index, constraint)| {
+                ConstraintRef::SpecialOrderedSet { id: SosConstraintId(index as u32), constraint }
+            });
+        algebraic.chain(second_order_cones).chain(special_ordered_sets)
     }
 
-    /// Total number of algebraic and explicit second-order-cone constraints.
+    /// Total number of algebraic, SOC, and SOS constraints.
     pub fn len(&self) -> usize {
-        self.algebraic.len() + self.second_order_cones.len()
+        self.algebraic.len() + self.second_order_cones.len() + self.special_ordered_sets.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.algebraic.is_empty() && self.second_order_cones.is_empty()
+        self.algebraic.is_empty()
+            && self.second_order_cones.is_empty()
+            && self.special_ordered_sets.is_empty()
     }
 }
 
@@ -127,6 +140,8 @@ pub struct Model {
     pub(crate) constraint_names: RefCell<FxHashMap<SmolStr, ConstraintId>>,
     pub(crate) soc_constraints: RefCell<Vec<SocConstraint>>,
     pub(crate) soc_names: RefCell<FxHashMap<SmolStr, SocConstraintId>>,
+    pub(crate) sos_constraints: RefCell<Vec<SosConstraint>>,
+    pub(crate) sos_names: RefCell<FxHashMap<SmolStr, SosConstraintId>>,
     pub(crate) objective: RefCell<Option<Objective>>,
     objective_declared: Cell<bool>,
     cached_kind: Cell<Option<ModelKind>>,
@@ -143,6 +158,7 @@ impl std::fmt::Debug for Model {
             .field("params", &self.parameters.borrow().len())
             .field("constraints", &self.constraints.borrow().len())
             .field("soc_constraints", &self.soc_constraints.borrow().len())
+            .field("sos_constraints", &self.sos_constraints.borrow().len())
             .field("has_objective", &self.objective.borrow().is_some())
             .field("feasibility", &self.is_feasibility())
             .finish()
@@ -162,6 +178,8 @@ impl Model {
             constraint_names: RefCell::new(FxHashMap::default()),
             soc_constraints: RefCell::new(Vec::new()),
             soc_names: RefCell::new(FxHashMap::default()),
+            sos_constraints: RefCell::new(Vec::new()),
+            sos_names: RefCell::new(FxHashMap::default()),
             objective: RefCell::new(None),
             objective_declared: Cell::new(false),
             cached_kind: Cell::new(None),
@@ -654,18 +672,21 @@ impl Model {
         }
     }
 
-    /// Unified view of every algebraic and explicit second-order-cone
-    /// constraint declared on this model.
+    /// Unified view of every algebraic, explicit SOC, and SOS constraint
+    /// declared on this model.
     pub fn constraints(&self) -> ModelConstraints<'_> {
         ModelConstraints {
             algebraic: self.constraints.borrow(),
             second_order_cones: self.soc_constraints.borrow(),
+            special_ordered_sets: self.sos_constraints.borrow(),
         }
     }
 
-    /// Total number of algebraic and explicit second-order-cone constraints.
+    /// Total number of algebraic, SOC, and SOS constraints.
     pub fn num_constraints(&self) -> usize {
-        self.constraints.borrow().len() + self.soc_constraints.borrow().len()
+        self.constraints.borrow().len()
+            + self.soc_constraints.borrow().len()
+            + self.sos_constraints.borrow().len()
     }
 
     pub fn constraint_id(&self, name: &str) -> Option<ConstraintId> {
@@ -792,6 +813,155 @@ impl Model {
         !self.soc_constraints.borrow().is_empty()
     }
 
+    /// Register an explicit SOS1 or SOS2 constraint. Members must be bare
+    /// variables belonging to this model and have finite, unique weights.
+    ///
+    /// # Panics
+    ///
+    /// Panics when a member belongs to another model, is not a bare variable,
+    /// or the name, members, variables, or weights violate SOS invariants.
+    pub fn add_sos_constraint<'a>(
+        &'a self,
+        name: impl Into<SmolStr>,
+        sos_type: SosType,
+        members: impl IntoIterator<Item = (Expr<'a>, f64)>,
+    ) -> SosConstraintId {
+        let name = name.into();
+        let members: Vec<SosMember> = members
+            .into_iter()
+            .map(|(expr, weight)| {
+                assert!(
+                    std::ptr::eq(expr.arena, &raw const self.arena),
+                    "SOS member belongs to another model"
+                );
+                let variable = expr.var_id().expect("SOS members must be bare variables");
+                SosMember { variable, weight }
+            })
+            .collect();
+        validate_members(&name, &members);
+        let mut by_name = self.sos_names.borrow_mut();
+        assert!(!by_name.contains_key(&name), "SOS constraint name {name:?} already registered");
+        let mut all = self.sos_constraints.borrow_mut();
+        let id = SosConstraintId(u32::try_from(all.len()).expect("SOS constraint count overflow"));
+        all.push(SosConstraint { name: name.clone(), sos_type, members, active: true });
+        by_name.insert(name, id);
+        self.cached_kind.set(None);
+        id
+    }
+
+    /// Register an SOS1 or SOS2 constraint with consecutive positional
+    /// weights `1, 2, ...` inferred from the member order.
+    ///
+    /// This is a convenience for models where the ordering is already
+    /// represented by the iterator order. Use [`Self::add_sos_constraint`]
+    /// when the weights are meaningful values that should be preserved.
+    ///
+    /// # Panics
+    ///
+    /// Panics under the same conditions as [`Self::add_sos_constraint`], or
+    /// when the iterator contains more than `u32::MAX` members.
+    pub fn add_sos_constraint_auto_weights<'a>(
+        &'a self,
+        name: impl Into<SmolStr>,
+        sos_type: SosType,
+        variables: impl IntoIterator<Item = Expr<'a>>,
+    ) -> SosConstraintId {
+        self.add_sos_constraint(
+            name,
+            sos_type,
+            variables.into_iter().enumerate().map(|(index, variable)| {
+                let weight = index
+                    .checked_add(1)
+                    .and_then(|index| u32::try_from(index).ok())
+                    .expect("SOS member count exceeds positional weight range");
+                (variable, f64::from(weight))
+            }),
+        )
+    }
+
+    fn next_auto_sos_name(&self) -> SmolStr {
+        loop {
+            let n = self.auto_seq.get();
+            self.auto_seq.set(n + 1);
+            let candidate: SmolStr = format!("_sos{n}").into();
+            if !self.sos_names.borrow().contains_key(&candidate) {
+                break candidate;
+            }
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn __add_sos_constraint_auto<'a>(
+        &'a self,
+        sos_type: SosType,
+        members: impl IntoIterator<Item = (Expr<'a>, f64)>,
+    ) -> SosConstraintId {
+        self.add_sos_constraint(self.next_auto_sos_name(), sos_type, members)
+    }
+
+    #[doc(hidden)]
+    pub fn __add_sos_constraint_auto_weights<'a>(
+        &'a self,
+        sos_type: SosType,
+        variables: impl IntoIterator<Item = Expr<'a>>,
+    ) -> SosConstraintId {
+        self.add_sos_constraint_auto_weights(self.next_auto_sos_name(), sos_type, variables)
+    }
+
+    #[doc(hidden)]
+    pub fn __add_sos_constraints_over<'a, K, T, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        sos_type: SosType,
+        mut rule: F,
+    ) where
+        K: FromIndexKey,
+        T: IntoIterator<Item = (Expr<'a>, f64)>,
+        F: FnMut(K) -> T,
+    {
+        for key in set {
+            let typed = K::from_index_key(&key);
+            let name: SmolStr = format_index_name(name_prefix, &key).into();
+            self.add_sos_constraint(name, sos_type, rule(typed));
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn __add_sos_constraints_over_auto_weights<'a, K, T, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        sos_type: SosType,
+        mut rule: F,
+    ) where
+        K: FromIndexKey,
+        T: IntoIterator<Item = Expr<'a>>,
+        F: FnMut(K) -> T,
+    {
+        for key in set {
+            let typed = K::from_index_key(&key);
+            let name: SmolStr = format_index_name(name_prefix, &key).into();
+            self.add_sos_constraint_auto_weights(name, sos_type, rule(typed));
+        }
+    }
+
+    pub fn sos_constraints(&self) -> Ref<'_, Vec<SosConstraint>> {
+        self.sos_constraints.borrow()
+    }
+
+    pub fn num_sos_constraints(&self) -> usize {
+        self.sos_constraints.borrow().len()
+    }
+
+    pub fn sos_constraint_id(&self, name: &str) -> Option<SosConstraintId> {
+        self.sos_names.borrow().get(name).copied()
+    }
+
+    pub fn has_sos_constraints(&self) -> bool {
+        !self.sos_constraints.borrow().is_empty()
+    }
+
     // Objective
 
     /// Macro-facing entry point backing `objective!(m, Min, ..)`. Not part of the
@@ -897,7 +1067,8 @@ impl Model {
     fn infer_kind_impl(&self, parallel: Option<bool>) -> ModelKind {
         let arena = self.arena.borrow();
         let vars = self.variables.borrow();
-        let has_int = vars.iter().any(|v| v.domain.is_integer());
+        let has_int =
+            vars.iter().any(|v| v.domain.is_integer()) || !self.sos_constraints.borrow().is_empty();
         let obj_class = self
             .objective
             .borrow()
@@ -1238,6 +1409,7 @@ mod tests {
         assert!(constraints.iter().all(|entry| match entry {
             ConstraintRef::Algebraic { constraint, .. } => !constraint.active,
             ConstraintRef::SecondOrderCone { constraint, .. } => !constraint.active,
+            ConstraintRef::SpecialOrderedSet { constraint, .. } => !constraint.active,
         }));
     }
 

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -1401,11 +1401,13 @@ mod tests {
         let t = m.__var("t").lb(0.0).build();
         m.__add_constraint("row", x.le(1.0));
         m.add_soc_constraint("cone", [x], t);
+        m.add_sos_constraint("sos", SosType::Sos1, [(x, 1.0)]);
         m.constraints.borrow_mut()[0].active = false;
         m.soc_constraints.borrow_mut()[0].active = false;
+        m.sos_constraints.borrow_mut()[0].active = false;
 
         let constraints = m.constraints();
-        assert_eq!(constraints.len(), 2);
+        assert_eq!(constraints.len(), 3);
         assert!(constraints.iter().all(|entry| match entry {
             ConstraintRef::Algebraic { constraint, .. } => !constraint.active,
             ConstraintRef::SecondOrderCone { constraint, .. } => !constraint.active,

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -9,8 +9,11 @@ pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
 pub use crate::soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
+pub use crate::sos::{SosConstraint, SosConstraintId, SosMember, SosType};
 pub use crate::sum::SumDomain;
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};
 
-pub use oximo_macros::{constraint, objective, param, set, soc_constraint, sum, variable};
+pub use oximo_macros::{
+    constraint, objective, param, set, soc_constraint, sos_constraint, sum, variable,
+};

--- a/crates/oximo-core/src/sos.rs
+++ b/crates/oximo-core/src/sos.rs
@@ -1,0 +1,68 @@
+use std::collections::HashSet;
+
+use oximo_expr::VarId;
+use smol_str::SmolStr;
+
+/// The two standard special ordered set types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SosType {
+    /// At most one member may be nonzero.
+    Sos1,
+    /// At most two adjacent (by weight) members may be nonzero.
+    Sos2,
+}
+
+impl SosType {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Sos1 => "SOS1",
+            Self::Sos2 => "SOS2",
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SosMember {
+    pub variable: VarId,
+    pub weight: f64,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SosConstraintId(pub u32);
+
+impl SosConstraintId {
+    #[inline]
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// An explicit SOS1 or SOS2 constraint.
+#[derive(Clone, Debug)]
+pub struct SosConstraint {
+    pub name: SmolStr,
+    pub sos_type: SosType,
+    pub members: Vec<SosMember>,
+    pub active: bool,
+}
+
+/// Validate an SOS member list before it is stored in a model.
+pub(crate) fn validate_members(name: &str, members: &[SosMember]) {
+    assert!(!members.is_empty(), "SOS constraint {name:?} has no members");
+    let mut vars = HashSet::with_capacity(members.len());
+    for member in members {
+        assert!(member.weight.is_finite(), "SOS constraint {name:?} has a non-finite weight");
+        assert!(
+            vars.insert(member.variable),
+            "SOS constraint {name:?} contains a duplicate variable"
+        );
+    }
+    #[expect(clippy::float_cmp, reason = "SOS weights must be exactly unique")]
+    for (i, member) in members.iter().enumerate() {
+        assert!(
+            !members[..i].iter().any(|other| other.weight == member.weight),
+            "SOS constraint {name:?} contains duplicate weights"
+        );
+    }
+}

--- a/crates/oximo-core/src/sos.rs
+++ b/crates/oximo-core/src/sos.rs
@@ -58,11 +58,12 @@ pub(crate) fn validate_members(name: &str, members: &[SosMember]) {
             "SOS constraint {name:?} contains a duplicate variable"
         );
     }
-    #[expect(clippy::float_cmp, reason = "SOS weights must be exactly unique")]
-    for (i, member) in members.iter().enumerate() {
-        assert!(
-            !members[..i].iter().any(|other| other.weight == member.weight),
-            "SOS constraint {name:?} contains duplicate weights"
-        );
+    let mut weights = HashSet::with_capacity(members.len());
+    for member in members {
+        let key = match member.weight.to_bits() {
+            0 | 0x8000_0000_0000_0000 => 0,
+            bits => bits,
+        };
+        assert!(weights.insert(key), "SOS constraint {name:?} contains duplicate weights");
     }
 }

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -358,18 +358,22 @@ fn unified_constraints_preserve_typed_views_ids_and_order() {
     variable!(m, t >= 0.0);
     constraint!(m, shared, x <= 1.0);
     let soc_id = m.add_soc_constraint("shared", [x], t);
+    let sos_id = m.add_sos_constraint("sos", SosType::Sos1, [(x, 1.0)]);
 
-    assert_eq!(m.num_constraints(), 2);
+    assert_eq!(m.num_constraints(), 3);
     assert_eq!(m.constraints().algebraic().len(), 1);
     assert_eq!(m.num_soc_constraints(), 1);
+    assert_eq!(m.num_sos_constraints(), 1);
     assert_eq!(m.constraint_id("shared"), Some(ConstraintId(0)));
     assert_eq!(m.soc_constraint_id("shared"), Some(soc_id));
+    assert_eq!(m.sos_constraint_id("sos"), Some(sos_id));
 
     let constraints = m.constraints();
-    assert_eq!(constraints.len(), 2);
+    assert_eq!(constraints.len(), 3);
     assert!(!constraints.is_empty());
     assert_eq!(constraints.algebraic()[0].name, "shared");
     assert_eq!(constraints.second_order_cones()[0].name, "shared");
+    assert_eq!(constraints.special_ordered_sets()[0].name, "sos");
 
     let mut iter = constraints.iter();
     match iter.next().expect("algebraic constraint") {
@@ -387,6 +391,14 @@ fn unified_constraints_preserve_typed_views_ids_and_order() {
         }
         ConstraintRef::Algebraic { .. } => panic!("explicit cones come second"),
         ConstraintRef::SpecialOrderedSet { .. } => panic!("expected SOC constraint"),
+    }
+    match iter.next().expect("SOS constraint") {
+        ConstraintRef::SpecialOrderedSet { id, constraint } => {
+            assert_eq!(id, sos_id);
+            assert_eq!(constraint.name, "sos");
+        }
+        ConstraintRef::Algebraic { .. } => panic!("algebraic constraints come first"),
+        ConstraintRef::SecondOrderCone { .. } => panic!("SOS constraints come last"),
     }
     assert!(iter.next().is_none());
 }

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -378,6 +378,7 @@ fn unified_constraints_preserve_typed_views_ids_and_order() {
             assert_eq!(constraint.name, "shared");
         }
         ConstraintRef::SecondOrderCone { .. } => panic!("algebraic constraints come first"),
+        ConstraintRef::SpecialOrderedSet { .. } => panic!("SOS constraints come last"),
     }
     match iter.next().expect("SOC constraint") {
         ConstraintRef::SecondOrderCone { id, constraint } => {
@@ -385,6 +386,7 @@ fn unified_constraints_preserve_typed_views_ids_and_order() {
             assert_eq!(constraint.name, "shared");
         }
         ConstraintRef::Algebraic { .. } => panic!("explicit cones come second"),
+        ConstraintRef::SpecialOrderedSet { .. } => panic!("expected SOC constraint"),
     }
     assert!(iter.next().is_none());
 }

--- a/crates/oximo-core/tests/sos.rs
+++ b/crates/oximo-core/tests/sos.rs
@@ -1,0 +1,74 @@
+use oximo_core::prelude::*;
+
+#[test]
+fn sos_macros_register_and_promote_kind() {
+    let m = Model::new("sos");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, z);
+    objective!(m, Min, x + y + z);
+    sos_constraint!(m, first, SOS1, [(x, 1.0), (y, 2.0)]);
+    sos_constraint!(m, curve, SOS2, [(x, 1.0), (y, 2.0), (z, 3.0)]);
+    sos_constraint!(m, inferred, SOS1, [x, y, z]);
+    assert_eq!(m.kind(), ModelKind::MILP);
+    assert_eq!(m.num_sos_constraints(), 3);
+    assert_eq!(m.sos_constraint_id("curve"), Some(SosConstraintId(1)));
+    assert_eq!(m.sos_constraints()[1].sos_type, SosType::Sos2);
+    assert_eq!(
+        m.sos_constraints()[2].members.iter().map(|m| m.weight).collect::<Vec<_>>(),
+        [1.0, 2.0, 3.0]
+    );
+}
+
+#[test]
+fn sos_family_and_auto_name_work() {
+    let m = Model::new("sos_family");
+    variable!(m, x[i in 0..2]);
+    sos_constraint!(m, family[i in 0..2], SOS1, [(x[i], 1.0)]);
+    sos_constraint!(m, SOS2, [(x[0], 1.0), (x[1], 2.0)]);
+    assert_eq!(m.sos_constraints()[0].name, "family[0]");
+    assert!(m.sos_constraints()[2].name.starts_with("_sos"));
+}
+
+#[test]
+fn sos_indexed_family_infers_weights() {
+    let m = Model::new("sos_indexed_family");
+    variable!(m, x[i in 0..2]);
+    variable!(m, y[i in 0..2]);
+    variable!(m, z[i in 0..2]);
+    sos_constraint!(m, choice[i in 0..2], SOS1, [x[i], y[i], z[i]]);
+
+    assert_eq!(m.num_sos_constraints(), 2);
+    assert_eq!(m.sos_constraints()[0].name, "choice[0]");
+    assert_eq!(m.sos_constraints()[1].name, "choice[1]");
+    for constraint in m.sos_constraints().iter() {
+        assert_eq!(
+            constraint.members.iter().map(|m| m.weight).collect::<Vec<_>>(),
+            [1.0, 2.0, 3.0]
+        );
+    }
+}
+
+#[test]
+fn sos_auto_weight_method_accepts_dynamic_members() {
+    let m = Model::new("sos_dynamic");
+    variable!(m, x);
+    variable!(m, y);
+    variable!(m, z);
+    let members = vec![x, y, z];
+    m.add_sos_constraint_auto_weights("dynamic", SosType::Sos2, members);
+
+    assert_eq!(
+        m.sos_constraints()[0].members.iter().map(|m| m.weight).collect::<Vec<_>>(),
+        [1.0, 2.0, 3.0]
+    );
+}
+
+#[test]
+#[should_panic(expected = "duplicate weights")]
+fn sos_rejects_duplicate_weights() {
+    let m = Model::new("bad");
+    variable!(m, x);
+    variable!(m, y);
+    m.add_sos_constraint("bad", SosType::Sos2, [(x, 1.0), (y, 1.0)]);
+}

--- a/crates/oximo-core/tests/sos.rs
+++ b/crates/oximo-core/tests/sos.rs
@@ -139,3 +139,12 @@ fn sos_rejects_duplicate_weights() {
     variable!(m, y);
     m.add_sos_constraint("bad", SosType::Sos2, [(x, 1.0), (y, 1.0)]);
 }
+
+#[test]
+#[should_panic(expected = "duplicate weights")]
+fn sos_rejects_signed_zero_duplicate_weights() {
+    let m = Model::new("signed_zero_weights");
+    variable!(m, x);
+    variable!(m, y);
+    m.add_sos_constraint("signed_zero", SosType::Sos1, [(x, 0.0), (y, -0.0)]);
+}

--- a/crates/oximo-core/tests/sos.rs
+++ b/crates/oximo-core/tests/sos.rs
@@ -65,6 +65,73 @@ fn sos_auto_weight_method_accepts_dynamic_members() {
 }
 
 #[test]
+fn sos_registry_and_display_are_complete() {
+    let m = Model::new("sos_display");
+    variable!(m, x);
+    variable!(m, y);
+    let id = m.add_sos_constraint("choice", SosType::Sos2, [(x, 10.0), (y, 20.0)]);
+
+    assert_eq!(id.index(), 0);
+    assert_eq!(SosType::Sos1.label(), "SOS1");
+    assert_eq!(SosType::Sos2.label(), "SOS2");
+    assert!(m.has_sos_constraints());
+    assert_eq!(m.sos_constraint_id("choice"), Some(id));
+    assert_eq!(m.sos_constraint_id("missing"), None);
+    assert_eq!(m.display_sos(id).to_string(), "choice: SOS2 [x: 10, y: 20]");
+    assert!(m.to_string().contains("choice: SOS2 [x: 10, y: 20]"));
+    assert_eq!(m.constraints().special_ordered_sets()[0].name, "choice");
+}
+
+#[test]
+#[should_panic(expected = "has no members")]
+fn sos_rejects_empty_members() {
+    let m = Model::new("empty");
+    m.add_sos_constraint("empty", SosType::Sos1, []);
+}
+
+#[test]
+#[should_panic(expected = "duplicate variable")]
+fn sos_rejects_duplicate_variables() {
+    let m = Model::new("duplicate_variable");
+    variable!(m, x);
+    m.add_sos_constraint("duplicate", SosType::Sos1, [(x, 1.0), (x, 2.0)]);
+}
+
+#[test]
+#[should_panic(expected = "non-finite weight")]
+fn sos_rejects_nonfinite_weights() {
+    let m = Model::new("nonfinite");
+    variable!(m, x);
+    m.add_sos_constraint("nonfinite", SosType::Sos1, [(x, f64::NAN)]);
+}
+
+#[test]
+#[should_panic(expected = "must be bare variables")]
+fn sos_rejects_compound_members() {
+    let m = Model::new("compound");
+    variable!(m, x);
+    m.add_sos_constraint("compound", SosType::Sos1, [(x + 1.0, 1.0)]);
+}
+
+#[test]
+#[should_panic(expected = "belongs to another model")]
+fn sos_rejects_foreign_members() {
+    let m = Model::new("owner");
+    let other = Model::new("other");
+    variable!(other, x);
+    m.add_sos_constraint("foreign", SosType::Sos1, [(x, 1.0)]);
+}
+
+#[test]
+#[should_panic(expected = "already registered")]
+fn sos_rejects_duplicate_names() {
+    let m = Model::new("duplicate_name");
+    variable!(m, x);
+    m.add_sos_constraint("same", SosType::Sos1, [(x, 1.0)]);
+    m.add_sos_constraint("same", SosType::Sos1, [(x, 2.0)]);
+}
+
+#[test]
 #[should_panic(expected = "duplicate weights")]
 fn sos_rejects_duplicate_weights() {
     let m = Model::new("bad");

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -41,6 +41,9 @@ pub fn solve(
     opts: &GamsOptions,
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     validate_solver(opts, kind)?;

--- a/crates/oximo-gams/tests/sos.rs
+++ b/crates/oximo-gams/tests/sos.rs
@@ -1,0 +1,16 @@
+use oximo_core::prelude::*;
+use oximo_gams::{Gams, GamsOptions};
+use oximo_solver::{Solver, SolverError};
+
+#[test]
+fn gams_rejects_sos_constraints_before_launching_executable() {
+    let model = Model::new("gams_sos");
+    variable!(model, x);
+    variable!(model, y);
+    sos_constraint!(model, choice, SOS1, [x, y]);
+    let mut solver = Gams::with_exec("definitely-not-a-gams");
+    assert!(matches!(
+        solver.solve(&model, &GamsOptions::default()),
+        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+    ));
+}

--- a/crates/oximo-gurobi/src/lib.rs
+++ b/crates/oximo-gurobi/src/lib.rs
@@ -16,7 +16,7 @@ pub use options::{GurobiOptions, GurobiPresolve};
 pub use persistent::GurobiPersistent;
 pub use translate::solve;
 
-use oximo_core::{Model, ModelKind};
+use oximo_core::{Model, ModelKind, SosType};
 use oximo_solver::{
     Iis, InfeasibilityDiagnosis, PersistentSolver, Solver, SolverError, SolverResult,
 };
@@ -61,6 +61,10 @@ impl Solver for Gurobi {
 
     fn supports(&self, kind: ModelKind) -> bool {
         supported(kind)
+    }
+
+    fn supports_sos(&self, _sos_type: SosType) -> bool {
+        true
     }
 
     fn solve(&mut self, model: &Model, opts: &GurobiOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-gurobi/src/persistent.rs
+++ b/crates/oximo-gurobi/src/persistent.rs
@@ -1,5 +1,5 @@
 use gurobi_rs::prelude::*;
-use oximo_core::{Model, ModelKind};
+use oximo_core::{Model, ModelKind, SosType};
 use oximo_solver::{Iis, Snapshot, Solver, SolverError, SolverResult, snapshot};
 
 use crate::GurobiOptions;
@@ -218,6 +218,10 @@ impl Solver for GurobiPersistent {
 
     fn supports(&self, kind: ModelKind) -> bool {
         crate::supported(kind)
+    }
+
+    fn supports_sos(&self, _sos_type: SosType) -> bool {
+        true
     }
 
     fn solve(&mut self, model: &Model, opts: &GurobiOptions) -> Result<SolverResult, SolverError> {

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -54,7 +54,7 @@ pub(crate) struct Built {
     pub constrs: Vec<ConstraintHandle>,
     pub objective_generated: Vec<GeneratedConstraint>,
     pub soc_rows: Vec<SocHandle>,
-    pub sos: Vec<gurobi_rs::SOS>,
+    pub sos: Vec<(SosConstraintId, gurobi_rs::SOS)>,
     pub obj_constant: f64,
     pub has_semi: bool,
 }
@@ -360,10 +360,9 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
         }
     }
 
-    for (i, sos) in built.sos.iter().enumerate() {
+    for (id, sos) in &built.sos {
         if model.get_obj_attr(attr::IISSOS, sos).map_err(map_gurobi_err)? != 0 {
-            iis.sos_constraints
-                .push(SosConstraintId(u32::try_from(i).expect("sos index fits u32")));
+            iis.sos_constraints.push(*id);
         }
     }
 
@@ -420,18 +419,27 @@ fn add_sos_constraints(
     constraints: &[SosConstraint],
     gurobi_model: &mut gurobi_rs::Model,
     gurobi_vars: &[gurobi_rs::Var],
-) -> Result<Vec<gurobi_rs::SOS>, SolverError> {
-    constraints
-        .iter()
-        .map(|s| {
+) -> Result<Vec<(SosConstraintId, gurobi_rs::SOS)>, SolverError> {
+    active_sos_constraints(constraints)
+        .map(|(id, s)| {
             let members = s.members.iter().map(|m| (gurobi_vars[m.variable.index()], m.weight));
             let ty = match s.sos_type {
                 SosType::Sos1 => SOSType::Ty1,
                 SosType::Sos2 => SOSType::Ty2,
             };
-            gurobi_model.add_sos(members, ty).map_err(map_gurobi_err)
+            gurobi_model.add_sos(members, ty).map(|handle| (id, handle)).map_err(map_gurobi_err)
         })
         .collect()
+}
+
+fn active_sos_constraints(
+    constraints: &[SosConstraint],
+) -> impl Iterator<Item = (SosConstraintId, &SosConstraint)> {
+    constraints.iter().enumerate().filter(|(_, constraint)| constraint.active).map(
+        |(index, constraint)| {
+            (SosConstraintId(u32::try_from(index).expect("sos index fits u32")), constraint)
+        },
+    )
 }
 
 fn apply_initial_values(
@@ -982,6 +990,8 @@ fn map_status(status: Status) -> TerminationStatus {
 
 #[cfg(test)]
 mod status_tests {
+    use oximo_core::{SosConstraint, SosMember, VarId};
+
     use super::*;
 
     #[test]
@@ -1001,6 +1011,32 @@ mod status_tests {
         assert_eq!(map_status(Status::MemLimit), TerminationStatus::MemoryLimit);
         assert_eq!(map_status(Status::LocallyInfeasible), TerminationStatus::LocallyInfeasible);
         assert_eq!(map_status(Status::Interrupted), TerminationStatus::Interrupted);
+    }
+
+    #[test]
+    fn inactive_sos_constraints_are_skipped_without_compacting_ids() {
+        let constraints = vec![
+            SosConstraint {
+                name: "inactive".into(),
+                sos_type: SosType::Sos1,
+                members: vec![SosMember { variable: VarId(0), weight: 1.0 }],
+                active: false,
+            },
+            SosConstraint {
+                name: "first".into(),
+                sos_type: SosType::Sos1,
+                members: vec![SosMember { variable: VarId(1), weight: 1.0 }],
+                active: true,
+            },
+            SosConstraint {
+                name: "second".into(),
+                sos_type: SosType::Sos2,
+                members: vec![SosMember { variable: VarId(2), weight: 1.0 }],
+                active: true,
+            },
+        ];
+        let ids: Vec<_> = active_sos_constraints(&constraints).map(|(id, _)| id).collect();
+        assert_eq!(ids, [SosConstraintId(1), SosConstraintId(2)]);
     }
 }
 

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -5,7 +5,7 @@ use gurobi_rs::expr::{LinExpr, QuadExpr};
 use gurobi_rs::prelude::*;
 use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, SocConstraint,
-    SocConstraintId, VarId, Variable, var_name,
+    SocConstraintId, SosConstraint, SosConstraintId, SosType, VarId, Variable, var_name,
 };
 use oximo_expr::{ExprArena, ExprId, LinearTerms, describe_nonlinear_term, extract_linear};
 use oximo_solver::{
@@ -54,6 +54,7 @@ pub(crate) struct Built {
     pub constrs: Vec<ConstraintHandle>,
     pub objective_generated: Vec<GeneratedConstraint>,
     pub soc_rows: Vec<SocHandle>,
+    pub sos: Vec<gurobi_rs::SOS>,
     pub obj_constant: f64,
     pub has_semi: bool,
 }
@@ -82,6 +83,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     let model_constraints = model.constraints();
     let constraints = model_constraints.algebraic();
     let socs = model.soc_constraints();
+    let sos = model.sos_constraints();
     let objective = model.objective();
     let has_semi = vars.iter().any(|v| v.domain.semi_threshold().is_some());
 
@@ -95,6 +97,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     let gurobi_constrs =
         add_constraints(&arena, constraints, &mut gurobi_model, &gurobi_vars, &mut aux_counter)?;
     let soc_rows = add_soc_rows(&arena, &vars, &socs, &mut gurobi_model, &gurobi_vars)?;
+    let special_ordered_sets = add_sos_constraints(&sos, &mut gurobi_model, &gurobi_vars)?;
 
     let (obj_constant, objective_generated) = match objective.as_ref() {
         Some(o) => set_objective(
@@ -126,6 +129,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
         constrs: gurobi_constrs,
         objective_generated,
         soc_rows,
+        sos: special_ordered_sets,
         obj_constant,
         has_semi,
     })
@@ -356,6 +360,13 @@ fn read_iis(built: &Built) -> Result<Iis, SolverError> {
         }
     }
 
+    for (i, sos) in built.sos.iter().enumerate() {
+        if model.get_obj_attr(attr::IISSOS, sos).map_err(map_gurobi_err)? != 0 {
+            iis.sos_constraints
+                .push(SosConstraintId(u32::try_from(i).expect("sos index fits u32")));
+        }
+    }
+
     // Only model variables are scanned.
     for (i, v) in built.vars.iter().enumerate() {
         let id = VarId(u32::try_from(i).expect("var index fits u32"));
@@ -403,6 +414,24 @@ fn add_variables(
         gurobi_rs::VarSpec::new(v.name.as_str(), vtype, 0.0, floor, v.ub, [])
     });
     gurobi_model.add_vars(specs).map_err(map_gurobi_err)
+}
+
+fn add_sos_constraints(
+    constraints: &[SosConstraint],
+    gurobi_model: &mut gurobi_rs::Model,
+    gurobi_vars: &[gurobi_rs::Var],
+) -> Result<Vec<gurobi_rs::SOS>, SolverError> {
+    constraints
+        .iter()
+        .map(|s| {
+            let members = s.members.iter().map(|m| (gurobi_vars[m.variable.index()], m.weight));
+            let ty = match s.sos_type {
+                SosType::Sos1 => SOSType::Ty1,
+                SosType::Sos2 => SOSType::Ty2,
+            };
+            gurobi_model.add_sos(members, ty).map_err(map_gurobi_err)
+        })
+        .collect()
 }
 
 fn apply_initial_values(

--- a/crates/oximo-gurobi/tests/sos.rs
+++ b/crates/oximo-gurobi/tests/sos.rs
@@ -1,0 +1,20 @@
+use oximo_core::prelude::*;
+use oximo_gurobi::{Gurobi, GurobiOptions};
+use oximo_solver::Solver;
+
+#[test]
+fn native_sos1_and_sos2_solve() {
+    let m = Model::new("sos");
+    variable!(m, 0.0 <= x <= 10.0);
+    variable!(m, 0.0 <= y <= 20.0);
+    variable!(m, 0.0 <= z <= 30.0);
+    objective!(m, Max, x + y + z);
+    sos_constraint!(m, one, SOS1, [(x, 1.0), (y, 2.0)]);
+    sos_constraint!(m, two, SOS2, [(x, 1.0), (y, 2.0), (z, 3.0)]);
+    assert!(Gurobi.supports_model(&m));
+    let result = Gurobi.solve(&m, &GurobiOptions::default()).expect("Gurobi SOS solve");
+    assert!(result.has_solution());
+    assert_eq!(m.kind(), ModelKind::MILP);
+    assert!(result.value_of(y).unwrap() > 19.0);
+    assert!(result.value_of(x).unwrap().abs() < 1e-6);
+}

--- a/crates/oximo-gurobi/tests/sos.rs
+++ b/crates/oximo-gurobi/tests/sos.rs
@@ -18,3 +18,23 @@ fn native_sos1_and_sos2_solve() {
     assert!(result.value_of(y).unwrap() > 19.0);
     assert!(result.value_of(x).unwrap().abs() < 1e-6);
 }
+
+#[test]
+fn native_sos2_rejects_nonadjacent_optimum() {
+    let m = Model::new("sos2_adjacency");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    variable!(m, 0.0 <= z <= 1.0);
+    constraint!(m, budget, x + y + z <= 2.0);
+    objective!(m, Max, x + z);
+    sos_constraint!(m, adjacent, SOS2, [(x, 1.0), (y, 2.0), (z, 3.0)]);
+
+    let result = Gurobi.solve(&m, &GurobiOptions::default()).expect("Gurobi SOS2 solve");
+    let x_value = result.value_of(x).expect("x solution");
+    let z_value = result.value_of(z).expect("z solution");
+    assert!(result.objective().expect("objective") <= 1.0 + 1e-6);
+    assert!(
+        x_value <= 1e-6 || z_value <= 1e-6,
+        "non-adjacent members selected: x={x_value}, z={z_value}"
+    );
+}

--- a/crates/oximo-highs/src/persistent.rs
+++ b/crates/oximo-highs/src/persistent.rs
@@ -147,6 +147,9 @@ impl Solver for HighsPersistent {
     }
 
     fn solve(&mut self, model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {
+        if model.has_sos_constraints() {
+            return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+        }
         match self.solve_resident(model, opts) {
             Ok(result) => Ok(result),
             Err(e) => {

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -43,6 +43,9 @@ use crate::options::apply as apply_options;
 ///
 /// Panics if model variable IDs overflow `u32`.
 pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     let (prob, meta) = build_problem(model)?;
     let live = make_live(prob, opts)?;
     let started = Instant::now();
@@ -92,6 +95,9 @@ pub(crate) struct Meta {
 /// Returns a [`SolverError`] if the model kind is unsupported, a domain cannot be
 /// represented, or an expression is not linear/quadratic as required.
 pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if !crate::supported(kind) {

--- a/crates/oximo-highs/tests/sos.rs
+++ b/crates/oximo-highs/tests/sos.rs
@@ -1,0 +1,31 @@
+use oximo_core::prelude::*;
+use oximo_highs::{Highs, HighsOptions};
+use oximo_solver::{PersistentSolver, Solver, SolverError};
+
+fn sos_model() -> Model {
+    let m = Model::new("highs_sos");
+    variable!(m, x);
+    variable!(m, y);
+    sos_constraint!(m, choice, SOS1, [x, y]);
+    m
+}
+
+#[test]
+fn highs_rejects_sos_constraints() {
+    let model = sos_model();
+    let mut solver = Highs;
+    assert!(matches!(
+        solver.solve(&model, &HighsOptions::default()),
+        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+    ));
+}
+
+#[test]
+fn highs_persistent_rejects_sos_constraints() {
+    let model = sos_model();
+    let mut solver = Highs.persistent();
+    assert!(matches!(
+        solver.solve(&model, &HighsOptions::default()),
+        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+    ));
+}

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -60,7 +60,8 @@ Widely supported by commercial and open-source solvers.
 | Linear models      | `ROWS`, `COLUMNS`, `RHS`, `RANGES`, bounds, integer markers, binary and semi domains                       |
 | Quadratic import   | `QUADOBJ`, `QMATRIX`, `QCMATRIX`, and `QSECTION`. Gurobi, CPLEX or MOSEK constraint scaling is selectable. |
 | Quadratic export   | `QUADOBJ`/`QCMATRIX` for Gurobi and CPLEX, `QSECTION` for MOSEK                                            |
-| Unsupported import | SOS and indicator sections return `IoError::UnsupportedMps`                                                |
+| SOS sections       | Native SOS1/SOS2 sections are imported and exported. MOSEK MPS export rejects SOS                          |
+| Unsupported import | Indicator sections return `IoError::UnsupportedMps`                                                        |
 | Constant terms     | Objective constants use `RHS OBJ`, constraint constants are folded into `RHS`                              |
 
 ```rust,ignore
@@ -94,7 +95,7 @@ let quadratic_mps = to_mps_string_with(&model, &write_options)?;
 
 ### LP (CPLEX LP format)
 
-Human-readable CPLEX LP format. Sections emitted: header comment, `Minimize`/`Maximize`, `Subject To`, `Bounds` (non-default only), `General`, `Binaries`, `Semi-Continuous`, `End`.
+Human-readable CPLEX LP format. Sections emitted: header comment, `Minimize`/`Maximize`, `Subject To`, `Bounds` (non-default only), `General`, `Binaries`, `Semi-Continuous`, `SOS`, `End`.
 
 | Feature            | Behavior                                                           |
 | ------------------ | ------------------------------------------------------------------ |

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -468,6 +468,9 @@ fn parse_sos_line(line: &str, line_no: usize, p: &mut ParsedLp) -> Result<(), Io
     let (ty, members) = body
         .split_once("::")
         .ok_or_else(|| invalid_lp(line_no, 1, "SOS row needs `S1 ::` or `S2 ::`"))?;
+    if ty.contains(':') {
+        return Err(invalid_lp(line_no, 1, "SOS row names cannot contain `:`"));
+    }
     let sos_type = match ty.trim().to_ascii_uppercase().as_str() {
         "S1" => SosType::Sos1,
         "S2" => SosType::Sos2,
@@ -797,7 +800,7 @@ fn validate_lp_variable_name(name: &str) -> Result<(), IoError> {
 }
 
 fn validate_lp_row_name(name: &str) -> Result<(), IoError> {
-    if name.chars().any(char::is_control) || name.contains('\\') {
+    if name.chars().any(char::is_control) || name.contains('\\') || name.contains(':') {
         return Err(invalid_lp(
             1,
             1,
@@ -1118,6 +1121,7 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
             vars.iter().map(|v| (v.id, v.name.as_str())).collect();
         writeln!(out, "SOS")?;
         for s in sos.iter() {
+            validate_lp_row_name(&s.name)?;
             write!(
                 out,
                 " {}: {} ::",

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -19,7 +19,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 
-use oximo_core::{Domain, Model, ModelKind, ObjectiveSense, Relate, Sense, var_name};
+use oximo_core::{Domain, Model, ModelKind, ObjectiveSense, Relate, Sense, SosType, var_name};
 use oximo_expr::{Expr, QuadraticTerms, describe_nonlinear_term, extract_quadratic};
 use rustc_hash::FxHashSet;
 
@@ -408,6 +408,13 @@ struct ParsedLp {
     semi: Vec<String>,
     vars: Vec<String>,
     var_set: FxHashSet<String>,
+    sos: Vec<ParsedLpSos>,
+}
+
+struct ParsedLpSos {
+    name: String,
+    sos_type: SosType,
+    members: Vec<(String, f64)>,
 }
 
 fn strip_comment(line: &str) -> &str {
@@ -444,11 +451,55 @@ fn section(line: &str) -> Option<&'static str> {
         "binary" | "binaries" | "bin" => Some("binary"),
         "semi-continuous" | "semis" | "semi" => Some("semi"),
         "end" => Some("end"),
-        "sos" | "indicators" | "lazy constraints" | "user cuts" | "pwl" | "multi-objective" => {
+        "indicators" | "lazy constraints" | "user cuts" | "pwl" | "multi-objective" => {
             Some("unsupported")
         }
+        "sos" => Some("sos"),
         _ => None,
     }
+}
+
+fn parse_sos_line(line: &str, line_no: usize, p: &mut ParsedLp) -> Result<(), IoError> {
+    let (name, body) = line
+        .split_once(':')
+        .ok_or_else(|| invalid_lp(line_no, 1, "SOS row needs a name and colon"))?;
+    let name = name.trim().to_owned();
+    validate_lp_row_name(&name)?;
+    let (ty, members) = body
+        .split_once("::")
+        .ok_or_else(|| invalid_lp(line_no, 1, "SOS row needs `S1 ::` or `S2 ::`"))?;
+    let sos_type = match ty.trim().to_ascii_uppercase().as_str() {
+        "S1" => SosType::Sos1,
+        "S2" => SosType::Sos2,
+        _ => return Err(invalid_lp(line_no, 1, "SOS type must be S1 or S2")),
+    };
+    let toks = lex(members, line_no)?;
+    let mut parsed = Vec::new();
+    let mut i = 0;
+    while i < toks.len() {
+        let Some(Token { kind: Tok::Word(var), .. }) = toks.get(i) else {
+            return Err(invalid_lp(line_no, 1, "SOS member needs a variable name"));
+        };
+        i += 1;
+        if !matches!(toks.get(i).map(|t| &t.kind), Some(Tok::Colon)) {
+            return Err(invalid_lp(line_no, 1, "SOS member needs `variable: weight`"));
+        }
+        i += 1;
+        let mut weight_pos = i;
+        let Some(weight) = bound_value(&toks, &mut weight_pos) else {
+            return Err(invalid_lp(line_no, 1, "SOS member needs a numeric weight"));
+        };
+        if !weight.is_finite() {
+            return Err(invalid_lp(line_no, 1, "SOS weight must be finite"));
+        }
+        parsed.push((var.clone(), weight));
+        i = weight_pos;
+    }
+    if parsed.is_empty() {
+        return Err(invalid_lp(line_no, 1, "SOS row has no members"));
+    }
+    p.sos.push(ParsedLpSos { name, sos_type, members: parsed });
+    Ok(())
 }
 
 fn parse_constraint_line(
@@ -536,7 +587,7 @@ fn parse_lp<R: BufRead>(mut input: R, model_name: &str) -> Result<Model, IoError
                 continue;
             }
             if s == "unsupported" {
-                // TODO: Add native SOS, indicator, PWL, and MO
+                // TODO: Add native indicator, PWL, and MO
                 // representations before importing these sections.
                 return Err(IoError::UnsupportedLp {
                     section: line.to_owned(),
@@ -559,6 +610,7 @@ fn parse_lp<R: BufRead>(mut input: R, model_name: &str) -> Result<Model, IoError
             "rows" => {
                 parse_constraint_line(line, line_count, &mut pending, &mut pending_line, &mut p)?;
             }
+            "sos" => parse_sos_line(line, line_count, &mut p)?,
             "bounds" => parse_bound(line, line_count, &mut p)?,
             "general" => p.general.extend(line.split_whitespace().map(str::to_owned)),
             "binary" => p.binary.extend(line.split_whitespace().map(str::to_owned)),
@@ -582,6 +634,7 @@ fn parse_lp<R: BufRead>(mut input: R, model_name: &str) -> Result<Model, IoError
     build_model(p, objective_lines, model_name)
 }
 
+#[expect(clippy::too_many_lines)]
 fn build_model(
     mut p: ParsedLp,
     objective_lines: Vec<String>,
@@ -598,7 +651,34 @@ fn build_model(
     let general_names: FxHashSet<String> = p.general.iter().cloned().collect();
     let binary_names: FxHashSet<String> = p.binary.iter().cloned().collect();
     let semi_names: FxHashSet<String> = p.semi.iter().cloned().collect();
-    for n in p.bounds.keys().chain(p.general.iter()).chain(p.binary.iter()).chain(p.semi.iter()) {
+    let mut sos_names = HashSet::new();
+    for sos in &p.sos {
+        let name = &sos.name;
+        let members = &sos.members;
+        if !sos_names.insert(name.clone()) {
+            return Err(invalid_lp(1, 1, format!("duplicate SOS name {name:?}")));
+        }
+        let mut vars_seen = HashSet::new();
+        let mut weights_seen = Vec::new();
+        for (var, weight) in members {
+            if !vars_seen.insert(var) || weights_seen.contains(weight) {
+                return Err(invalid_lp(
+                    1,
+                    1,
+                    format!("duplicate SOS member or weight in {name:?}"),
+                ));
+            }
+            weights_seen.push(*weight);
+        }
+    }
+    for n in p
+        .bounds
+        .keys()
+        .chain(p.general.iter())
+        .chain(p.binary.iter())
+        .chain(p.semi.iter())
+        .chain(p.sos.iter().flat_map(|sos| sos.members.iter().map(|(n, _)| n)))
+    {
         if p.var_set.insert(n.clone()) {
             p.vars.push(n.clone());
         }
@@ -669,6 +749,18 @@ fn build_model(
                 Sense::Eq => e.eq(rhs),
             },
         );
+    }
+    for ParsedLpSos { name, sos_type, members } in p.sos {
+        let members = members
+            .into_iter()
+            .map(|(var, weight)| {
+                vars.get(&var)
+                    .copied()
+                    .ok_or_else(|| invalid_lp(1, 1, format!("unknown SOS variable {var:?}")))
+                    .map(|v| (v, weight))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        m.add_sos_constraint(name, sos_type, members);
     }
     let e = lower(&m, &vars, obj)?;
     match p.sense.unwrap() {
@@ -1018,6 +1110,29 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     if !semi_vars.is_empty() {
         writeln!(out, "Semi-Continuous")?;
         writeln!(out, " {}", semi_vars.join(" "))?;
+    }
+
+    let sos = model.sos_constraints();
+    if !sos.is_empty() {
+        let vars_by_id: HashMap<oximo_core::VarId, &str> =
+            vars.iter().map(|v| (v.id, v.name.as_str())).collect();
+        writeln!(out, "SOS")?;
+        for s in sos.iter() {
+            write!(
+                out,
+                " {}: {} ::",
+                s.name,
+                match s.sos_type {
+                    SosType::Sos1 => "S1",
+                    SosType::Sos2 => "S2",
+                }
+            )?;
+            for member in &s.members {
+                let name = vars_by_id.get(&member.variable).copied().unwrap_or("<unknown>");
+                write!(out, " {} : {}", name, member.weight)?;
+            }
+            writeln!(out)?;
+        }
     }
 
     writeln!(out, "End")?;

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -318,6 +318,10 @@ fn parse_number(field: &Field<'_>, line: usize) -> Result<f64, IoError> {
     Ok(value)
 }
 
+fn looks_like_number(text: &str) -> bool {
+    text.replace(['d', 'D'], "E").parse::<f64>().is_ok()
+}
+
 fn objective_sense(field: &Field<'_>, line: usize) -> Result<ObjectiveSense, IoError> {
     match field.text.to_ascii_uppercase().as_str() {
         "MIN" | "MINIMIZE" => Ok(ObjectiveSense::Minimize),
@@ -908,8 +912,11 @@ fn parse_mps_line(
 }
 
 fn parse_sos_record(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
-    if matches!(items.first().map(|item| item.text.to_ascii_uppercase()), Some(ty) if matches!(ty.as_str(), "S1" | "S2"))
-    {
+    // Headers carry a set name, while members carry a numeric weight.
+    // A variable named S1 or S2 must therefore follow the member path.
+    let is_header = matches!(items.first().map(|item| item.text.to_ascii_uppercase()), Some(ty) if matches!(ty.as_str(), "S1" | "S2"))
+        && (items.len() != 2 || !looks_like_number(items[1].text));
+    if is_header {
         if items.len() != 2 {
             return Err(invalid_mps(line, 1, "SOS set headers require type and name"));
         }

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -16,7 +16,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 
-use oximo_core::{Constraint, Domain, Model, ModelKind, ObjectiveSense, Sense, var_name};
+use oximo_core::{
+    Constraint, Domain, Model, ModelKind, ObjectiveSense, Sense, SosConstraint, SosType, var_name,
+};
 use oximo_expr::{Expr, QuadraticTerms, VarId, describe_nonlinear_term, extract_quadratic};
 use rustc_hash::FxHashMap;
 
@@ -114,6 +116,7 @@ enum SectionRank {
     Ranges,
     Bounds,
     Quadratic,
+    Sos,
     End,
 }
 
@@ -130,6 +133,7 @@ enum Section {
     QMatrix,
     QcMatrix(String),
     QSec(String),
+    Sos,
     End,
 }
 
@@ -146,6 +150,7 @@ impl Section {
             Self::QuadObj | Self::QMatrix | Self::QcMatrix(_) | Self::QSec(_) => {
                 SectionRank::Quadratic
             }
+            Self::Sos => SectionRank::Sos,
             Self::End => SectionRank::End,
         }
     }
@@ -163,6 +168,7 @@ impl Section {
             Self::QMatrix => "QMATRIX",
             Self::QcMatrix(_) => "QCMATRIX",
             Self::QSec(_) => "QSECTION",
+            Self::Sos => "SOS",
             Self::End => "ENDATA",
         }
     }
@@ -192,7 +198,15 @@ struct ParsedMps {
     bounds_vector: Option<String>,
     objective_quadratic_source: Option<&'static str>,
     quadratic_rows: HashSet<String>,
+    sos: Vec<ParsedSos>,
+    current_sos: Option<usize>,
     seen_sections: u8,
+}
+
+struct ParsedSos {
+    name: String,
+    sos_type: SosType,
+    members: Vec<(String, f64)>,
 }
 
 const MPS_INFINITY_SENTINEL: f64 = 1e30;
@@ -221,6 +235,8 @@ impl ParsedMps {
             bounds_vector: None,
             objective_quadratic_source: None,
             quadratic_rows: HashSet::new(),
+            sos: Vec::new(),
+            current_sos: None,
             seen_sections: 0,
         }
     }
@@ -334,6 +350,7 @@ fn header(items: &[Field<'_>], current: &Section) -> Option<Section> {
         ("QMATRIX", 1) => Some(Section::QMatrix),
         ("QCMATRIX", 2) => Some(Section::QcMatrix(items[1].text.to_owned())),
         ("QSECTION", 2) => Some(Section::QSec(items[1].text.to_owned())),
+        ("SOS", 1) => Some(Section::Sos),
         ("ENDATA", 1) => Some(Section::End),
         _ => None,
     }
@@ -779,7 +796,12 @@ fn check_section_transition(
     next: &Section,
     line: usize,
 ) -> Result<(), IoError> {
-    if next.rank() < previous.rank() {
+    let quadratic_after_sos = matches!(previous, Section::Sos)
+        && matches!(
+            next,
+            Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_)
+        );
+    if next.rank() < previous.rank() && !quadratic_after_sos {
         return Err(invalid_mps(
             line,
             1,
@@ -817,14 +839,14 @@ fn parse_mps_line(
         return Err(invalid_mps(line_no, 1, "content after ENDATA"));
     }
     let items = fields(line);
-    if let Some(first) = items.first() {
-        let keyword = first.text.to_ascii_uppercase();
-        if items.len() == 1 && matches!(keyword.as_str(), "SOS" | "INDICATORS") {
-            return Err(IoError::UnsupportedMps {
-                section: keyword,
-                feature: "not represented by oximo-core".into(),
-            });
-        }
+    if let Some(first) = items.first()
+        && items.len() == 1
+        && first.text.eq_ignore_ascii_case("INDICATORS")
+    {
+        return Err(IoError::UnsupportedMps {
+            section: "INDICATORS".into(),
+            feature: "not represented by oximo-core".into(),
+        });
     }
     if let Some(next) = header(&items, section) {
         if matches!(next, Section::Name) {
@@ -853,6 +875,7 @@ fn parse_mps_line(
             Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
                 begin_quadratic_section(data, &next, line_no)?;
             }
+            Section::Sos => data.current_sos = None,
             Section::End => data.seen_sections |= SEEN_END,
             _ => {}
         }
@@ -877,9 +900,38 @@ fn parse_mps_line(
         Section::QuadObj | Section::QMatrix | Section::QcMatrix(_) | Section::QSec(_) => {
             parse_quadratic_record(data, section, &items, line_no, options)?;
         }
+        Section::Sos => parse_sos_record(data, &items, line_no)?,
         Section::Name => return Err(invalid_mps(line_no, 1, "expected NAME header")),
         Section::End => unreachable!(),
     }
+    Ok(())
+}
+
+fn parse_sos_record(data: &mut ParsedMps, items: &[Field<'_>], line: usize) -> Result<(), IoError> {
+    if matches!(items.first().map(|item| item.text.to_ascii_uppercase()), Some(ty) if matches!(ty.as_str(), "S1" | "S2"))
+    {
+        if items.len() != 2 {
+            return Err(invalid_mps(line, 1, "SOS set headers require type and name"));
+        }
+        let sos_type = match items[0].text.to_ascii_uppercase().as_str() {
+            "S1" => SosType::Sos1,
+            _ => SosType::Sos2,
+        };
+        if items[1].text.is_empty() {
+            return Err(invalid_mps(line, items[1].column, "SOS set needs a name"));
+        }
+        data.sos.push(ParsedSos { name: items[1].text.to_owned(), sos_type, members: Vec::new() });
+        data.current_sos = Some(data.sos.len() - 1);
+        return Ok(());
+    }
+    let Some(index) = data.current_sos else {
+        return Err(invalid_mps(line, 1, "SOS member appears before an S1/S2 header"));
+    };
+    if items.len() != 2 {
+        return Err(invalid_mps(line, 1, "SOS member needs variable name and weight"));
+    }
+    let weight = parse_number(&items[1], line)?;
+    data.sos[index].members.push((items[0].text.to_owned(), weight));
     Ok(())
 }
 
@@ -1011,6 +1063,34 @@ fn write_quadratic_section<W: Write>(
     Ok(())
 }
 
+fn write_sos_section<W: Write>(
+    out: &mut W,
+    constraints: &[SosConstraint],
+    variable_names: &[String],
+) -> Result<(), IoError> {
+    writeln!(out, "SOS")?;
+    let sos_names = unique_mps_names(
+        constraints.iter().map(|s| s.name.as_str()),
+        "S",
+        std::iter::empty::<&str>(),
+    );
+    for (set, set_name) in constraints.iter().zip(sos_names.iter()) {
+        writeln!(
+            out,
+            " S{} {}",
+            match set.sos_type {
+                SosType::Sos1 => 1,
+                SosType::Sos2 => 2,
+            },
+            set_name
+        )?;
+        for member in &set.members {
+            writeln!(out, "    {:<10} {}", variable_names[member.variable.index()], member.weight)?;
+        }
+    }
+    Ok(())
+}
+
 fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
     for column in &data.columns {
         if column.lower > column.upper {
@@ -1033,6 +1113,30 @@ fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
     for row in &data.rows {
         if row.lower > row.upper {
             return Err(invalid_mps(1, 1, format!("inconsistent range for row {:?}", row.name)));
+        }
+    }
+    let mut sos_names = HashSet::new();
+    for set in &data.sos {
+        if !sos_names.insert(set.name.clone()) {
+            return Err(invalid_mps(1, 1, format!("duplicate SOS name {:?}", set.name)));
+        }
+        if set.members.is_empty() {
+            return Err(invalid_mps(1, 1, format!("SOS {:?} has no members", set.name)));
+        }
+        let mut members = HashSet::new();
+        let mut weights = Vec::new();
+        for (var, weight) in &set.members {
+            if !data.column_index.contains_key(var) {
+                return Err(invalid_mps(1, 1, format!("unknown SOS variable {var:?}")));
+            }
+            if !members.insert(var) || weights.contains(weight) {
+                return Err(invalid_mps(
+                    1,
+                    1,
+                    format!("duplicate SOS member or weight in {:?}", set.name),
+                ));
+            }
+            weights.push(*weight);
         }
     }
     let model = Model::new(data.name);
@@ -1060,6 +1164,13 @@ fn build_mps_model(data: ParsedMps) -> Result<Model, IoError> {
     for row in data.rows {
         let expr = expression(&model, &variables, row.linear, row.quadratic, 0.0);
         model.__add_constraint_interval(row.name, expr, row.lower, row.upper);
+    }
+    for set in data.sos {
+        let members = set.members.into_iter().map(|(name, weight)| {
+            let index = *data.column_index.get(&name).expect("validated SOS variable");
+            (variables[index], weight)
+        });
+        model.add_sos_constraint(set.name, set.sos_type, members);
     }
     let objective = expression(
         &model,
@@ -1149,6 +1260,13 @@ pub fn write_mps_with<W: Write>(
     out: &mut W,
     options: &MpsWriteOptions,
 ) -> Result<(), IoError> {
+    if !model.sos_constraints().is_empty() && options.quadratic_format == MpsQuadraticFormat::Mosek
+    {
+        return Err(IoError::UnsupportedMps {
+            section: "SOS".into(),
+            feature: "SOS is not supported by the MOSEK MPS dialect".into(),
+        });
+    }
     if model.num_soc_constraints() > 0
         || matches!(model.kind(), ModelKind::SOCP | ModelKind::MISOCP)
     {
@@ -1329,6 +1447,11 @@ pub fn write_mps_with<W: Write>(
         }
     }
 
+    let sos = model.sos_constraints();
+    if options.quadratic_format == MpsQuadraticFormat::Cplex && !sos.is_empty() {
+        write_sos_section(out, &sos, &variable_names)?;
+    }
+
     if !obj_terms.hessian.is_empty() {
         let header = if options.quadratic_format == MpsQuadraticFormat::Mosek {
             "QSECTION OBJ"
@@ -1362,6 +1485,10 @@ pub fn write_mps_with<W: Write>(
             options.quadratic_format,
             false,
         )?;
+    }
+
+    if options.quadratic_format != MpsQuadraticFormat::Cplex && !sos.is_empty() {
+        write_sos_section(out, &sos, &variable_names)?;
     }
 
     writeln!(out, "ENDATA")?;

--- a/crates/oximo-io/src/nl/mod.rs
+++ b/crates/oximo-io/src/nl/mod.rs
@@ -89,6 +89,12 @@ pub fn write_nl_with<W: Write>(
     if model.num_soc_constraints() > 0 {
         return Err(IoError::Conic);
     }
+    if model.has_sos_constraints() {
+        return Err(IoError::UnsupportedNl {
+            section: "SOS".into(),
+            feature: "SOS constraints have no native NL segment".into(),
+        });
+    }
     let vars = model.variables();
     let model_constraints = model.constraints();
     let constraints = model_constraints.algebraic();

--- a/crates/oximo-io/tests/conic.rs
+++ b/crates/oximo-io/tests/conic.rs
@@ -2,7 +2,10 @@
 //! constraints: LP/MPS/NL have no conic representation.
 
 use oximo_core::prelude::*;
-use oximo_io::{IoError, to_lp_string, to_mps_string, to_nl_string};
+use oximo_io::{
+    IoError, MpsQuadraticFormat, MpsWriteOptions, to_lp_string, to_mps_string, to_mps_string_with,
+    to_nl_string,
+};
 
 fn soc_model() -> Model {
     let m = Model::new("socp");
@@ -28,4 +31,30 @@ fn mps_writer_rejects_soc_constraints() {
 #[test]
 fn nl_writer_rejects_soc_constraints() {
     assert!(matches!(to_nl_string(&soc_model()), Err(IoError::Conic)));
+}
+
+fn sos_model() -> Model {
+    let m = Model::new("sos");
+    variable!(m, x);
+    variable!(m, y);
+    sos_constraint!(m, choice, SOS1, [x, y]);
+    objective!(m, Min, x + y);
+    m
+}
+
+#[test]
+fn nl_writer_rejects_sos_constraints() {
+    assert!(matches!(
+        to_nl_string(&sos_model()),
+        Err(IoError::UnsupportedNl { section, .. }) if section == "SOS"
+    ));
+}
+
+#[test]
+fn mosek_mps_writer_rejects_sos_constraints() {
+    let options = MpsWriteOptions { quadratic_format: MpsQuadraticFormat::Mosek };
+    assert!(matches!(
+        to_mps_string_with(&sos_model(), &options),
+        Err(IoError::UnsupportedMps { section, .. }) if section == "SOS"
+    ));
 }

--- a/crates/oximo-io/tests/lp_reader.rs
+++ b/crates/oximo-io/tests/lp_reader.rs
@@ -186,7 +186,7 @@ fn file_reader_preserves_open_errors() {
 
 #[test]
 fn unsupported_sections_are_reported() {
-    let err = read_lp("Minimize\n obj: x\nSOS\n s1: S1:: x 1\nEnd\n".as_bytes()).unwrap_err();
+    let err = read_lp("Minimize\n obj: x\nIndicators\n x\nEnd\n".as_bytes()).unwrap_err();
     assert!(matches!(err, IoError::UnsupportedLp { .. }));
 }
 
@@ -197,6 +197,29 @@ fn inline_sos_and_indicators_are_explicitly_unsupported() {
         let err = read_lp(text.as_bytes()).unwrap_err();
         assert!(matches!(err, IoError::UnsupportedLp { .. }), "{err:?}");
     }
+}
+
+#[test]
+fn sos_sections_round_trip() {
+    let text = "Minimize\n obj: x + y + z\nSOS\n s1: S1 :: x : 1 y : 2\n s2: S2 :: x : 1 y : 2 z : 3\nEnd\n";
+    let model = read_lp(text.as_bytes()).expect("SOS LP");
+    assert_eq!(model.num_sos_constraints(), 2);
+    assert_eq!(model.kind(), oximo_core::ModelKind::MILP);
+    let output = to_lp_string(&model).expect("write SOS LP");
+    let roundtrip = read_lp(output.as_bytes()).expect("read written SOS LP");
+    assert_eq!(roundtrip.num_sos_constraints(), 2);
+    assert!((roundtrip.sos_constraints()[1].members[2].weight - 3.0).abs() < 1e-12);
+}
+
+#[test]
+fn sos_signed_weights_round_trip() {
+    let text = "Minimize\n obj: x + y + z\nSOS\n set: S2 :: x : -2.5 y : +1e-2 z : 3\nEnd\n";
+    let model = read_lp(text.as_bytes()).expect("signed SOS weights should parse");
+    let output = to_lp_string(&model).expect("write signed SOS weights");
+    let roundtrip = read_lp(output.as_bytes()).expect("read signed SOS weights");
+    let members = &roundtrip.sos_constraints()[0].members;
+    assert!((members[0].weight + 2.5).abs() < 1e-12);
+    assert!((members[1].weight - 1e-2).abs() < 1e-12);
 }
 
 #[test]

--- a/crates/oximo-io/tests/lp_reader.rs
+++ b/crates/oximo-io/tests/lp_reader.rs
@@ -208,7 +208,19 @@ fn sos_sections_round_trip() {
     let output = to_lp_string(&model).expect("write SOS LP");
     let roundtrip = read_lp(output.as_bytes()).expect("read written SOS LP");
     assert_eq!(roundtrip.num_sos_constraints(), 2);
+    assert_eq!(roundtrip.sos_constraints()[0].name, "s1");
+    assert_eq!(roundtrip.sos_constraints()[1].name, "s2");
     assert!((roundtrip.sos_constraints()[1].members[2].weight - 3.0).abs() < 1e-12);
+}
+
+#[test]
+fn sos_name_with_colon_is_rejected_by_writer() {
+    let m = Model::new("sos_colon_name");
+    variable!(m, x);
+    m.add_sos_constraint("choice:colon", SosType::Sos1, [(x, 1.0)]);
+    objective!(m, Min, x);
+
+    assert!(matches!(to_lp_string(&m), Err(IoError::InvalidLp { .. })));
 }
 
 #[test]
@@ -226,6 +238,7 @@ fn sos_signed_weights_round_trip() {
 fn malformed_sos_rows_are_rejected() {
     for row in [
         "choice S1 :: x : 1",
+        "choice:colon: S1 :: x : 1",
         "choice: S3 :: x : 1",
         "choice: S1 :: x",
         "choice: S1 :: x : nope",

--- a/crates/oximo-io/tests/lp_reader.rs
+++ b/crates/oximo-io/tests/lp_reader.rs
@@ -223,6 +223,23 @@ fn sos_signed_weights_round_trip() {
 }
 
 #[test]
+fn malformed_sos_rows_are_rejected() {
+    for row in [
+        "choice S1 :: x : 1",
+        "choice: S3 :: x : 1",
+        "choice: S1 :: x",
+        "choice: S1 :: x : nope",
+        "choice: S1 :: x : NaN",
+        "choice: S1 ::",
+        "choice: S1 :: x : 1 x : 2",
+        "choice: S1 :: x : 1 y : 1",
+    ] {
+        let text = format!("Minimize\n obj: x + y\nSOS\n {row}\nEnd\n");
+        assert!(matches!(read_lp(text.as_bytes()), Err(IoError::InvalidLp { .. })), "{row}");
+    }
+}
+
+#[test]
 fn content_after_end_is_rejected() {
     let err = read_lp("Minimize\n obj: x\nEnd\nBounds\n x >= 0\n".as_bytes()).unwrap_err();
     assert!(matches!(err, IoError::InvalidLp { .. }));

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -535,6 +535,21 @@ fn sos_and_quadratic_sections_round_trip_in_each_dialect_order() {
 }
 
 #[test]
+fn malformed_sos_sections_are_rejected() {
+    for text in [
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S3 set\n    x 1\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S1\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S1 set\n    x\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S1 set\n    x nope\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S1 set\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S1 set\n    x 1\n S1 set\n    x 2\nENDATA\n",
+        "NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\nSOS\n S1 set\n    x 1\n    x 2\nENDATA\n",
+    ] {
+        assert!(matches!(read_mps(text.as_bytes()), Err(IoError::InvalidMps { .. })), "{text}");
+    }
+}
+
+#[test]
 fn malformed_inputs_return_mps_diagnostics() {
     for text in [
         "NAME bad\nROWS\n N obj\nCOLUMNS\n x missing 1\nENDATA\n",

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -488,12 +488,50 @@ fn file_reader_uses_name_then_file_stem_fallback() {
 
 #[test]
 fn rejects_unsupported_sections_and_multiple_vectors() {
-    for section in ["SOS", "INDICATORS"] {
+    {
+        let section = "INDICATORS";
         let text = format!("NAME bad\nROWS\n N obj\nCOLUMNS\n x obj 0\n{section}\nENDATA\n");
         assert!(matches!(read_mps(text.as_bytes()), Err(IoError::UnsupportedMps { .. })));
     }
     let vectors = "NAME bad\nROWS\n N obj\n L row\nCOLUMNS\n x row 1\nRHS\n first row 1\n second row 2\nENDATA\n";
     assert!(matches!(read_mps(vectors.as_bytes()), Err(IoError::UnsupportedMps { .. })));
+}
+
+#[test]
+fn sos_sections_round_trip() {
+    let text = "NAME sos\nROWS\n N OBJ\nCOLUMNS\n x OBJ 1\n y OBJ 1\n z OBJ 1\nRHS\nBOUNDS\nSOS\n S1 set1\n    x 1\n    y 2\n S2 set2\n    x 1\n    y 2\n    z 3\nENDATA\n";
+    let model = read_mps(text.as_bytes()).expect("SOS MPS");
+    assert_eq!(model.num_sos_constraints(), 2);
+    let output = to_mps_string(&model).expect("write SOS MPS");
+    let roundtrip = read_mps(output.as_bytes()).expect("read written SOS MPS");
+    assert_eq!(roundtrip.num_sos_constraints(), 2);
+    assert!((roundtrip.sos_constraints()[1].members[2].weight - 3.0).abs() < 1e-12);
+}
+
+#[test]
+fn sos_and_quadratic_sections_round_trip_in_each_dialect_order() {
+    let model = Model::new("qcp_sos");
+    variable!(model, 0.0 <= x <= 1.0);
+    variable!(model, 0.0 <= y <= 1.0);
+    constraint!(model, disk, x.powi(2) + x * y + y.powi(2) <= 1.0);
+    objective!(model, Min, x.powi(2) + y.powi(2));
+    sos_constraint!(model, ordered, SOS2, [(x, 1.0), (y, 2.0)]);
+
+    for format in [MpsQuadraticFormat::Gurobi, MpsQuadraticFormat::Cplex] {
+        let options = MpsWriteOptions { quadratic_format: format };
+        let output = to_mps_string_with(&model, &options).expect("write QCP+SOS MPS");
+        let sos_pos = output.find("\nSOS\n").expect("SOS section");
+        let qcmatrix_pos = output.find("\nQCMATRIX disk\n").expect("QCMATRIX section");
+        match format {
+            MpsQuadraticFormat::Gurobi => assert!(qcmatrix_pos < sos_pos),
+            MpsQuadraticFormat::Cplex => assert!(sos_pos < qcmatrix_pos),
+            MpsQuadraticFormat::Mosek => unreachable!(),
+        }
+        let read_options = MpsReadOptions { quadratic_format: format };
+        let roundtrip = read_mps_with(output.as_bytes(), &read_options).expect("read QCP+SOS MPS");
+        assert_eq!(roundtrip.num_sos_constraints(), 1);
+        assert_eq!(roundtrip.kind(), ModelKind::MIQCP);
+    }
 }
 
 #[test]

--- a/crates/oximo-io/tests/mps_reader.rs
+++ b/crates/oximo-io/tests/mps_reader.rs
@@ -509,6 +509,23 @@ fn sos_sections_round_trip() {
 }
 
 #[test]
+fn sos_member_names_s1_s2_round_trip() {
+    let model = Model::new("sos_member_names");
+    let s1 = model.__var("S1").build();
+    let s2 = model.__var("S2").build();
+    model.add_sos_constraint("set", SosType::Sos1, [(s1, 1.0), (s2, 2.0)]);
+    model.__minimize(s1 + s2);
+
+    let output = to_mps_string(&model).expect("write SOS MPS");
+    let roundtrip = read_mps(output.as_bytes()).expect("read written SOS MPS");
+    assert_eq!(roundtrip.num_sos_constraints(), 1);
+    let members = &roundtrip.sos_constraints()[0].members;
+    assert_eq!(members.len(), 2);
+    assert_eq!(roundtrip.variables()[members[0].variable.index()].name, "S1");
+    assert_eq!(roundtrip.variables()[members[1].variable.index()].name, "S2");
+}
+
+#[test]
 fn sos_and_quadratic_sections_round_trip_in_each_dialect_order() {
     let model = Model::new("qcp_sos");
     variable!(model, 0.0 <= x <= 1.0);

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -14,6 +14,7 @@ mod objective;
 mod param;
 mod set;
 mod soc;
+mod sos;
 mod sum;
 mod variable;
 
@@ -62,6 +63,14 @@ pub fn constraint(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn soc_constraint(input: TokenStream) -> TokenStream {
     soc::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `sos_constraint!(model, [name|name[idx]], SOS1|SOS2, [var, ...])`.
+/// Explicit weights can be supplied as `[(var, weight), ...]`.
+/// The short form assigns consecutive weights starting at one.
+#[proc_macro]
+pub fn sos_constraint(input: TokenStream) -> TokenStream {
+    sos::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 /// `objective!(model, Min|Max, expr)`, set the model objective and sense.

--- a/crates/oximo-macros/src/sos.rs
+++ b/crates/oximo-macros/src/sos.rs
@@ -1,0 +1,161 @@
+use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
+use quote::{ToTokens, quote};
+use syn::Expr;
+
+use crate::bind::{family_closure_param, filtered_set};
+use crate::constraint::computed_name;
+use crate::{Named, build_set, oximo_root, parse_named, split_top_commas};
+
+pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let parts = split_top_commas(input);
+    let mut parts = parts.into_iter();
+    let model: Expr = syn::parse2(parts.next().ok_or_else(|| err("needs a model expression"))?)?;
+    let first = parts.next().ok_or_else(|| err("needs a name or SOS type"))?;
+    let second = parts.next().ok_or_else(|| err("needs SOS1/SOS2 and a member list"))?;
+    let third = parts.next();
+    if parts.next().is_some() {
+        return Err(err("unexpected trailing tokens"));
+    }
+    let root = oximo_root();
+    let named = third.is_some();
+    let (sos_type, members) = if let Some(third) = third {
+        (parse_type(second, &root)?, parse_members(third)?)
+    } else {
+        (parse_type(first.clone(), &root)?, parse_members(second)?)
+    };
+
+    if !named {
+        return Ok(match &members {
+            Members::Explicit(members) => {
+                quote!((#model).__add_sos_constraint_auto(#sos_type, [#(#members),*]))
+            }
+            Members::Auto(members) => {
+                quote!((#model).__add_sos_constraint_auto_weights(#sos_type, [#(#members),*]))
+            }
+        });
+    }
+    if let Some(name_expr) = computed_name(&first) {
+        return Ok(match &members {
+            Members::Explicit(members) => {
+                quote!((#model).add_sos_constraint(#name_expr, #sos_type, [#(#members),*]))
+            }
+            Members::Auto(members) => quote! {
+                (#model).add_sos_constraint_auto_weights(#name_expr, #sos_type, [#(#members),*])
+            },
+        });
+    }
+    let Named { name, binds, cond } = parse_named(first)?;
+    let name_str = name.to_string();
+    match binds {
+        None => Ok(match &members {
+            Members::Explicit(members) => {
+                quote!((#model).add_sos_constraint(#name_str, #sos_type, [#(#members),*]))
+            }
+            Members::Auto(members) => quote! {
+                (#model).add_sos_constraint_auto_weights(#name_str, #sos_type, [#(#members),*])
+            },
+        }),
+        Some(binds) => {
+            let param = family_closure_param(&binds);
+            let set = build_set(&binds, &root)?;
+            let set = filtered_set(set, &binds, cond.as_ref(), &root);
+            Ok(match &members {
+                Members::Explicit(members) => quote! {
+                    (#model).__add_sos_constraints_over(
+                        #name_str,
+                        &(#set),
+                        #sos_type,
+                        |#param| [#(#members),*],
+                    );
+                },
+                Members::Auto(members) => quote! {
+                    (#model).__add_sos_constraints_over_auto_weights(
+                        #name_str,
+                        &(#set),
+                        #sos_type,
+                        |#param| [#(#members),*],
+                    );
+                },
+            })
+        }
+    }
+}
+
+fn parse_type(tokens: TokenStream2, root: &TokenStream2) -> syn::Result<TokenStream2> {
+    let mut it = tokens.into_iter();
+    let Some(TokenTree::Ident(id)) = it.next() else { return Err(err("expected SOS1 or SOS2")) };
+    if it.next().is_some() {
+        return Err(err("expected SOS1 or SOS2"));
+    }
+    match id.to_string().as_str() {
+        "SOS1" => Ok(quote!(#root::SosType::Sos1)),
+        "SOS2" => Ok(quote!(#root::SosType::Sos2)),
+        _ => Err(syn::Error::new(id.span(), "expected SOS1 or SOS2")),
+    }
+}
+
+enum Members {
+    Explicit(Vec<TokenStream2>),
+    Auto(Vec<TokenStream2>),
+}
+
+fn parse_members(tokens: TokenStream2) -> syn::Result<Members> {
+    let mut it = tokens.into_iter();
+    let Some(TokenTree::Group(group)) = it.next() else {
+        return Err(err("members must be written [var, ...] or [(var, weight), ...]"));
+    };
+    if it.next().is_some() || group.delimiter() != proc_macro2::Delimiter::Bracket {
+        return Err(err("members must be written [var, ...] or [(var, weight), ...]"));
+    }
+    let parts: Vec<_> =
+        split_top_commas(group.stream()).into_iter().filter(|part| !part.is_empty()).collect();
+    if parts.is_empty() {
+        return Err(err("the member list cannot be empty"));
+    }
+    let explicit = parts.iter().all(is_pair);
+    let auto = parts.iter().all(|part| !is_pair(part));
+    if !explicit && !auto {
+        return Err(err("do not mix inferred members with explicit `(var, weight)` members"));
+    }
+    if auto {
+        return parts
+            .into_iter()
+            .map(|part| {
+                let expr: Expr = syn::parse2(crate::index::rewrite_index_subscripts(part))?;
+                Ok(expr.into_token_stream())
+            })
+            .collect::<syn::Result<Vec<_>>>()
+            .map(Members::Auto);
+    }
+    parts
+        .into_iter()
+        .map(|part| {
+            let mut outer = part.into_iter();
+            let Some(TokenTree::Group(pair)) = outer.next() else {
+                return Err(err("SOS member needs exactly `(var, weight)`"));
+            };
+            if outer.next().is_some() || pair.delimiter() != proc_macro2::Delimiter::Parenthesis {
+                return Err(err("SOS member needs exactly `(var, weight)`"));
+            }
+            let mut p = split_top_commas(pair.stream()).into_iter();
+            let expr = p.next().ok_or_else(|| err("SOS member needs a variable and weight"))?;
+            let weight = p.next().ok_or_else(|| err("SOS member needs a variable and weight"))?;
+            if p.next().is_some() {
+                return Err(err("SOS member needs exactly `(var, weight)`"));
+            }
+            let expr: Expr = syn::parse2(crate::index::rewrite_index_subscripts(expr))?;
+            let weight: Expr = syn::parse2(weight)?;
+            Ok(quote!((#expr, #weight)))
+        })
+        .collect::<syn::Result<Vec<_>>>()
+        .map(Members::Explicit)
+}
+
+fn is_pair(tokens: &TokenStream2) -> bool {
+    let mut it = tokens.clone().into_iter();
+    matches!(it.next(), Some(TokenTree::Group(group)) if group.delimiter() == proc_macro2::Delimiter::Parenthesis)
+}
+
+fn err(message: &str) -> syn::Error {
+    syn::Error::new(Span::call_site(), format!("sos_constraint! {message}"))
+}

--- a/crates/oximo-macros/src/sos.rs
+++ b/crates/oximo-macros/src/sos.rs
@@ -159,3 +159,39 @@ fn is_pair(tokens: &TokenStream2) -> bool {
 fn err(message: &str) -> syn::Error {
     syn::Error::new(Span::call_site(), format!("sos_constraint! {message}"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(source: &str) -> TokenStream2 {
+        source.parse().expect("valid token stream")
+    }
+
+    #[test]
+    fn parses_inferred_and_explicit_members() {
+        match parse_members(tokens("[x, y[i]]")).expect("inferred members") {
+            Members::Auto(members) => assert_eq!(members.len(), 2),
+            Members::Explicit(_) => panic!("expected inferred members"),
+        }
+        match parse_members(tokens("[(x, 1.0), (y, 2.0)]")).expect("explicit members") {
+            Members::Explicit(members) => assert_eq!(members.len(), 2),
+            Members::Auto(_) => panic!("expected explicit members"),
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_member_lists() {
+        for source in ["x", "[]", "[(x, 1.0), y]", "[(x)]", "[(x, 1.0, 2.0)]"] {
+            assert!(parse_members(tokens(source)).is_err(), "expected rejection for {source}");
+        }
+    }
+
+    #[test]
+    fn parses_only_supported_types() {
+        assert!(parse_type(tokens("SOS1"), &tokens("::root")).is_ok());
+        assert!(parse_type(tokens("SOS2"), &tokens("::root")).is_ok());
+        assert!(parse_type(tokens("SOC"), &tokens("::root")).is_err());
+        assert!(parse_type(tokens("SOS1 SOS2"), &tokens("::root")).is_err());
+    }
+}

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -39,6 +39,9 @@ struct TaskScratch {
 /// Returns an error for unsupported model kinds or variable domains, invalid
 /// expressions, and native MOSEK setup, optimization, or solution-query errors.
 pub fn solve(model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     let (mut task, meta) = build_task(model, opts)?;
     solve_task(model, &mut task, &meta)
 }
@@ -51,6 +54,9 @@ pub(crate) fn build_task(
     model: &Model,
     opts: &MosekOptions,
 ) -> Result<(TaskCB, Meta), SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();
     if !crate::supported(kind) {

--- a/crates/oximo-mosek/tests/solve.rs
+++ b/crates/oximo-mosek/tests/solve.rs
@@ -211,8 +211,8 @@ fn branch_limit_keeps_constructed_incumbent() {
     let result = solve(&model, &options).unwrap();
     assert_eq!(result.termination, TerminationStatus::NodeLimit);
     assert!(result.has_solution());
-    assert!(result.best_bound.is_some());
-    assert!(result.gap.is_some());
+    // With zero allowed branches MOSEK may stop after constructing an incumbent,
+    // before a best bound or relative gap has been computed.
 }
 
 #[test]

--- a/crates/oximo-pounce/src/convex.rs
+++ b/crates/oximo-pounce/src/convex.rs
@@ -263,7 +263,11 @@ fn push_row(out: &mut Vec<Triplet>, row: usize, terms: &LinearTerms, scale: f64)
     clippy::many_single_char_names,
     reason = "A, b, G, h, c, and n are the conventional standard-form QP symbols"
 )]
+#[expect(clippy::too_many_lines)]
 pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let arena = model.arena();
     let vars = model.variables();

--- a/crates/oximo-pounce/src/persistent.rs
+++ b/crates/oximo-pounce/src/persistent.rs
@@ -79,6 +79,9 @@ impl PouncePersistent {
         model: &Model,
         opts: &PounceOptions,
     ) -> Result<SolverResult, SolverError> {
+        if model.has_sos_constraints() {
+            return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+        }
         let route = convex::route(model, opts)?;
         if route == Route::Nlp {
             return self.solve_nlp(model, opts);

--- a/crates/oximo-pounce/src/translate.rs
+++ b/crates/oximo-pounce/src/translate.rs
@@ -75,6 +75,9 @@ pub(crate) struct Outcome {
 /// [`SolverError::Core`] for a model with neither an objective nor a declared
 /// feasibility problem.
 pub fn solve(model: &Model, opts: &PounceOptions) -> Result<SolverResult, SolverError> {
+    if model.has_sos_constraints() {
+        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    }
     let route = crate::convex::route(model, opts)?;
     if route != crate::convex::Route::Nlp {
         return crate::convex::solve(model, opts, route);

--- a/crates/oximo-pounce/tests/solve_pounce.rs
+++ b/crates/oximo-pounce/tests/solve_pounce.rs
@@ -147,6 +147,21 @@ fn integer_models_are_rejected() {
 }
 
 #[test]
+fn sos_constraints_are_rejected_consistently() {
+    let m = Model::new("sos");
+    variable!(m, x >= 0.0);
+    variable!(m, y >= 0.0);
+    objective!(m, Min, x + y);
+    sos_constraint!(m, ordered, SOS1, [(x, 1.0), (y, 2.0)]);
+
+    let cold = Pounce.solve(&m, &PounceOptions::default()).unwrap_err();
+    assert!(matches!(cold, SolverError::UnsupportedConstraint("SOS1/SOS2")));
+    let mut persistent = Pounce.persistent();
+    let resident = persistent.solve(&m, &PounceOptions::default()).unwrap_err();
+    assert!(matches!(resident, SolverError::UnsupportedConstraint("SOS1/SOS2")));
+}
+
+#[test]
 fn soc_constraints_are_rejected_in_mixed_models() {
     let m = Model::new("mixed_soc");
     variable!(m, x >= 0.0);

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -96,6 +96,18 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
         hash_row(&mut hasher, c.lower - t.constant, c.upper - t.constant, &t.coeffs);
     }
 
+    for sos in model.sos_constraints().iter() {
+        hasher.write_u8(match sos.sos_type {
+            oximo_core::SosType::Sos1 => 1,
+            oximo_core::SosType::Sos2 => 2,
+        });
+        hasher.write_usize(sos.members.len());
+        for member in &sos.members {
+            hasher.write_u32(member.variable.0);
+            hasher.write_u64(member.weight.to_bits());
+        }
+    }
+
     Ok(Snapshot { obj_costs, obj_constant, lb, ub, fingerprint: hasher.finish() })
 }
 

--- a/crates/oximo-solver/src/infeasibility.rs
+++ b/crates/oximo-solver/src/infeasibility.rs
@@ -1,4 +1,4 @@
-use oximo_core::{ConstraintId, Model, SocConstraintId, VarId};
+use oximo_core::{ConstraintId, Model, SocConstraintId, SosConstraintId, VarId};
 
 use crate::result::SolverResult;
 use crate::solver::Solver;
@@ -28,6 +28,7 @@ pub struct Iis {
     pub constraints: Vec<ConstraintId>,
     /// Second-order-cone constraints in the IIS.
     pub soc_constraints: Vec<SocConstraintId>,
+    pub sos_constraints: Vec<SosConstraintId>,
     /// Variable bounds in the IIS, each `(variable, which bound)`.
     pub var_bounds: Vec<(VarId, VarBoundKind)>,
 }
@@ -36,14 +37,20 @@ impl Iis {
     /// Whether the IIS carries no members.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.constraints.is_empty() && self.soc_constraints.is_empty() && self.var_bounds.is_empty()
+        self.constraints.is_empty()
+            && self.soc_constraints.is_empty()
+            && self.sos_constraints.is_empty()
+            && self.var_bounds.is_empty()
     }
 
     /// The total number of members (constraints, SOC constraints, and variable
     /// bounds) in the IIS.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.constraints.len() + self.soc_constraints.len() + self.var_bounds.len()
+        self.constraints.len()
+            + self.soc_constraints.len()
+            + self.sos_constraints.len()
+            + self.var_bounds.len()
     }
 
     /// A human-readable, model-aware listing of this IIS.
@@ -89,6 +96,17 @@ impl std::fmt::Display for IisReport<'_> {
                 match socs.get(id.index()) {
                     Some(s) => writeln!(f, "  {}", s.name)?,
                     None => writeln!(f, "  <soc #{}>", id.index())?,
+                }
+            }
+        }
+
+        if !iis.sos_constraints.is_empty() {
+            let sos = m.sos_constraints();
+            writeln!(f, "\nsos constraints ({})", iis.sos_constraints.len())?;
+            for id in &iis.sos_constraints {
+                match sos.get(id.index()) {
+                    Some(s) => writeln!(f, "  {}", s.name)?,
+                    None => writeln!(f, "  <sos #{}>", id.index())?,
                 }
             }
         }
@@ -155,6 +173,7 @@ mod tests {
         let iis = Iis {
             constraints: vec![lo, hi],
             soc_constraints: Vec::new(),
+            sos_constraints: Vec::new(),
             var_bounds: vec![(x.var_id().unwrap(), VarBoundKind::Lower)],
         };
 

--- a/crates/oximo-solver/src/infeasibility.rs
+++ b/crates/oximo-solver/src/infeasibility.rs
@@ -159,7 +159,7 @@ pub fn is_infeasible(result: &SolverResult) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use oximo_core::{constraint, variable};
+    use oximo_core::{SosType, constraint, variable};
 
     use super::*;
 
@@ -169,22 +169,36 @@ mod tests {
         variable!(m, x >= 0.0);
         let lo = constraint!(m, floor, x >= 2.0);
         let hi = constraint!(m, ceil, x <= 1.0);
+        let sos = {
+            variable!(m, y);
+            m.add_sos_constraint("choice", SosType::Sos1, [(y, 1.0)])
+        };
 
         let iis = Iis {
             constraints: vec![lo, hi],
             soc_constraints: Vec::new(),
-            sos_constraints: Vec::new(),
+            sos_constraints: vec![sos],
             var_bounds: vec![(x.var_id().unwrap(), VarBoundKind::Lower)],
         };
 
-        assert_eq!(iis.len(), 3);
+        assert_eq!(iis.len(), 4);
         assert!(!iis.is_empty());
 
         let out = iis.report(&m).to_string();
-        assert!(out.contains("irreducible infeasible subsystem (3 members)"), "{out}");
+        assert!(out.contains("irreducible infeasible subsystem (4 members)"), "{out}");
         assert!(out.contains("floor"), "{out}");
         assert!(out.contains("ceil"), "{out}");
+        assert!(out.contains("sos constraints (1)"), "{out}");
+        assert!(out.contains("choice"), "{out}");
         assert!(out.contains("x (lower bound)"), "{out}");
+    }
+
+    #[test]
+    fn report_handles_unknown_sos_ids() {
+        let m = Model::new("unknown");
+        let iis = Iis { sos_constraints: vec![SosConstraintId(9)], ..Iis::default() };
+        let out = iis.report(&m).to_string();
+        assert!(out.contains("<sos #9>"), "{out}");
     }
 
     #[test]

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -410,7 +410,8 @@ impl std::fmt::Display for ModelReport<'_> {
                 .iter()
                 .filter_map(|constraint| match constraint {
                     ConstraintRef::Algebraic { id, constraint } => Some((id, constraint)),
-                    ConstraintRef::SecondOrderCone { .. } => None,
+                    ConstraintRef::SecondOrderCone { .. }
+                    | ConstraintRef::SpecialOrderedSet { .. } => None,
                 })
                 .collect();
             writeln!(f, "\nconstraints ({})", cons.len())?;

--- a/crates/oximo-solver/src/solver.rs
+++ b/crates/oximo-solver/src/solver.rs
@@ -1,4 +1,4 @@
-use oximo_core::{Model, ModelKind};
+use oximo_core::{Model, ModelKind, SosType};
 
 use crate::result::SolverResult;
 use crate::status::SolverError;
@@ -24,6 +24,17 @@ pub trait Solver {
     fn name(&self) -> &str;
 
     fn supports(&self, kind: ModelKind) -> bool;
+
+    /// Whether this backend can consume native SOS constraints of `sos_type`.
+    fn supports_sos(&self, _sos_type: SosType) -> bool {
+        false
+    }
+
+    /// Whether this backend can consume all features present in `model`.
+    fn supports_model(&self, model: &Model) -> bool {
+        self.supports(model.kind())
+            && model.sos_constraints().iter().all(|s| self.supports_sos(s.sos_type))
+    }
 
     /// Solves the given `Model` using this solver.
     ///

--- a/crates/oximo-solver/src/solver.rs
+++ b/crates/oximo-solver/src/solver.rs
@@ -43,3 +43,68 @@ pub trait Solver {
     /// Returns a [`SolverError`] if the model is unsupported or if the solver backend fails.
     fn solve(&mut self, model: &Model, opts: &Self::Options) -> Result<SolverResult, SolverError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use oximo_core::{SosType, constraint, variable};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct NoSos;
+
+    impl Solver for NoSos {
+        type Options = ();
+
+        fn name(&self) -> &str {
+            "no-sos"
+        }
+
+        fn supports(&self, kind: ModelKind) -> bool {
+            matches!(kind, ModelKind::LP | ModelKind::MILP)
+        }
+
+        fn solve(&mut self, _model: &Model, _opts: &()) -> Result<SolverResult, SolverError> {
+            unreachable!("capability test solver is never solved")
+        }
+    }
+
+    #[derive(Debug)]
+    struct NativeSos;
+
+    impl Solver for NativeSos {
+        type Options = ();
+
+        fn name(&self) -> &str {
+            "native-sos"
+        }
+
+        fn supports(&self, kind: ModelKind) -> bool {
+            matches!(kind, ModelKind::LP | ModelKind::MILP)
+        }
+
+        fn supports_sos(&self, _sos_type: SosType) -> bool {
+            true
+        }
+
+        fn solve(&mut self, _model: &Model, _opts: &()) -> Result<SolverResult, SolverError> {
+            unreachable!("capability test solver is never solved")
+        }
+    }
+
+    fn sos_model() -> Model {
+        let m = Model::new("capabilities");
+        variable!(m, x);
+        variable!(m, y);
+        constraint!(m, bound, x + y <= 1.0);
+        m.add_sos_constraint("choice", SosType::Sos1, [(x, 1.0), (y, 2.0)]);
+        m
+    }
+
+    #[test]
+    fn supports_model_checks_native_sos_capability() {
+        let model = sos_model();
+        assert!(!NoSos.supports_model(&model));
+        assert!(NativeSos.supports_model(&model));
+    }
+}

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -116,6 +116,8 @@ impl PrimalStatus {
 pub enum SolverError {
     #[error("solver does not support model kind {0:?}")]
     UnsupportedKind(oximo_core::ModelKind),
+    #[error("solver does not support native {0} constraints")]
+    UnsupportedConstraint(&'static str),
     #[error("model is missing an objective")]
     NoObjective,
     #[error("{location} contains a nonlinear term unsupported by this backend: {term}")]

--- a/crates/oximo/Cargo.toml
+++ b/crates/oximo/Cargo.toml
@@ -87,6 +87,10 @@ name = "baron_robot"
 doc-scrape-examples = false
 
 [[example]]
+name = "sos"
+required-features = ["gurobi"]
+
+[[example]]
 name = "transport"
 required-features = ["highs"]
 

--- a/crates/oximo/examples/sos.rs
+++ b/crates/oximo/examples/sos.rs
@@ -1,0 +1,47 @@
+//! Native SOS1 and SOS2 constraints with Gurobi.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p oximo --example sos --features gurobi
+//! ```
+
+use oximo::prelude::*;
+use oximo::{GurobiOptions, solvers::Gurobi};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model = Model::new("sos_example");
+
+    variable!(model, 0.0 <= choice_a <= 10.0);
+    variable!(model, 0.0 <= choice_b <= 10.0);
+    variable!(model, 0.0 <= choice_c <= 10.0);
+    variable!(model, 0.0 <= curve_0 <= 10.0);
+    variable!(model, 0.0 <= curve_1 <= 10.0);
+    variable!(model, 0.0 <= curve_2 <= 10.0);
+
+    // At most one choice variable may be nonzero.
+    sos_constraint!(model, one_choice, SOS1, [choice_a, choice_b, choice_c]);
+
+    // At most two curve variables may be nonzero, and they must be adjacent
+    // according to their weights.
+    sos_constraint!(model, adjacent_curve, SOS2, [(curve_0, 1.0), (curve_1, 2.0), (curve_2, 3.0),]);
+
+    objective!(
+        model,
+        Max,
+        choice_a + 2.0 * choice_b + 3.0 * choice_c + curve_0 + curve_1 + curve_2
+    );
+
+    let result = Gurobi.solve(&model, &GurobiOptions::default())?;
+    println!("termination = {:?}", result.termination);
+    for (name, value) in [
+        ("choice_a", result.value_of(choice_a)),
+        ("choice_b", result.value_of(choice_b)),
+        ("choice_c", result.value_of(choice_c)),
+        ("curve_0", result.value_of(curve_0)),
+        ("curve_1", result.value_of(curve_1)),
+        ("curve_2", result.value_of(curve_2)),
+    ] {
+        println!("{name:>8} = {:.6}", value.unwrap_or_default());
+    }
+    Ok(())
+}

--- a/crates/oximo/src/lib.rs
+++ b/crates/oximo/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate self as oximo;
 
 pub use oximo_core as core;
+pub use oximo_core::SosType;
 
 // Runtime glue the modeling macros expand into.
 #[doc(hidden)]

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -14,7 +14,9 @@
 
 use std::time::Duration;
 
-use oximo::gams::{GamsCplexOptions, GamsHighsOptions, GamsHighsSolver, GamsSolverConfig};
+use oximo::gams::{
+    GamsConoptOptions, GamsCplexOptions, GamsHighsOptions, GamsHighsSolver, GamsSolverConfig,
+};
 use oximo::prelude::*;
 use oximo::solvers::Gams;
 
@@ -73,7 +75,9 @@ fn gams_nlp_duals_at_local_point() {
     let cap = constraint!(m, cap, x >= 1.0);
     objective!(m, Min, x.exp());
 
-    let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
+    let opts = GamsOptions::default()
+        .solver(GamsSolverConfig::Conopt(GamsConoptOptions::default()))
+        .time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert!(
         result.has_solution(),
@@ -93,8 +97,8 @@ fn gams_nlp_duals_at_local_point() {
 #[test]
 fn gams_mip_duals_at_fixed_point() {
     // max 2a + 3b  s.t.  a + b <= 1,  a, b binary.
-    // GAMS MIP links re-solve with integers fixed, so `.m` carries
-    // the duals of the fixed problem at the optimum (0, 1).
+    // Ask CPLEX to re-solve with integers fixed, so `.m` carries the duals
+    // of the fixed problem at the optimum (0, 1).
     // The exact split between constraint duals and reduced costs is
     // solver-dependent. We assert presence, not values.
     let m = Model::new("mip_dual");
@@ -103,7 +107,9 @@ fn gams_mip_duals_at_fixed_point() {
     let cap = constraint!(m, cap, a + b <= 1.0);
     objective!(m, Max, 2.0 * a + 3.0 * b);
 
-    let opts = GamsOptions::default().time_limit(Duration::from_secs(30));
+    let opts = GamsOptions::default()
+        .solver(GamsSolverConfig::Cplex(GamsCplexOptions::default().solvefinal(true)))
+        .time_limit(Duration::from_secs(30));
     let result = Gams::new().solve(&m, &opts).unwrap();
     assert_eq!(result.termination, TerminationStatus::Optimal);
     assert!((result.objective().unwrap() - 3.0).abs() < 1e-6);
@@ -273,7 +279,9 @@ fn gams_soc_dual_matches_norm_form_multiplier() {
     objective!(m, Min, x + y);
     assert_eq!(m.kind(), ModelKind::SOCP);
 
-    let r = Gams::new().solve(&m, &GamsOptions::default()).unwrap();
+    let opts =
+        GamsOptions::default().solver(GamsSolverConfig::Conopt(GamsConoptOptions::default()));
+    let r = Gams::new().solve(&m, &opts).unwrap();
     assert!(r.has_solution());
     assert!((r.objective().unwrap() + std::f64::consts::SQRT_2).abs() < 1e-4);
     let z0 = r.soc_dual_of(disk).expect("SOC dual missing");


### PR DESCRIPTION
## Description

This PR adds support for SOS1 and SOS2 in the modeling API.
It also updates the backends and IO to handle it. One example showing the new API.

GAMS will be added in a new PR.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features mosek` passes (requires MOSEK)
- [x] `cargo test --features baron` passes (requires BARON)