### PR TITLE
Add SOS-to-MILP reformulation

### DIFF
--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -46,8 +46,8 @@ pub fn solve(
     opts: &BaronOptions,
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     let sense = model.objective().as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
     let (bar, var_order, con_order, soc_bounds) = build_bar(model, opts)?;
@@ -218,8 +218,8 @@ fn run_baron(bar: &str, opts: &BaronOptions, exec: Option<&str>) -> Result<Baron
 type BarParts = (String, Vec<VarId>, Vec<ConstraintId>, Vec<LinearTerms>);
 
 fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let arena = model.arena();

--- a/crates/oximo-baron/tests/sos.rs
+++ b/crates/oximo-baron/tests/sos.rs
@@ -11,6 +11,6 @@ fn baron_rejects_sos_constraints_before_launching_executable() {
     let mut solver = Baron::with_exec("definitely-not-a-baron");
     assert!(matches!(
         solver.solve(&model, &BaronOptions::default()),
-        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+        Err(SolverError::UnsupportedSos)
     ));
 }

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -145,8 +145,8 @@ impl Problem {
 /// domains or a Clarabel setup failure, and [`SolverError::Nonlinear`] if an
 /// expression defeats extraction.
 pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     let problem = build_problem(model)?;
     let settings = build_settings(opts);
@@ -178,8 +178,8 @@ pub fn solve(model: &Model, opts: &ClarabelOptions) -> Result<SolverResult, Solv
 ///
 /// Panics if variable or constraint indices overflow `u32`.
 pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     build_problem_with(model, None)
 }

--- a/crates/oximo-clarabel/tests/sos.rs
+++ b/crates/oximo-clarabel/tests/sos.rs
@@ -16,7 +16,7 @@ fn clarabel_rejects_sos_constraints() {
     let mut solver = Clarabel;
     assert!(matches!(
         solver.solve(&model, &ClarabelOptions::default()),
-        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+        Err(SolverError::UnsupportedSos)
     ));
 }
 
@@ -26,6 +26,6 @@ fn clarabel_persistent_rejects_sos_constraints() {
     let mut solver = Clarabel.persistent();
     assert!(matches!(
         solver.solve(&model, &ClarabelOptions::default()),
-        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+        Err(SolverError::UnsupportedSos)
     ));
 }

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -215,6 +215,12 @@ sos_constraint!(m, weighted, SOS2, [
 ]);
 ```
 
+The indexed form creates one set for every key in the binder. The binder is
+required because the macro cannot infer an index domain from an `IndexedVar`:
+`choice[i in 0..n]` produces `choice[0]`, ..., `choice[n - 1]`. To create one
+SOS over a dynamically assembled collection, use
+`m.add_sos_constraint_auto_weights("choice", SosType::Sos1, members)`.
+
 The single-constraint form returns a model-bound `SosConstraintHandle`.
 Backends without native SOS support return an error.
 Reformulate one constraint through its handle, or every active SOS in a model explicitly:
@@ -251,12 +257,6 @@ then appends all generated artifacts without copying the source model.
 Because the generated rows embed the current member bounds, those bounds cannot
 be changed on a reformulated model. Change bounds before reformulating, or
 produce a fresh reformulated copy after changing the source model.
-
-The indexed form creates one set for every key in the binder. The binder is
-required because the macro cannot infer an index domain from an `IndexedVar`:
-`choice[i in 0..n]` produces `choice[0]`, ..., `choice[n - 1]`. To create one
-SOS over a dynamically assembled collection, use
-`m.add_sos_constraint_auto_weights("choice", SosType::Sos1, members)`.
 
 ### Second-order cone constraints
 

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -173,32 +173,6 @@ constraint!(m, band, 1.0 <= e <= 3.0);             // two-sided range -> one con
 constraint!(m, name = format!("c_{k}"), e == rhs); // computed run-time name
 ```
 
-### Special ordered sets
-
-SOS1 and SOS2 constraints apply ordering weights to bare variables. SOS1 allows
-at most one nonzero member. SOS2 allows at most two adjacent nonzero members.
-Weights must be finite and unique within each set.
-
-```rust,ignore
-variable!(m, 0.0 <= choice_a <= 1.0);
-variable!(m, 0.0 <= choice_b <= 1.0);
-variable!(m, 0.0 <= choice_c <= 1.0);
-
-sos_constraint!(m, one_choice, SOS1, [choice_a, choice_b, choice_c]);
-sos_constraint!(m, adjacent_choice, SOS2, [choice_a, choice_b, choice_c]);
-sos_constraint!(m, weighted, SOS2, [
-    (choice_a, 10.0), (choice_b, 20.0), (choice_c, 30.0),
-]);
-```
-
-They are currently passed through only to backends with native SOS support.
-
-The indexed form creates one set for every key in the binder. The binder is
-required because the macro cannot infer an index domain from an `IndexedVar`:
-`choice[i in 0..n]` produces `choice[0]`, ..., `choice[n - 1]`. To create one
-SOS over a dynamically assembled collection, use
-`m.add_sos_constraint_auto_weights("choice", SosType::Sos1, members)`.
-
 ### Indexed family over a set
 
 ```rust,ignore
@@ -211,6 +185,78 @@ constraint!(m, flow[i in 0..n, j in 0..m], x[i, j] >= 0.0);
 // Filtered family: only keys passing the guard.
 constraint!(m, diag[(i, j) in rc if i == j], x[i, j] <= 1.0);
 ```
+
+### Summation
+
+`sum!(body for k in domain)` reads as `sum_{k in domain} body`. Nest with extra
+clauses and filter with a trailing `if`:
+
+```rust,ignore
+constraint!(m, cap, sum!(weights[i] * x[i] for i in items) <= capacity);
+objective!(m, Min, sum!(c[i, j] * x[i, j] for i in rows, j in cols));
+let evens = sum!(x[i] for i in items if i % 2 == 0); // filtered
+```
+
+### Special ordered sets
+
+SOS1 and SOS2 constraints apply ordering weights to bare variables. SOS1 allows
+at most one nonzero member. SOS2 allows at most two adjacent nonzero members.
+Weights must be finite and unique within each set.
+
+```rust,ignore
+variable!(m, 0.0 <= choice_a <= 1.0);
+variable!(m, 0.0 <= choice_b <= 1.0);
+variable!(m, 0.0 <= choice_c <= 1.0);
+
+let one_choice = sos_constraint!(m, one_choice, SOS1, [choice_a, choice_b, choice_c]);
+sos_constraint!(m, adjacent_choice, SOS2, [choice_a, choice_b, choice_c]);
+sos_constraint!(m, weighted, SOS2, [
+    (choice_a, 10.0), (choice_b, 20.0), (choice_c, 30.0),
+]);
+```
+
+The single-constraint form returns a model-bound `SosConstraintHandle`.
+Backends without native SOS support return an error.
+Reformulate one constraint through its handle, or every active SOS in a model explicitly:
+
+```rust,ignore
+let transformed = one_choice.to_reformulated_model(SosReformulationOptions::default())?;
+solver.solve(&transformed, &options)?;
+
+let transformed = m.to_reformulated_sos_model(
+    SosReformulationOptions::default().with_fallback_big_m(1.0e6),
+)?;
+
+// Reformulate every active SOS in place when the native form is no longer needed.
+let artifacts = m.reformulate_sos(
+    SosReformulationOptions::default().with_fallback_big_m(1.0e6),
+)?;
+solver.solve(&m, &options)?;
+```
+
+The `to_reformulated_*` methods produce an independent model.
+`reformulate*` methods modify the source model.
+
+All forms preserve original IDs, append binary variables and linear rows,
+and retain the source SOS entries as inactive provenance. Finite variable bounds
+are used as member-specific Big-M values. An infinite bound is an error unless
+the caller explicitly supplies a positive finite fallback. A fallback that is too small can truncate
+the feasible region.
+
+Prefer solving the original model with a backend that supports native SOS.
+Reformulate when the selected backend lacks that capability or when you intentionally
+need a MILP representation. In-place reformulation first validates every active set,
+then appends all generated artifacts without copying the source model.
+
+Because the generated rows embed the current member bounds, those bounds cannot
+be changed on a reformulated model. Change bounds before reformulating, or
+produce a fresh reformulated copy after changing the source model.
+
+The indexed form creates one set for every key in the binder. The binder is
+required because the macro cannot infer an index domain from an `IndexedVar`:
+`choice[i in 0..n]` produces `choice[0]`, ..., `choice[n - 1]`. To create one
+SOS over a dynamically assembled collection, use
+`m.add_sos_constraint_auto_weights("choice", SosType::Sos1, members)`.
 
 ### Second-order cone constraints
 
@@ -225,17 +271,6 @@ soc_constraint!(m, risk[i in assets], [s[i] * w[i]] <= cap); // family: risk[key
 ```
 
 The method form `m.add_soc_constraint("cone", [x, y], t)` is equivalent.
-
-### Summation
-
-`sum!(body for k in domain)` reads as `sum_{k in domain} body`. Nest with extra
-clauses and filter with a trailing `if`:
-
-```rust,ignore
-constraint!(m, cap, sum!(weights[i] * x[i] for i in items) <= capacity);
-objective!(m, Min, sum!(c[i, j] * x[i, j] for i in rows, j in cols));
-let evens = sum!(x[i] for i in items if i % 2 == 0); // filtered
-```
 
 ## Objectives
 

--- a/crates/oximo-core/src/display.rs
+++ b/crates/oximo-core/src/display.rs
@@ -212,8 +212,8 @@ impl Model {
     }
 
     #[must_use]
-    pub fn display_sos(&self, id: SosConstraintId) -> SosDisplay<'_> {
-        SosDisplay { model: self, id }
+    pub fn display_sos(&self, id: impl Into<SosConstraintId>) -> SosDisplay<'_> {
+        SosDisplay { model: self, id: id.into() }
     }
 }
 

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod model;
 pub mod objective;
 pub mod param;
 pub mod prelude;
+pub mod reformulation;
 pub mod set;
 pub mod soc;
 pub mod sos;
@@ -31,9 +32,12 @@ pub use model::{
 };
 pub use objective::{Objective, ObjectiveSense};
 pub use param::Parameter;
+pub use reformulation::{
+    ReformulatedModel, ReformulationError, SosReformulationArtifacts, SosReformulationOptions,
+};
 pub use set::{Axis, FromIndexKey, IndexKey, IndexTuple, KeyCat, ScalarKey, Set, SetIter};
 pub use soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
-pub use sos::{SosConstraint, SosConstraintId, SosMember, SosType};
+pub use sos::{SosConstraint, SosConstraintHandle, SosConstraintId, SosMember, SosType};
 pub use sum::SumDomain;
 pub use var::{VarBuilder, Variable, var_name};
 

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use oximo_expr::{EvalError, Expr, ExprArena, ExprClass, ExprId, ParamId, VarId, classify};
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use smol_str::SmolStr;
 
 use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
@@ -12,9 +12,12 @@ use crate::error::{Error, Result};
 use crate::indexed::{IndexedFamily, IndexedParam, IndexedVar, build_storage};
 use crate::objective::{Objective, ObjectiveSense};
 use crate::param::Parameter;
+use crate::reformulation::SosReformulationArtifacts;
 use crate::set::{Axis, FromIndexKey, IndexKey, Set};
 use crate::soc::{SocConstraint, SocConstraintId, is_detected_soc};
-use crate::sos::{SosConstraint, SosConstraintId, SosMember, SosType, validate_members};
+use crate::sos::{
+    SosConstraint, SosConstraintHandle, SosConstraintId, SosMember, SosType, validate_members,
+};
 use crate::var::{VarBuilder, Variable};
 
 const PAR_KIND_THRESHOLD: usize = 256;
@@ -142,12 +145,70 @@ pub struct Model {
     pub(crate) soc_names: RefCell<FxHashMap<SmolStr, SocConstraintId>>,
     pub(crate) sos_constraints: RefCell<Vec<SosConstraint>>,
     pub(crate) sos_names: RefCell<FxHashMap<SmolStr, SosConstraintId>>,
+    pub(crate) sos_reformulations: RefCell<Vec<SosReformulationArtifacts>>,
     pub(crate) objective: RefCell<Option<Objective>>,
     objective_declared: Cell<bool>,
     cached_kind: Cell<Option<ModelKind>>,
     /// Monotonic counter for auto-naming anonymous constraints registered via
     /// the `constraint!` macro.
     auto_seq: Cell<u32>,
+}
+
+impl Model {
+    /// Deep-copy every registry while preserving stable IDs.
+    pub(crate) fn clone_preserving_ids_with_capacity(
+        &self,
+        additional_variables: usize,
+        additional_constraints: usize,
+        additional_expr_nodes: usize,
+    ) -> Self {
+        let variables = self.variables.borrow();
+        let mut cloned_variables =
+            Vec::with_capacity(variables.len().saturating_add(additional_variables));
+        cloned_variables.extend_from_slice(&variables);
+
+        let var_names = self.var_names.borrow();
+        let mut cloned_var_names = FxHashMap::with_capacity_and_hasher(
+            var_names.len().saturating_add(additional_variables),
+            FxBuildHasher,
+        );
+        cloned_var_names.extend(var_names.iter().map(|(name, id)| (name.clone(), *id)));
+
+        let constraints = self.constraints.borrow();
+        let mut cloned_constraints =
+            Vec::with_capacity(constraints.len().saturating_add(additional_constraints));
+        cloned_constraints.extend_from_slice(&constraints);
+
+        let constraint_names = self.constraint_names.borrow();
+        let mut cloned_constraint_names = FxHashMap::with_capacity_and_hasher(
+            constraint_names.len().saturating_add(additional_constraints),
+            FxBuildHasher,
+        );
+        cloned_constraint_names
+            .extend(constraint_names.iter().map(|(name, id)| (name.clone(), *id)));
+
+        Self {
+            name: self.name.clone(),
+            arena: RefCell::new(
+                self.arena.borrow().__clone_with_additional_capacity(additional_expr_nodes),
+            ),
+            variables: RefCell::new(cloned_variables),
+            var_names: RefCell::new(cloned_var_names),
+            parameters: RefCell::new(self.parameters.borrow().clone()),
+            param_names: RefCell::new(self.param_names.borrow().clone()),
+            constraints: RefCell::new(cloned_constraints),
+            constraint_names: RefCell::new(cloned_constraint_names),
+            soc_constraints: RefCell::new(self.soc_constraints.borrow().clone()),
+            soc_names: RefCell::new(self.soc_names.borrow().clone()),
+            sos_constraints: RefCell::new(self.sos_constraints.borrow().clone()),
+            sos_names: RefCell::new(self.sos_names.borrow().clone()),
+            sos_reformulations: RefCell::new(self.sos_reformulations.borrow().clone()),
+            objective: RefCell::new(self.objective.borrow().clone()),
+            objective_declared: Cell::new(self.objective_declared.get()),
+            cached_kind: Cell::new(self.cached_kind.get()),
+            auto_seq: Cell::new(self.auto_seq.get()),
+        }
+    }
 }
 
 impl std::fmt::Debug for Model {
@@ -166,6 +227,10 @@ impl std::fmt::Debug for Model {
 }
 
 impl Model {
+    pub(crate) fn invalidate_kind(&self) {
+        self.cached_kind.set(None);
+    }
+
     pub fn new(name: impl Into<SmolStr>) -> Self {
         Self {
             name: name.into(),
@@ -180,6 +245,7 @@ impl Model {
             soc_names: RefCell::new(FxHashMap::default()),
             sos_constraints: RefCell::new(Vec::new()),
             sos_names: RefCell::new(FxHashMap::default()),
+            sos_reformulations: RefCell::new(Vec::new()),
             objective: RefCell::new(None),
             objective_declared: Cell::new(false),
             cached_kind: Cell::new(None),
@@ -299,14 +365,21 @@ impl Model {
     ///
     /// # Panics
     ///
-    /// Panics if `e` is not a bare variable handle.
+    /// Panics if `e` is not a bare variable handle or if the variable belongs
+    /// to an SOS constraint that has already been reformulated.
     pub fn fix(&self, e: Expr<'_>, value: f64) {
         let id = e.var_id().expect("Model::fix expects a single-variable expression");
         self.fix_var(id, value);
     }
 
     /// Fix variable `id` to `value` by setting `lb = ub = value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the variable belongs to an SOS constraint that has already
+    /// been reformulated, because its bounds are embedded in generated rows.
     pub fn fix_var(&self, id: VarId, value: f64) {
+        self.assert_sos_member_bounds_mutable(id);
         let mut vars = self.variables.borrow_mut();
         let v = &mut vars[id.index()];
         v.lb = value;
@@ -329,13 +402,36 @@ impl Model {
 
     /// Restore bounds on variable `id`. Pass `f64::NEG_INFINITY` / `f64::INFINITY`
     /// to restore an unbounded direction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the variable belongs to an SOS constraint that has already
+    /// been reformulated, because its bounds are embedded in generated rows.
     pub fn unfix_var(&self, id: VarId, lb: f64, ub: f64) {
+        self.assert_sos_member_bounds_mutable(id);
         let mut vars = self.variables.borrow_mut();
         let v = &mut vars[id.index()];
         v.lb = lb;
         v.ub = ub;
         drop(vars);
         self.cached_kind.set(None);
+    }
+
+    /// Reformulation embeds the member bounds in generated Big-M rows.
+    /// Once an SOS has been reformulated, changing one of its member bounds
+    /// would make those rows stale and could either truncate or enlarge
+    /// the feasible set.
+    fn assert_sos_member_bounds_mutable(&self, id: VarId) {
+        if let Some(source) = self.sos_constraints.borrow().iter().find(|constraint| {
+            !constraint.active && constraint.members.iter().any(|member| member.variable == id)
+        }) {
+            panic!(
+                "cannot change bounds of variable {:?} after SOS constraint {:?} was reformulated; \
+                 change bounds before reformulating or create a new reformulated model",
+                self.variables.borrow()[id.index()].name,
+                source.name,
+            );
+        }
     }
 
     // Parameters
@@ -825,7 +921,7 @@ impl Model {
         name: impl Into<SmolStr>,
         sos_type: SosType,
         members: impl IntoIterator<Item = (Expr<'a>, f64)>,
-    ) -> SosConstraintId {
+    ) -> SosConstraintHandle<'a> {
         let name = name.into();
         let members: Vec<SosMember> = members
             .into_iter()
@@ -846,7 +942,7 @@ impl Model {
         all.push(SosConstraint { name: name.clone(), sos_type, members, active: true });
         by_name.insert(name, id);
         self.cached_kind.set(None);
-        id
+        SosConstraintHandle { model: self, id }
     }
 
     /// Register an SOS1 or SOS2 constraint with consecutive positional
@@ -865,7 +961,7 @@ impl Model {
         name: impl Into<SmolStr>,
         sos_type: SosType,
         variables: impl IntoIterator<Item = Expr<'a>>,
-    ) -> SosConstraintId {
+    ) -> SosConstraintHandle<'a> {
         self.add_sos_constraint(
             name,
             sos_type,
@@ -895,7 +991,7 @@ impl Model {
         &'a self,
         sos_type: SosType,
         members: impl IntoIterator<Item = (Expr<'a>, f64)>,
-    ) -> SosConstraintId {
+    ) -> SosConstraintHandle<'a> {
         self.add_sos_constraint(self.next_auto_sos_name(), sos_type, members)
     }
 
@@ -904,7 +1000,7 @@ impl Model {
         &'a self,
         sos_type: SosType,
         variables: impl IntoIterator<Item = Expr<'a>>,
-    ) -> SosConstraintId {
+    ) -> SosConstraintHandle<'a> {
         self.add_sos_constraint_auto_weights(self.next_auto_sos_name(), sos_type, variables)
     }
 
@@ -960,6 +1056,13 @@ impl Model {
 
     pub fn has_sos_constraints(&self) -> bool {
         !self.sos_constraints.borrow().is_empty()
+    }
+
+    /// Whether at least one SOS constraint still requires native backend
+    /// handling. Reformulation retains source SOS entries but marks them
+    /// inactive so their stable IDs and provenance are preserved.
+    pub fn has_active_sos_constraints(&self) -> bool {
+        self.sos_constraints.borrow().iter().any(|constraint| constraint.active)
     }
 
     // Objective
@@ -1067,8 +1170,8 @@ impl Model {
     fn infer_kind_impl(&self, parallel: Option<bool>) -> ModelKind {
         let arena = self.arena.borrow();
         let vars = self.variables.borrow();
-        let has_int =
-            vars.iter().any(|v| v.domain.is_integer()) || !self.sos_constraints.borrow().is_empty();
+        let has_int = vars.iter().any(|v| v.domain.is_integer())
+            || self.sos_constraints.borrow().iter().any(|constraint| constraint.active);
         let obj_class = self
             .objective
             .borrow()

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -7,9 +7,12 @@ pub use crate::model::{
 };
 pub use crate::objective::{Objective, ObjectiveSense};
 pub use crate::param::Parameter;
+pub use crate::reformulation::{
+    ReformulatedModel, ReformulationError, SosReformulationArtifacts, SosReformulationOptions,
+};
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
 pub use crate::soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
-pub use crate::sos::{SosConstraint, SosConstraintId, SosMember, SosType};
+pub use crate::sos::{SosConstraint, SosConstraintHandle, SosConstraintId, SosMember, SosType};
 pub use crate::sum::SumDomain;
 pub use crate::var::{VarBuilder, Variable};
 pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};

--- a/crates/oximo-core/src/reformulation/mod.rs
+++ b/crates/oximo-core/src/reformulation/mod.rs
@@ -1,0 +1,12 @@
+//! Explicit, solver-independent model reformulations.
+//!
+//! `reformulate*` operations append to the source model after validating the
+//! complete plan. `to_reformulated_*` operations preserve the source and operate
+//! on an independent clone. Both forms preserve existing variable and constraint
+//! IDs.
+
+mod sos;
+
+pub use sos::{
+    ReformulatedModel, ReformulationError, SosReformulationArtifacts, SosReformulationOptions,
+};

--- a/crates/oximo-core/src/reformulation/sos.rs
+++ b/crates/oximo-core/src/reformulation/sos.rs
@@ -209,12 +209,25 @@ impl Model {
     ///
     /// Returns [`ReformulationError`] before modifying the model when the
     /// fallback Big-M or any required member bound is invalid.
+    ///
+    /// Reformulation history remains available through
+    /// [`Self::sos_reformulations`] after the returned artifacts are dropped.
     pub fn reformulate_sos(
         &self,
         options: SosReformulationOptions,
     ) -> Result<Vec<SosReformulationArtifacts>, ReformulationError> {
         let plan = SosReformulationPlan::for_all(self, options)?;
         Ok(plan.apply(self))
+    }
+
+    /// Complete SOS reformulation history accumulated by this model.
+    ///
+    /// The returned guard dereferences to a slice of artifacts. This is useful
+    /// after an in-place reformulation when the `Vec` returned by
+    /// [`Self::reformulate_sos`] is no longer available.
+    #[must_use]
+    pub fn sos_reformulations(&self) -> Ref<'_, [SosReformulationArtifacts]> {
+        Ref::map(self.sos_reformulations.borrow(), Vec::as_slice)
     }
 }
 

--- a/crates/oximo-core/src/reformulation/sos.rs
+++ b/crates/oximo-core/src/reformulation/sos.rs
@@ -1,0 +1,594 @@
+//! SOS-to-MILP reformulation implementation.
+
+use std::cell::Ref;
+use std::ops::Deref;
+
+use oximo_expr::{Expr, VarId};
+use smol_str::SmolStr;
+use thiserror::Error;
+
+use crate::constraint::{ConstraintId, Relate};
+use crate::domain::Domain;
+use crate::model::Model;
+use crate::sos::{SosConstraint, SosConstraintId, SosMember, SosType};
+use crate::var::Variable;
+
+/// Settings for an SOS-to-MILP reformulation.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct SosReformulationOptions {
+    fallback_big_m: Option<f64>,
+}
+
+impl SosReformulationOptions {
+    /// Use `big_m` for an SOS member side whose variable bound is infinite.
+    /// Finite variable bounds are always preferred.
+    #[must_use]
+    pub const fn with_fallback_big_m(mut self, big_m: f64) -> Self {
+        self.fallback_big_m = Some(big_m);
+        self
+    }
+
+    #[must_use]
+    pub const fn fallback_big_m(self) -> Option<f64> {
+        self.fallback_big_m
+    }
+}
+
+/// Why an explicit model reformulation could not be constructed.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub enum ReformulationError {
+    #[error("SOS constraint #{0} does not exist on this model")]
+    UnknownSosConstraint(usize),
+    #[error("fallback Big-M must be finite and positive, got {0}")]
+    InvalidFallbackBigM(f64),
+    #[error(
+        "cannot reformulate SOS constraint {constraint:?}: variable {variable:?} has no finite \
+         {side} bound; provide SosReformulationOptions::with_fallback_big_m(...)"
+    )]
+    MissingFiniteBound { constraint: SmolStr, variable: SmolStr, side: &'static str },
+}
+
+/// IDs appended while replacing one source SOS constraint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SosReformulationArtifacts {
+    pub source: SosConstraintId,
+    pub variables: Vec<VarId>,
+    pub constraints: Vec<ConstraintId>,
+}
+
+/// An independent transformed model plus source-to-generated provenance.
+#[derive(Debug)]
+pub struct ReformulatedModel {
+    model: Model,
+}
+
+impl ReformulatedModel {
+    #[must_use]
+    pub fn model(&self) -> &Model {
+        &self.model
+    }
+
+    /// Complete SOS reformulation history carried by this transformed model.
+    /// The returned guard dereferences to a slice of artifacts.
+    #[must_use]
+    pub fn sos_reformulations(&self) -> Ref<'_, [SosReformulationArtifacts]> {
+        // The history lives on the model so a later clone-and-reformulate
+        // operation maintains traceability from earlier transformations.
+        Ref::map(self.model.sos_reformulations.borrow(), Vec::as_slice)
+    }
+
+    #[must_use]
+    pub fn into_model(self) -> Model {
+        self.model
+    }
+}
+
+impl Deref for ReformulatedModel {
+    type Target = Model;
+
+    fn deref(&self) -> &Self::Target {
+        &self.model
+    }
+}
+
+impl AsRef<Model> for ReformulatedModel {
+    fn as_ref(&self) -> &Model {
+        &self.model
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct PlannedMember {
+    member_index: usize,
+    member: SosMember,
+    lower: f64,
+    upper: f64,
+}
+
+impl PlannedMember {
+    fn gate_count(self) -> usize {
+        usize::from(self.lower < 0.0) + usize::from(self.upper > 0.0)
+    }
+}
+
+#[derive(Debug)]
+enum PlannedSosForm {
+    Trivial,
+    Sos1 { members: Vec<PlannedMember> },
+    Sos2 { members: Vec<PlannedMember> },
+}
+
+#[derive(Debug)]
+struct PlannedSos {
+    source: SosConstraintId,
+    form: PlannedSosForm,
+}
+
+#[derive(Debug)]
+struct SosReformulationPlan {
+    entries: Vec<PlannedSos>,
+    additional_variables: usize,
+    additional_constraints: usize,
+    additional_expr_nodes: usize,
+}
+
+impl Model {
+    /// Clone this model and replace one active SOS constraint with an MILP
+    /// formulation. An already-inactive constraint is copied unchanged. The
+    /// source model remains mutable and unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReformulationError`] for an unknown ID, invalid fallback
+    /// Big-M, or an unbounded member side without a fallback.
+    pub fn to_reformulated_sos_constraint_model(
+        &self,
+        id: SosConstraintId,
+        options: SosReformulationOptions,
+    ) -> Result<ReformulatedModel, ReformulationError> {
+        let plan = SosReformulationPlan::for_one(self, id, options)?;
+        let model = self.clone_preserving_ids_with_capacity(
+            plan.additional_variables,
+            plan.additional_constraints,
+            plan.additional_expr_nodes,
+        );
+        plan.apply(&model);
+        Ok(ReformulatedModel { model })
+    }
+
+    /// Replace one active SOS constraint on this model without cloning it.
+    /// Existing variable and parameter expression handles remain valid because
+    /// registries are only appended and all existing IDs are preserved.
+    ///
+    /// Returns `Ok(None)` when the source SOS is already inactive.
+    /// Bounds of all source members become immutable after reformulation because
+    /// their current values are embedded in the generated Big-M rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReformulationError`] before modifying the model when the ID,
+    /// fallback Big-M, or required member bounds are invalid.
+    pub fn reformulate_sos_constraint(
+        &self,
+        id: SosConstraintId,
+        options: SosReformulationOptions,
+    ) -> Result<Option<SosReformulationArtifacts>, ReformulationError> {
+        let plan = SosReformulationPlan::for_one(self, id, options)?;
+        Ok(plan.apply(self).pop())
+    }
+
+    /// Clone this model and replace every active SOS constraint with an MILP
+    /// formulation, in stable [`SosConstraintId`] order. The source model
+    /// remains mutable and unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReformulationError`] when the fallback Big-M is invalid or an
+    /// active member has an unbounded side without a fallback. No partial
+    /// transformed model is returned.
+    pub fn to_reformulated_sos_model(
+        &self,
+        options: SosReformulationOptions,
+    ) -> Result<ReformulatedModel, ReformulationError> {
+        let plan = SosReformulationPlan::for_all(self, options)?;
+        let model = self.clone_preserving_ids_with_capacity(
+            plan.additional_variables,
+            plan.additional_constraints,
+            plan.additional_expr_nodes,
+        );
+        plan.apply(&model);
+        Ok(ReformulatedModel { model })
+    }
+
+    /// Replace every active SOS constraint on this model without cloning it.
+    /// This is the memory-efficient alternative to
+    /// [`Self::to_reformulated_sos_model`]
+    /// when the original native-SOS form is no longer needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReformulationError`] before modifying the model when the
+    /// fallback Big-M or any required member bound is invalid.
+    pub fn reformulate_sos(
+        &self,
+        options: SosReformulationOptions,
+    ) -> Result<Vec<SosReformulationArtifacts>, ReformulationError> {
+        let plan = SosReformulationPlan::for_all(self, options)?;
+        Ok(plan.apply(self))
+    }
+}
+
+fn validate_options(options: SosReformulationOptions) -> Result<(), ReformulationError> {
+    if let Some(big_m) = options.fallback_big_m {
+        if !big_m.is_finite() || big_m <= 0.0 {
+            return Err(ReformulationError::InvalidFallbackBigM(big_m));
+        }
+    }
+    Ok(())
+}
+
+impl SosReformulationPlan {
+    fn for_one(
+        model: &Model,
+        id: SosConstraintId,
+        options: SosReformulationOptions,
+    ) -> Result<Self, ReformulationError> {
+        validate_options(options)?;
+        let variables = model.variables.borrow();
+        let constraints = model.sos_constraints.borrow();
+        let source = constraints
+            .get(id.index())
+            .ok_or(ReformulationError::UnknownSosConstraint(id.index()))?;
+        let entries = if source.active {
+            vec![plan_one(id, source, &variables, options)?]
+        } else {
+            Vec::new()
+        };
+        Ok(Self::new(entries))
+    }
+
+    fn for_all(
+        model: &Model,
+        options: SosReformulationOptions,
+    ) -> Result<Self, ReformulationError> {
+        validate_options(options)?;
+        let variables = model.variables.borrow();
+        let constraints = model.sos_constraints.borrow();
+        let mut entries =
+            Vec::with_capacity(constraints.iter().filter(|constraint| constraint.active).count());
+        for (index, source) in constraints.iter().enumerate() {
+            if !source.active {
+                continue;
+            }
+            let id = SosConstraintId(
+                u32::try_from(index).expect("SOS registration guarantees IDs fit in u32"),
+            );
+            entries.push(plan_one(id, source, &variables, options)?);
+        }
+        Ok(Self::new(entries))
+    }
+
+    fn new(entries: Vec<PlannedSos>) -> Self {
+        let mut additional_variables = 0;
+        let mut additional_constraints = 0;
+        let mut additional_expr_nodes = 0;
+        for entry in &entries {
+            let (variables, constraints, expr_nodes) = entry.capacity();
+            additional_variables += variables;
+            additional_constraints += constraints;
+            additional_expr_nodes += expr_nodes;
+        }
+        Self { entries, additional_variables, additional_constraints, additional_expr_nodes }
+    }
+
+    fn apply(self, model: &Model) -> Vec<SosReformulationArtifacts> {
+        model.variables.borrow_mut().reserve_exact(self.additional_variables);
+        model.var_names.borrow_mut().reserve(self.additional_variables);
+        model.constraints.borrow_mut().reserve_exact(self.additional_constraints);
+        model.constraint_names.borrow_mut().reserve(self.additional_constraints);
+        model.arena.borrow_mut().__reserve_nodes(self.additional_expr_nodes);
+
+        let mut artifacts = Vec::with_capacity(self.entries.len());
+        for entry in self.entries {
+            artifacts.push(entry.apply(model));
+        }
+        if !artifacts.is_empty() {
+            model.invalidate_kind();
+        }
+        model.sos_reformulations.borrow_mut().extend(artifacts.iter().cloned());
+        artifacts
+    }
+}
+
+impl PlannedSos {
+    fn capacity(&self) -> (usize, usize, usize) {
+        let (activation_count, members, sos2) = match &self.form {
+            PlannedSosForm::Trivial => return (0, 0, 0),
+            PlannedSosForm::Sos1 { members } => (members.len(), members.as_slice(), false),
+            PlannedSosForm::Sos2 { members } => (members.len() - 1, members.as_slice(), true),
+        };
+        let gate_count: usize = members.iter().copied().map(PlannedMember::gate_count).sum();
+        let gated_members = members.iter().filter(|member| member.gate_count() > 0).count();
+        let adjacent_sums = if sos2 {
+            members
+                .iter()
+                .enumerate()
+                .filter(|(index, member)| {
+                    *index > 0 && *index + 1 < members.len() && member.gate_count() > 0
+                })
+                .count()
+        } else {
+            0
+        };
+        let constraints = 1 + gate_count;
+        let expr_nodes = activation_count
+            + activation_count.saturating_sub(1)
+            + gated_members
+            + 4 * gate_count
+            + adjacent_sums;
+        (activation_count, constraints, expr_nodes)
+    }
+
+    fn apply(self, model: &Model) -> SosReformulationArtifacts {
+        let (variable_capacity, constraint_capacity, _) = self.capacity();
+        let mut generated_variables = Vec::with_capacity(variable_capacity);
+        let mut generated_constraints = Vec::with_capacity(constraint_capacity);
+        match self.form {
+            PlannedSosForm::Trivial => {}
+            PlannedSosForm::Sos1 { members } => {
+                let activations = add_binary_activations(
+                    model,
+                    self.source,
+                    members.len(),
+                    "member",
+                    &mut generated_variables,
+                );
+                add_at_most_one(model, self.source, &activations, &mut generated_constraints);
+                for (member, activation) in members.iter().zip(activations.iter().copied()) {
+                    add_planned_member_gates(
+                        model,
+                        self.source,
+                        member,
+                        activation,
+                        &mut generated_constraints,
+                    );
+                }
+            }
+            PlannedSosForm::Sos2 { members } => {
+                let intervals = add_binary_activations(
+                    model,
+                    self.source,
+                    members.len() - 1,
+                    "interval",
+                    &mut generated_variables,
+                );
+                add_at_most_one(model, self.source, &intervals, &mut generated_constraints);
+                for (index, member) in members.iter().enumerate() {
+                    if member.gate_count() == 0 {
+                        continue;
+                    }
+                    let activation = match index {
+                        0 => intervals[0],
+                        i if i + 1 == members.len() => intervals[i - 1],
+                        i => intervals[i - 1] + intervals[i],
+                    };
+                    add_planned_member_gates(
+                        model,
+                        self.source,
+                        member,
+                        activation,
+                        &mut generated_constraints,
+                    );
+                }
+            }
+        }
+        model.sos_constraints.borrow_mut()[self.source.index()].active = false;
+        SosReformulationArtifacts {
+            source: self.source,
+            variables: generated_variables,
+            constraints: generated_constraints,
+        }
+    }
+}
+
+fn plan_one(
+    id: SosConstraintId,
+    source: &SosConstraint,
+    variables: &[Variable],
+    options: SosReformulationOptions,
+) -> Result<PlannedSos, ReformulationError> {
+    let form = match source.sos_type {
+        SosType::Sos1
+            if source.members.len() >= 2
+                && potential_nonzero_count(variables, &source.members) >= 2 =>
+        {
+            let members = source
+                .members
+                .iter()
+                .copied()
+                .enumerate()
+                .filter(|(_, member)| {
+                    raw_effective_bounds(&variables[member.variable.index()]) != (0.0, 0.0)
+                })
+                .map(|(member_index, member)| {
+                    let (lower, upper) = effective_bounds(
+                        &variables[member.variable.index()],
+                        &source.name,
+                        options,
+                    )?;
+                    Ok(PlannedMember { member_index, member, lower, upper })
+                })
+                .collect::<Result<Vec<_>, ReformulationError>>()?;
+            PlannedSosForm::Sos1 { members }
+        }
+        SosType::Sos2 if source.members.len() >= 3 => {
+            let mut ordered = source.members.clone();
+            ordered.sort_by(|left, right| left.weight.total_cmp(&right.weight));
+            if sos2_requires_reformulation(variables, &ordered) {
+                let members = ordered
+                    .into_iter()
+                    .enumerate()
+                    .map(|(member_index, member)| {
+                        let (lower, upper) = effective_bounds(
+                            &variables[member.variable.index()],
+                            &source.name,
+                            options,
+                        )?;
+                        Ok(PlannedMember { member_index, member, lower, upper })
+                    })
+                    .collect::<Result<Vec<_>, ReformulationError>>()?;
+                PlannedSosForm::Sos2 { members }
+            } else {
+                PlannedSosForm::Trivial
+            }
+        }
+        SosType::Sos1 | SosType::Sos2 => PlannedSosForm::Trivial,
+    };
+    Ok(PlannedSos { source: id, form })
+}
+
+fn add_binary_activations<'a>(
+    model: &'a Model,
+    sos_id: SosConstraintId,
+    count: usize,
+    label: &str,
+    generated: &mut Vec<VarId>,
+) -> Vec<Expr<'a>> {
+    (0..count)
+        .map(|index| {
+            let base = format!("__oximo_sos{}_{}_{}", sos_id.index(), label, index);
+            let name = unique_variable_name(model, &base);
+            let expression = model.__var(name).binary().build();
+            generated.push(expression.var_id().expect("new activation is a variable"));
+            expression
+        })
+        .collect()
+}
+
+fn add_at_most_one(
+    model: &Model,
+    sos_id: SosConstraintId,
+    activations: &[Expr<'_>],
+    generated: &mut Vec<ConstraintId>,
+) {
+    let sum = activations
+        .iter()
+        .copied()
+        .reduce(|left, right| left + right)
+        .expect("nontrivial SOS has at least one activation");
+    let name = unique_constraint_name(model, &format!("__oximo_sos{}_select", sos_id.index()));
+    generated.push(model.__add_constraint(name, sum.le(1.0)));
+}
+
+fn add_planned_member_gates(
+    model: &Model,
+    sos_id: SosConstraintId,
+    planned: &PlannedMember,
+    activation: Expr<'_>,
+    generated: &mut Vec<ConstraintId>,
+) {
+    if planned.gate_count() == 0 {
+        return;
+    }
+    let variable = Expr::from_var(&model.arena, planned.member.variable);
+    // Native variable bounds already enforce each gate while the activation is
+    // one. A Big-M row is only needed to force the member toward zero while the
+    // activation is zero, so sign-definite members need one row instead of two,
+    // and a fixed-zero member needs none.
+    if planned.lower < 0.0 {
+        let lower_name = unique_constraint_name(
+            model,
+            &format!("__oximo_sos{}_member_{}_lower", sos_id.index(), planned.member_index),
+        );
+        generated.push(model.__add_constraint(lower_name, variable.ge(planned.lower * activation)));
+    }
+    if planned.upper > 0.0 {
+        let upper_name = unique_constraint_name(
+            model,
+            &format!("__oximo_sos{}_member_{}_upper", sos_id.index(), planned.member_index),
+        );
+        generated.push(model.__add_constraint(upper_name, variable.le(planned.upper * activation)));
+    }
+}
+
+fn effective_bounds(
+    variable: &Variable,
+    constraint_name: &SmolStr,
+    options: SosReformulationOptions,
+) -> Result<(f64, f64), ReformulationError> {
+    let (lower, upper) = raw_effective_bounds(variable);
+    let lower = finite_or_fallback(lower, -1.0, options, constraint_name, &variable.name, "lower")?;
+    let upper = finite_or_fallback(upper, 1.0, options, constraint_name, &variable.name, "upper")?;
+    Ok((lower, upper))
+}
+
+fn raw_effective_bounds(variable: &Variable) -> (f64, f64) {
+    match variable.domain {
+        Domain::SemiContinuous { threshold } | Domain::SemiInteger { threshold } => {
+            (threshold.min(0.0), variable.ub.max(0.0))
+        }
+        Domain::Real | Domain::Integer | Domain::Binary => (variable.lb, variable.ub),
+    }
+}
+
+fn potential_nonzero_count(variables: &[Variable], members: &[SosMember]) -> usize {
+    members
+        .iter()
+        .filter(|member| raw_effective_bounds(&variables[member.variable.index()]) != (0.0, 0.0))
+        .count()
+}
+
+fn sos2_requires_reformulation(variables: &[Variable], ordered_members: &[SosMember]) -> bool {
+    let mut potential = ordered_members.iter().enumerate().filter_map(|(index, member)| {
+        (raw_effective_bounds(&variables[member.variable.index()]) != (0.0, 0.0)).then_some(index)
+    });
+    let Some(first) = potential.next() else {
+        return false;
+    };
+    let Some(second) = potential.next() else {
+        return false;
+    };
+    potential.next().is_some() || second != first + 1
+}
+
+fn finite_or_fallback(
+    bound: f64,
+    sign: f64,
+    options: SosReformulationOptions,
+    constraint: &SmolStr,
+    variable: &SmolStr,
+    side: &'static str,
+) -> Result<f64, ReformulationError> {
+    if bound.is_finite() {
+        Ok(bound)
+    } else if let Some(big_m) = options.fallback_big_m {
+        Ok(sign * big_m)
+    } else {
+        Err(ReformulationError::MissingFiniteBound {
+            constraint: constraint.clone(),
+            variable: variable.clone(),
+            side,
+        })
+    }
+}
+
+fn unique_variable_name(model: &Model, base: &str) -> SmolStr {
+    unique_name(base, |candidate| model.variable_id(candidate).is_some())
+}
+
+fn unique_constraint_name(model: &Model, base: &str) -> SmolStr {
+    unique_name(base, |candidate| model.constraint_id(candidate).is_some())
+}
+
+fn unique_name(base: &str, exists: impl Fn(&str) -> bool) -> SmolStr {
+    if !exists(base) {
+        return base.into();
+    }
+    for suffix in 1_u64.. {
+        let candidate = format!("{base}_{suffix}");
+        if !exists(&candidate) {
+            return candidate.into();
+        }
+    }
+    unreachable!("u64 name suffix space exhausted")
+}

--- a/crates/oximo-core/src/sos.rs
+++ b/crates/oximo-core/src/sos.rs
@@ -1,7 +1,11 @@
-use std::collections::HashSet;
-
 use oximo_expr::VarId;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 use smol_str::SmolStr;
+
+use crate::model::Model;
+use crate::reformulation::{
+    ReformulatedModel, ReformulationError, SosReformulationArtifacts, SosReformulationOptions,
+};
 
 /// The two standard special ordered set types.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -38,6 +42,68 @@ impl SosConstraintId {
     }
 }
 
+/// A model-bound handle to an SOS constraint.
+///
+/// Single-constraint forms of [`crate::sos_constraint!`] and the programmatic
+/// SOS registration methods return this handle.
+#[derive(Copy, Clone)]
+pub struct SosConstraintHandle<'a> {
+    pub(crate) model: &'a Model,
+    pub(crate) id: SosConstraintId,
+}
+
+impl std::fmt::Debug for SosConstraintHandle<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SosConstraintHandle").field("id", &self.id).finish()
+    }
+}
+
+impl SosConstraintHandle<'_> {
+    #[must_use]
+    pub const fn id(self) -> SosConstraintId {
+        self.id
+    }
+
+    #[must_use]
+    pub fn index(self) -> usize {
+        self.id.index()
+    }
+
+    /// Produce an independent model in which this SOS constraint is replaced
+    /// by mixed-integer algebraic constraints.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReformulationError`] when a fallback Big-M is invalid or a
+    /// member lacks a finite bound and no fallback was supplied.
+    pub fn to_reformulated_model(
+        self,
+        options: SosReformulationOptions,
+    ) -> Result<ReformulatedModel, ReformulationError> {
+        self.model.to_reformulated_sos_constraint_model(self.id, options)
+    }
+
+    /// Replace this SOS constraint on its source model without cloning the
+    /// model. Returns `Ok(None)` if it was already reformulated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReformulationError`] before modifying the model when the
+    /// fallback Big-M or a required member bound is invalid.
+    pub fn reformulate(
+        self,
+        options: SosReformulationOptions,
+    ) -> Result<Option<SosReformulationArtifacts>, ReformulationError> {
+        self.model.reformulate_sos_constraint(self.id, options)
+    }
+}
+
+impl From<SosConstraintHandle<'_>> for SosConstraintId {
+    fn from(value: SosConstraintHandle<'_>) -> Self {
+        value.id
+    }
+}
+
 /// An explicit SOS1 or SOS2 constraint.
 #[derive(Clone, Debug)]
 pub struct SosConstraint {
@@ -50,16 +116,14 @@ pub struct SosConstraint {
 /// Validate an SOS member list before it is stored in a model.
 pub(crate) fn validate_members(name: &str, members: &[SosMember]) {
     assert!(!members.is_empty(), "SOS constraint {name:?} has no members");
-    let mut vars = HashSet::with_capacity(members.len());
+    let mut vars = FxHashSet::with_capacity_and_hasher(members.len(), FxBuildHasher);
+    let mut weights = FxHashSet::with_capacity_and_hasher(members.len(), FxBuildHasher);
     for member in members {
         assert!(member.weight.is_finite(), "SOS constraint {name:?} has a non-finite weight");
         assert!(
             vars.insert(member.variable),
             "SOS constraint {name:?} contains a duplicate variable"
         );
-    }
-    let mut weights = HashSet::with_capacity(members.len());
-    for member in members {
         let key = match member.weight.to_bits() {
             0 | 0x8000_0000_0000_0000 => 0,
             bits => bits,

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -358,7 +358,7 @@ fn unified_constraints_preserve_typed_views_ids_and_order() {
     variable!(m, t >= 0.0);
     constraint!(m, shared, x <= 1.0);
     let soc_id = m.add_soc_constraint("shared", [x], t);
-    let sos_id = m.add_sos_constraint("sos", SosType::Sos1, [(x, 1.0)]);
+    let sos_id = m.add_sos_constraint("sos", SosType::Sos1, [(x, 1.0)]).id();
 
     assert_eq!(m.num_constraints(), 3);
     assert_eq!(m.constraints().algebraic().len(), 1);

--- a/crates/oximo-core/tests/sos.rs
+++ b/crates/oximo-core/tests/sos.rs
@@ -411,6 +411,23 @@ fn in_place_reformulation_validates_all_sets_before_mutating() {
 }
 
 #[test]
+fn model_exposes_in_place_reformulation_history_after_artifacts_drop() {
+    let m = Model::new("in_place_history");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    sos_constraint!(m, choice, SOS1, [x, y]);
+
+    let artifacts = m.reformulate_sos(SosReformulationOptions::default()).unwrap();
+    assert_eq!(artifacts.len(), 1);
+    drop(artifacts);
+
+    let history = m.sos_reformulations();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].source, SosConstraintId(0));
+    assert_eq!(history[0].variables.len(), 2);
+}
+
+#[test]
 fn preserving_reformulation_leaves_source_member_bounds_mutable() {
     let m = Model::new("preserved_source_bounds");
     variable!(m, 0.0 <= x <= 1.0);

--- a/crates/oximo-core/tests/sos.rs
+++ b/crates/oximo-core/tests/sos.rs
@@ -1,4 +1,5 @@
 use oximo_core::prelude::*;
+use oximo_expr::extract_linear;
 
 #[test]
 fn sos_macros_register_and_promote_kind() {
@@ -69,7 +70,8 @@ fn sos_registry_and_display_are_complete() {
     let m = Model::new("sos_display");
     variable!(m, x);
     variable!(m, y);
-    let id = m.add_sos_constraint("choice", SosType::Sos2, [(x, 10.0), (y, 20.0)]);
+    let handle = m.add_sos_constraint("choice", SosType::Sos2, [(x, 10.0), (y, 20.0)]);
+    let id = handle.id();
 
     assert_eq!(id.index(), 0);
     assert_eq!(SosType::Sos1.label(), "SOS1");
@@ -77,7 +79,7 @@ fn sos_registry_and_display_are_complete() {
     assert!(m.has_sos_constraints());
     assert_eq!(m.sos_constraint_id("choice"), Some(id));
     assert_eq!(m.sos_constraint_id("missing"), None);
-    assert_eq!(m.display_sos(id).to_string(), "choice: SOS2 [x: 10, y: 20]");
+    assert_eq!(m.display_sos(handle).to_string(), "choice: SOS2 [x: 10, y: 20]");
     assert!(m.to_string().contains("choice: SOS2 [x: 10, y: 20]"));
     assert_eq!(m.constraints().special_ordered_sets()[0].name, "choice");
 }
@@ -147,4 +149,321 @@ fn sos_rejects_signed_zero_duplicate_weights() {
     variable!(m, x);
     variable!(m, y);
     m.add_sos_constraint("signed_zero", SosType::Sos1, [(x, 0.0), (y, -0.0)]);
+}
+
+#[test]
+fn single_sos_reformulation_is_independent_and_tracks_artifacts() {
+    let m = Model::new("single_reformulation");
+    variable!(m, -2.0 <= x <= 4.0);
+    variable!(m, 0.0 <= y <= 5.0);
+    objective!(m, Max, x + y);
+    let choice = sos_constraint!(m, choice, SOS1, [(x, 1.0), (y, 2.0)]);
+
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+
+    assert_eq!(m.num_variables(), 2);
+    assert_eq!(m.constraints().algebraic().len(), 0);
+    assert!(m.sos_constraints()[choice.index()].active);
+    assert!(m.has_active_sos_constraints());
+
+    assert_eq!(transformed.num_variables(), 4);
+    assert_eq!(transformed.constraints().algebraic().len(), 4);
+    assert!(!transformed.sos_constraints()[choice.index()].active);
+    assert!(transformed.has_sos_constraints());
+    assert!(!transformed.has_active_sos_constraints());
+    assert_eq!(transformed.kind(), ModelKind::MILP);
+    assert_eq!(transformed.sos_reformulations().len(), 1);
+    let history = transformed.sos_reformulations();
+    let artifacts = &history[0];
+    assert_eq!(artifacts.source, choice.id());
+    assert_eq!(artifacts.variables.len(), 2);
+    assert_eq!(artifacts.constraints.len(), 4);
+}
+
+#[test]
+fn sos_reformulation_requires_bounds_unless_fallback_is_explicit() {
+    let m = Model::new("fallback_big_m");
+    variable!(m, x <= 4.0);
+    variable!(m, 0.0 <= y <= 5.0);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+
+    assert!(matches!(
+        choice.to_reformulated_model(SosReformulationOptions::default()),
+        Err(ReformulationError::MissingFiniteBound { side: "lower", .. })
+    ));
+    assert_eq!(m.num_variables(), 2, "failed reformulation did not mutate its source");
+
+    let transformed = choice
+        .to_reformulated_model(SosReformulationOptions::default().with_fallback_big_m(100.0))
+        .unwrap();
+    assert_eq!(transformed.num_variables(), 4);
+    assert!(!transformed.has_active_sos_constraints());
+
+    assert!(matches!(
+        choice.to_reformulated_model(SosReformulationOptions::default().with_fallback_big_m(0.0),),
+        Err(ReformulationError::InvalidFallbackBigM(0.0))
+    ));
+}
+
+#[test]
+fn sos2_reformulation_uses_weight_order_and_adjacent_intervals() {
+    let m = Model::new("sos2_order");
+    variable!(m, 0.0 <= x <= 10.0);
+    variable!(m, 0.0 <= y <= 10.0);
+    variable!(m, 0.0 <= z <= 10.0);
+    objective!(m, Max, x + y + z);
+    let adjacent = sos_constraint!(m, adjacent, SOS2, [(z, 30.0), (x, 10.0), (y, 20.0)]);
+
+    let transformed = adjacent.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+    let history = transformed.sos_reformulations();
+    let artifacts = &history[0];
+    assert_eq!(artifacts.variables.len(), 2, "one binary per adjacent interval");
+    assert_eq!(artifacts.constraints.len(), 4, "selection plus one upper gate per member");
+
+    let interval_0 = artifacts.variables[0];
+    let interval_1 = artifacts.variables[1];
+    let arena = transformed.arena();
+    let model_constraints = transformed.constraints();
+    let rows = model_constraints.algebraic();
+    let coefficients = |row: usize| {
+        extract_linear(&arena, rows[row].lhs)
+            .unwrap()
+            .coeffs
+            .into_iter()
+            .collect::<std::collections::HashMap<_, _>>()
+    };
+
+    let x_upper = coefficients(1);
+    assert_eq!(x_upper.get(&x.var_id().unwrap()), Some(&1.0));
+    assert_eq!(x_upper.get(&interval_0), Some(&-10.0));
+    assert!(!x_upper.contains_key(&interval_1));
+
+    let y_upper = coefficients(2);
+    assert_eq!(y_upper.get(&y.var_id().unwrap()), Some(&1.0));
+    assert_eq!(y_upper.get(&interval_0), Some(&-10.0));
+    assert_eq!(y_upper.get(&interval_1), Some(&-10.0));
+
+    let z_upper = coefficients(3);
+    assert_eq!(z_upper.get(&z.var_id().unwrap()), Some(&1.0));
+    assert!(!z_upper.contains_key(&interval_0));
+    assert_eq!(z_upper.get(&interval_1), Some(&-10.0));
+}
+
+#[test]
+fn whole_model_reformulation_skips_inactive_and_handles_degenerate_sets() {
+    let m = Model::new("all_sos");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    objective!(m, Max, x + y);
+    sos_constraint!(m, singleton, SOS1, [x]);
+    sos_constraint!(m, pair, SOS2, [x, y]);
+
+    let transformed = m.to_reformulated_sos_model(SosReformulationOptions::default()).unwrap();
+    assert_eq!(transformed.num_variables(), 2, "degenerate sets need no binaries");
+    assert_eq!(transformed.constraints().algebraic().len(), 0);
+    assert_eq!(transformed.sos_reformulations().len(), 2);
+    assert!(
+        transformed
+            .sos_reformulations()
+            .iter()
+            .all(|entry| { entry.variables.is_empty() && entry.constraints.is_empty() })
+    );
+    assert!(!transformed.has_active_sos_constraints());
+    assert_eq!(transformed.kind(), ModelKind::LP);
+}
+
+#[test]
+fn generated_names_avoid_user_collisions() {
+    let m = Model::new("name_collision");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    variable!(m, __oximo_sos0_member_0, Binary);
+    constraint!(m, __oximo_sos0_select, x <= 1.0);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+    assert!(transformed.variable_id("__oximo_sos0_member_0_1").is_some());
+    assert!(transformed.constraint_id("__oximo_sos0_select_1").is_some());
+}
+
+#[test]
+fn reformulation_omits_sign_redundant_big_m_rows() {
+    let m = Model::new("sign_redundant_rows");
+    variable!(m, -5.0 <= crossing <= 7.0);
+    variable!(m, 2.0 <= nonnegative <= 8.0);
+    variable!(m, -9.0 <= nonpositive <= -3.0);
+    variable!(m, fixed, fix = 0.0);
+    let choice = sos_constraint!(m, choice, SOS1, [crossing, nonnegative, nonpositive, fixed]);
+
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+    let history = transformed.sos_reformulations();
+    let artifacts = &history[0];
+
+    assert_eq!(artifacts.variables.len(), 3, "fixed-zero members need no activation");
+    assert_eq!(
+        artifacts.constraints.len(),
+        5,
+        "one selection row, two crossing-sign gates, and one gate per sign-definite member"
+    );
+    assert!(transformed.constraint_id("__oximo_sos0_member_0_lower").is_some());
+    assert!(transformed.constraint_id("__oximo_sos0_member_0_upper").is_some());
+    assert!(transformed.constraint_id("__oximo_sos0_member_1_lower").is_none());
+    assert!(transformed.constraint_id("__oximo_sos0_member_1_upper").is_some());
+    assert!(transformed.constraint_id("__oximo_sos0_member_2_lower").is_some());
+    assert!(transformed.constraint_id("__oximo_sos0_member_2_upper").is_none());
+    assert!(transformed.constraint_id("__oximo_sos0_member_3_lower").is_none());
+    assert!(transformed.constraint_id("__oximo_sos0_member_3_upper").is_none());
+}
+
+#[test]
+fn trivially_satisfied_sos_sets_need_no_bounds_or_artifacts() {
+    let m = Model::new("trivial_fixed_zero_members");
+    variable!(m, unbounded);
+    variable!(m, other_unbounded);
+    variable!(m, zero_1, fix = 0.0);
+    variable!(m, zero_2, fix = 0.0);
+    let sos1 = sos_constraint!(m, one_possible_nonzero, SOS1, [unbounded, zero_1]);
+    sos_constraint!(
+        m,
+        adjacent_possible_nonzeros,
+        SOS2,
+        [(unbounded, 30.0), (zero_2, 10.0), (other_unbounded, 20.0)]
+    );
+
+    let transformed = m.to_reformulated_sos_model(SosReformulationOptions::default()).unwrap();
+
+    assert!(!transformed.has_active_sos_constraints());
+    assert_eq!(transformed.num_variables(), 4);
+    assert!(transformed.constraints().algebraic().is_empty());
+    assert_eq!(transformed.sos_reformulations().len(), 2);
+    assert!(
+        transformed
+            .sos_reformulations()
+            .iter()
+            .all(|artifacts| artifacts.variables.is_empty() && artifacts.constraints.is_empty())
+    );
+    assert_eq!(sos1.index(), 0);
+}
+
+#[test]
+fn fixed_zero_member_still_separates_nonadjacent_sos2_members() {
+    let m = Model::new("fixed_zero_sos2_gap");
+    variable!(m, left);
+    variable!(m, gap, fix = 0.0);
+    variable!(m, right);
+    sos_constraint!(m, separated, SOS2, [left, gap, right]);
+
+    assert!(matches!(
+        m.to_reformulated_sos_model(SosReformulationOptions::default()),
+        Err(ReformulationError::MissingFiniteBound { .. })
+    ));
+
+    let transformed = m
+        .to_reformulated_sos_model(SosReformulationOptions::default().with_fallback_big_m(10.0))
+        .unwrap();
+    let history = transformed.sos_reformulations();
+    let artifacts = &history[0];
+    assert_eq!(artifacts.variables.len(), 2);
+    assert_eq!(artifacts.constraints.len(), 5);
+}
+
+#[test]
+fn in_place_reformulation_preserves_handles_and_matches_independent_shape() {
+    let m = Model::new("in_place");
+    variable!(m, -2.0 <= x <= 4.0);
+    variable!(m, 0.0 <= y <= 5.0);
+    objective!(m, Max, x + y);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+    let independent = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+
+    let artifacts = m
+        .reformulate_sos(SosReformulationOptions::default())
+        .unwrap()
+        .pop()
+        .expect("active SOS produces artifacts");
+
+    assert!(!m.has_active_sos_constraints());
+    assert_eq!(m.num_variables(), independent.num_variables());
+    assert_eq!(m.constraints().algebraic().len(), independent.constraints().algebraic().len());
+    assert_eq!(artifacts.variables, independent.sos_reformulations()[0].variables);
+    assert_eq!(artifacts.constraints, independent.sos_reformulations()[0].constraints);
+    assert_eq!(m.display_expr(x + y).to_string(), "x + y");
+    assert!(choice.reformulate(SosReformulationOptions::default()).unwrap().is_none());
+}
+
+#[test]
+fn in_place_reformulation_validates_all_sets_before_mutating() {
+    let m = Model::new("in_place_atomic_error");
+    variable!(m, 0.0 <= bounded_x <= 1.0);
+    variable!(m, 0.0 <= bounded_y <= 1.0);
+    variable!(m, unbounded_x);
+    variable!(m, unbounded_y);
+    sos_constraint!(m, bounded, SOS1, [bounded_x, bounded_y]);
+    sos_constraint!(m, unbounded, SOS1, [unbounded_x, unbounded_y]);
+
+    assert!(matches!(
+        m.reformulate_sos(SosReformulationOptions::default()),
+        Err(ReformulationError::MissingFiniteBound { .. })
+    ));
+    assert_eq!(m.num_variables(), 4);
+    assert!(m.constraints().algebraic().is_empty());
+    assert!(m.sos_constraints().iter().all(|constraint| constraint.active));
+}
+
+#[test]
+fn preserving_reformulation_leaves_source_member_bounds_mutable() {
+    let m = Model::new("preserved_source_bounds");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+    m.unfix_var(x.var_id().unwrap(), -10.0, 100.0);
+
+    assert!((m.variables()[x.var_id().unwrap().index()].ub - 100.0).abs() < f64::EPSILON);
+    assert!((transformed.variables()[x.var_id().unwrap().index()].ub - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+#[should_panic(expected = "after SOS constraint \"choice\" was reformulated")]
+fn reformulated_model_rejects_member_bound_changes() {
+    let m = Model::new("frozen_reformulated_bounds");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+
+    transformed.unfix_var(x.var_id().unwrap(), -10.0, 100.0);
+}
+
+#[test]
+#[should_panic(expected = "after SOS constraint \"choice\" was reformulated")]
+fn trivial_reformulation_also_freezes_member_bounds() {
+    let m = Model::new("frozen_trivial_reformulation");
+    variable!(m, x);
+    variable!(m, y, fix = 0.0);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+    choice.reformulate(SosReformulationOptions::default()).unwrap();
+
+    m.unfix_var(y.var_id().unwrap(), -1.0, 1.0);
+}
+
+#[test]
+fn chained_preserving_reformulations_retain_complete_provenance() {
+    let m = Model::new("chained_provenance");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    variable!(m, 0.0 <= z <= 1.0);
+    let first = sos_constraint!(m, first, SOS1, [x, y]);
+    let second = sos_constraint!(m, second, SOS1, [y, z]);
+
+    let once = first.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+    let twice = once
+        .to_reformulated_sos_constraint_model(second.id(), SosReformulationOptions::default())
+        .unwrap();
+    let history = twice.sos_reformulations();
+
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].source, first.id());
+    assert_eq!(history[1].source, second.id());
 }

--- a/crates/oximo-expr/src/arena.rs
+++ b/crates/oximo-expr/src/arena.rs
@@ -69,6 +69,22 @@ impl ExprArena {
         Self { nodes: Vec::with_capacity(cap), param_values: Vec::new() }
     }
 
+    /// Clone this arena while reserving room for nodes that will immediately
+    /// be appended to the copy.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __clone_with_additional_capacity(&self, additional_nodes: usize) -> Self {
+        let mut nodes = Vec::with_capacity(self.nodes.len().saturating_add(additional_nodes));
+        nodes.extend_from_slice(&self.nodes);
+        Self { nodes, param_values: self.param_values.clone() }
+    }
+
+    /// Reserve room for additional expression nodes without changing IDs.
+    #[doc(hidden)]
+    pub fn __reserve_nodes(&mut self, additional: usize) {
+        self.nodes.reserve(additional);
+    }
+
     #[inline]
     pub fn len(&self) -> usize {
         self.nodes.len()

--- a/crates/oximo-gams/tests/sos.rs
+++ b/crates/oximo-gams/tests/sos.rs
@@ -15,3 +15,17 @@ fn gams_advertises_sos1_and_sos2_support() {
     assert!(solver.supports_sos(SosType::Sos2));
     assert!(solver.supports_model(&model));
 }
+
+#[test]
+fn gams_accepts_a_reformulated_model_without_active_sos() {
+    let model = Model::new("gams_reformulated_sos");
+    variable!(model, 0.0 <= x <= 1.0);
+    variable!(model, 0.0 <= y <= 1.0);
+    objective!(model, Max, x + y);
+    let choice = sos_constraint!(model, choice, SOS1, [x, y]);
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+
+    let solver = Gams::new();
+    assert!(!transformed.has_active_sos_constraints());
+    assert!(solver.supports_model(&transformed));
+}

--- a/crates/oximo-gurobi/tests/sos.rs
+++ b/crates/oximo-gurobi/tests/sos.rs
@@ -38,3 +38,23 @@ fn native_sos2_rejects_nonadjacent_optimum() {
         "non-adjacent members selected: x={x_value}, z={z_value}"
     );
 }
+
+#[test]
+fn reformulated_sos1_solves_and_preserves_original_ids() {
+    let m = Model::new("reformulated_sos1");
+    variable!(m, 0.0 <= x <= 1.0);
+    variable!(m, 0.0 <= y <= 1.0);
+    objective!(m, Max, x + y);
+    let choice = sos_constraint!(m, choice, SOS1, [x, y]);
+
+    let transformed = choice.to_reformulated_model(SosReformulationOptions::default()).unwrap();
+    assert!(Gurobi.supports_model(&transformed));
+    let result = Gurobi
+        .solve(&transformed, &GurobiOptions::default())
+        .expect("Gurobi reformulated SOS solve");
+
+    assert!((result.objective().unwrap() - 1.0).abs() < 1e-6);
+    assert!(result.value_of(x).unwrap() + result.value_of(y).unwrap() <= 1.0 + 1e-6);
+    assert_eq!(choice.id().index(), 0);
+    assert!(!transformed.sos_constraints()[choice.index()].active);
+}

--- a/crates/oximo-highs/src/persistent.rs
+++ b/crates/oximo-highs/src/persistent.rs
@@ -147,8 +147,8 @@ impl Solver for HighsPersistent {
     }
 
     fn solve(&mut self, model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {
-        if model.has_sos_constraints() {
-            return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+        if model.has_active_sos_constraints() {
+            return Err(SolverError::UnsupportedSos);
         }
         match self.solve_resident(model, opts) {
             Ok(result) => Ok(result),

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -43,8 +43,8 @@ use crate::options::apply as apply_options;
 ///
 /// Panics if model variable IDs overflow `u32`.
 pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     let (prob, meta) = build_problem(model)?;
     let live = make_live(prob, opts)?;
@@ -95,8 +95,8 @@ pub(crate) struct Meta {
 /// Returns a [`SolverError`] if the model kind is unsupported, a domain cannot be
 /// represented, or an expression is not linear/quadratic as required.
 pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();

--- a/crates/oximo-highs/tests/sos.rs
+++ b/crates/oximo-highs/tests/sos.rs
@@ -16,7 +16,7 @@ fn highs_rejects_sos_constraints() {
     let mut solver = Highs;
     assert!(matches!(
         solver.solve(&model, &HighsOptions::default()),
-        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+        Err(SolverError::UnsupportedSos)
     ));
 }
 
@@ -26,6 +26,37 @@ fn highs_persistent_rejects_sos_constraints() {
     let mut solver = Highs.persistent();
     assert!(matches!(
         solver.solve(&model, &HighsOptions::default()),
-        Err(SolverError::UnsupportedConstraint("SOS1/SOS2"))
+        Err(SolverError::UnsupportedSos)
     ));
+}
+
+#[test]
+fn highs_solves_explicit_sos1_reformulation() {
+    let model = Model::new("highs_reformulated_sos1");
+    variable!(model, 0.0 <= x <= 1.0);
+    variable!(model, 0.0 <= y <= 1.0);
+    objective!(model, Max, x + y);
+    sos_constraint!(model, choice, SOS1, [x, y]);
+    let transformed = model.to_reformulated_sos_model(SosReformulationOptions::default()).unwrap();
+
+    let mut solver = Highs;
+    let result = solver.solve(&transformed, &HighsOptions::default()).unwrap();
+    assert!((result.objective().unwrap() - 1.0).abs() < 1e-7);
+    assert!(result.value_of(x).unwrap() + result.value_of(y).unwrap() <= 1.0 + 1e-7);
+}
+
+#[test]
+fn highs_solves_weight_ordered_sos2_reformulation() {
+    let model = Model::new("highs_reformulated_sos2");
+    variable!(model, 0.0 <= x <= 1.0);
+    variable!(model, 0.0 <= y <= 1.0);
+    variable!(model, 0.0 <= z <= 1.0);
+    objective!(model, Max, x + z);
+    sos_constraint!(model, adjacent, SOS2, [(z, 3.0), (x, 1.0), (y, 2.0)]);
+    let transformed = model.to_reformulated_sos_model(SosReformulationOptions::default()).unwrap();
+
+    let mut solver = Highs;
+    let result = solver.solve(&transformed, &HighsOptions::default()).unwrap();
+    assert!((result.objective().unwrap() - 1.0).abs() < 1e-7);
+    assert!(result.value_of(x).unwrap() + result.value_of(z).unwrap() <= 1.0 + 1e-7);
 }

--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -1116,11 +1116,11 @@ pub fn write_lp<W: Write>(model: &Model, out: &mut W) -> Result<(), IoError> {
     }
 
     let sos = model.sos_constraints();
-    if !sos.is_empty() {
+    if sos.iter().any(|constraint| constraint.active) {
         let vars_by_id: HashMap<oximo_core::VarId, &str> =
             vars.iter().map(|v| (v.id, v.name.as_str())).collect();
         writeln!(out, "SOS")?;
-        for s in sos.iter() {
+        for s in sos.iter().filter(|constraint| constraint.active) {
             validate_lp_row_name(&s.name)?;
             write!(
                 out,

--- a/crates/oximo-io/src/mps.rs
+++ b/crates/oximo-io/src/mps.rs
@@ -1076,12 +1076,10 @@ fn write_sos_section<W: Write>(
     variable_names: &[String],
 ) -> Result<(), IoError> {
     writeln!(out, "SOS")?;
-    let sos_names = unique_mps_names(
-        constraints.iter().map(|s| s.name.as_str()),
-        "S",
-        std::iter::empty::<&str>(),
-    );
-    for (set, set_name) in constraints.iter().zip(sos_names.iter()) {
+    let active = || constraints.iter().filter(|constraint| constraint.active);
+    let sos_names =
+        unique_mps_names(active().map(|s| s.name.as_str()), "S", std::iter::empty::<&str>());
+    for (set, set_name) in active().zip(sos_names.iter()) {
         writeln!(
             out,
             " S{} {}",
@@ -1267,8 +1265,7 @@ pub fn write_mps_with<W: Write>(
     out: &mut W,
     options: &MpsWriteOptions,
 ) -> Result<(), IoError> {
-    if !model.sos_constraints().is_empty() && options.quadratic_format == MpsQuadraticFormat::Mosek
-    {
+    if model.has_active_sos_constraints() && options.quadratic_format == MpsQuadraticFormat::Mosek {
         return Err(IoError::UnsupportedMps {
             section: "SOS".into(),
             feature: "SOS is not supported by the MOSEK MPS dialect".into(),
@@ -1455,7 +1452,8 @@ pub fn write_mps_with<W: Write>(
     }
 
     let sos = model.sos_constraints();
-    if options.quadratic_format == MpsQuadraticFormat::Cplex && !sos.is_empty() {
+    let has_active_sos = sos.iter().any(|constraint| constraint.active);
+    if options.quadratic_format == MpsQuadraticFormat::Cplex && has_active_sos {
         write_sos_section(out, &sos, &variable_names)?;
     }
 
@@ -1494,7 +1492,7 @@ pub fn write_mps_with<W: Write>(
         )?;
     }
 
-    if options.quadratic_format != MpsQuadraticFormat::Cplex && !sos.is_empty() {
+    if options.quadratic_format != MpsQuadraticFormat::Cplex && has_active_sos {
         write_sos_section(out, &sos, &variable_names)?;
     }
 

--- a/crates/oximo-io/src/nl/mod.rs
+++ b/crates/oximo-io/src/nl/mod.rs
@@ -89,7 +89,7 @@ pub fn write_nl_with<W: Write>(
     if model.num_soc_constraints() > 0 {
         return Err(IoError::Conic);
     }
-    if model.has_sos_constraints() {
+    if model.has_active_sos_constraints() {
         return Err(IoError::UnsupportedNl {
             section: "SOS".into(),
             feature: "SOS constraints have no native NL segment".into(),

--- a/crates/oximo-io/tests/conic.rs
+++ b/crates/oximo-io/tests/conic.rs
@@ -58,3 +58,20 @@ fn mosek_mps_writer_rejects_sos_constraints() {
         Err(IoError::UnsupportedMps { section, .. }) if section == "SOS"
     ));
 }
+
+#[test]
+fn text_writers_omit_reformulated_source_sos_constraints() {
+    let transformed = sos_model()
+        .to_reformulated_sos_model(SosReformulationOptions::default().with_fallback_big_m(10.0))
+        .expect("SOS reformulation");
+
+    let lp = to_lp_string(&transformed).expect("reformulated LP");
+    assert!(!lp.contains("\nSOS\n"));
+
+    for format in [MpsQuadraticFormat::Gurobi, MpsQuadraticFormat::Cplex, MpsQuadraticFormat::Mosek]
+    {
+        let options = MpsWriteOptions { quadratic_format: format };
+        let mps = to_mps_string_with(&transformed, &options).expect("reformulated MPS");
+        assert!(!mps.contains("\nSOS\n"));
+    }
+}

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -39,8 +39,8 @@ struct TaskScratch {
 /// Returns an error for unsupported model kinds or variable domains, invalid
 /// expressions, and native MOSEK setup, optimization, or solution-query errors.
 pub fn solve(model: &Model, opts: &MosekOptions) -> Result<SolverResult, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     let (mut task, meta) = build_task(model, opts)?;
     solve_task(model, &mut task, &meta)
@@ -54,8 +54,8 @@ pub(crate) fn build_task(
     model: &Model,
     opts: &MosekOptions,
 ) -> Result<(TaskCB, Meta), SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let kind = model.kind();

--- a/crates/oximo-mosek/tests/solve.rs
+++ b/crates/oximo-mosek/tests/solve.rs
@@ -173,6 +173,19 @@ fn unsupported_nonlinear_and_semi_domains() {
 }
 
 #[test]
+fn unsupported_sos_reports_explicit_reformulation_hint() {
+    let model = Model::new("mosek_sos");
+    variable!(model, 0.0 <= x <= 1.0);
+    variable!(model, 0.0 <= y <= 1.0);
+    objective!(model, Max, x + y);
+    sos_constraint!(model, choice, SOS1, [x, y]);
+
+    let error = solve(&model, &MosekOptions::default()).unwrap_err();
+    assert!(matches!(error, SolverError::UnsupportedSos));
+    assert!(error.to_string().contains("Model::to_reformulated_sos_model"));
+}
+
+#[test]
 fn mosek_reports_nonconvex_quadratic_data() {
     let model = Model::new("nonconvex");
     variable!(model, -1.0 <= x <= 1.0);

--- a/crates/oximo-pounce/src/convex.rs
+++ b/crates/oximo-pounce/src/convex.rs
@@ -265,8 +265,8 @@ fn push_row(out: &mut Vec<Triplet>, row: usize, terms: &LinearTerms, scale: f64)
 )]
 #[expect(clippy::too_many_lines)]
 pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     model.ensure_objective_declared().map_err(SolverError::Core)?;
     let arena = model.arena();

--- a/crates/oximo-pounce/src/persistent.rs
+++ b/crates/oximo-pounce/src/persistent.rs
@@ -79,8 +79,8 @@ impl PouncePersistent {
         model: &Model,
         opts: &PounceOptions,
     ) -> Result<SolverResult, SolverError> {
-        if model.has_sos_constraints() {
-            return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+        if model.has_active_sos_constraints() {
+            return Err(SolverError::UnsupportedSos);
         }
         let route = convex::route(model, opts)?;
         if route == Route::Nlp {

--- a/crates/oximo-pounce/src/translate.rs
+++ b/crates/oximo-pounce/src/translate.rs
@@ -75,8 +75,8 @@ pub(crate) struct Outcome {
 /// [`SolverError::Core`] for a model with neither an objective nor a declared
 /// feasibility problem.
 pub fn solve(model: &Model, opts: &PounceOptions) -> Result<SolverResult, SolverError> {
-    if model.has_sos_constraints() {
-        return Err(SolverError::UnsupportedConstraint("SOS1/SOS2"));
+    if model.has_active_sos_constraints() {
+        return Err(SolverError::UnsupportedSos);
     }
     let route = crate::convex::route(model, opts)?;
     if route != crate::convex::Route::Nlp {

--- a/crates/oximo-pounce/tests/solve_pounce.rs
+++ b/crates/oximo-pounce/tests/solve_pounce.rs
@@ -155,10 +155,10 @@ fn sos_constraints_are_rejected_consistently() {
     sos_constraint!(m, ordered, SOS1, [(x, 1.0), (y, 2.0)]);
 
     let cold = Pounce.solve(&m, &PounceOptions::default()).unwrap_err();
-    assert!(matches!(cold, SolverError::UnsupportedConstraint("SOS1/SOS2")));
+    assert!(matches!(cold, SolverError::UnsupportedSos));
     let mut persistent = Pounce.persistent();
     let resident = persistent.solve(&m, &PounceOptions::default()).unwrap_err();
-    assert!(matches!(resident, SolverError::UnsupportedConstraint("SOS1/SOS2")));
+    assert!(matches!(resident, SolverError::UnsupportedSos));
 }
 
 #[test]

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -97,6 +97,9 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
     }
 
     for sos in model.sos_constraints().iter() {
+        if !sos.active {
+            continue;
+        }
         hasher.write_u8(match sos.sos_type {
             oximo_core::SosType::Sos1 => 1,
             oximo_core::SosType::Sos2 => 2,
@@ -171,6 +174,21 @@ mod tests {
         let s2 = snapshot(&m).unwrap();
         assert_eq!(s1.fingerprint, s2.fingerprint, "structure unchanged");
         assert_ne!(s1.ub, s2.ub, "bound moved");
+    }
+
+    #[test]
+    fn reformulated_inactive_sos_snapshots_as_linear_structure() {
+        let m = Model::new("reformulated_sos");
+        variable!(m, 0.0 <= x <= 1.0);
+        variable!(m, 0.0 <= y <= 1.0);
+        sos_constraint!(m, choice, SOS1, [x, y]);
+        objective!(m, Max, x + y);
+
+        let transformed = m
+            .to_reformulated_sos_model(SosReformulationOptions::default())
+            .expect("bounded SOS reformulates");
+        assert!(!transformed.has_active_sos_constraints());
+        assert!(snapshot(&transformed).is_ok());
     }
 
     #[test]

--- a/crates/oximo-solver/src/infeasibility.rs
+++ b/crates/oximo-solver/src/infeasibility.rs
@@ -171,7 +171,7 @@ mod tests {
         let hi = constraint!(m, ceil, x <= 1.0);
         let sos = {
             variable!(m, y);
-            m.add_sos_constraint("choice", SosType::Sos1, [(y, 1.0)])
+            m.add_sos_constraint("choice", SosType::Sos1, [(y, 1.0)]).id()
         };
 
         let iis = Iis {

--- a/crates/oximo-solver/src/solver.rs
+++ b/crates/oximo-solver/src/solver.rs
@@ -33,7 +33,11 @@ pub trait Solver {
     /// Whether this backend can consume all features present in `model`.
     fn supports_model(&self, model: &Model) -> bool {
         self.supports(model.kind())
-            && model.sos_constraints().iter().all(|s| self.supports_sos(s.sos_type))
+            && model
+                .sos_constraints()
+                .iter()
+                .filter(|constraint| constraint.active)
+                .all(|constraint| self.supports_sos(constraint.sos_type))
     }
 
     /// Solves the given `Model` using this solver.
@@ -106,5 +110,13 @@ mod tests {
         let model = sos_model();
         assert!(!NoSos.supports_model(&model));
         assert!(NativeSos.supports_model(&model));
+
+        let transformed = model
+            .to_reformulated_sos_model(
+                oximo_core::SosReformulationOptions::default().with_fallback_big_m(100.0),
+            )
+            .unwrap();
+        assert!(NoSos.supports_model(&transformed));
+        assert!(NativeSos.supports_model(&transformed));
     }
 }

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -118,6 +118,11 @@ pub enum SolverError {
     UnsupportedKind(oximo_core::ModelKind),
     #[error("solver does not support native {0} constraints")]
     UnsupportedConstraint(&'static str),
+    #[error(
+        "solver does not support native SOS1/SOS2 constraints. Explicitly reformulate them with \
+         Model::reformulate_sos or Model::to_reformulated_sos_model"
+    )]
+    UnsupportedSos,
     #[error("model is missing an objective")]
     NoObjective,
     #[error("{location} contains a nonlinear term unsupported by this backend: {term}")]
@@ -141,6 +146,13 @@ impl std::fmt::Debug for SolverError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unsupported_sos_error_points_to_explicit_reformulation_methods() {
+        let message = SolverError::UnsupportedSos.to_string();
+        assert!(message.contains("Model::reformulate_sos"));
+        assert!(message.contains("Model::to_reformulated_sos_model"));
+    }
 
     /// The contract for a single termination: whether it admits a primal point
     /// ([`TerminationStatus::admits_primal`]) and what [`PrimalStatus::infer`]

--- a/crates/oximo/Cargo.toml
+++ b/crates/oximo/Cargo.toml
@@ -91,6 +91,10 @@ name = "sos"
 required-features = ["gurobi"]
 
 [[example]]
+name = "sos_reformulated"
+required-features = ["highs"]
+
+[[example]]
 name = "transport"
 required-features = ["highs"]
 

--- a/crates/oximo/examples/sos_reformulated.rs
+++ b/crates/oximo/examples/sos_reformulated.rs
@@ -1,0 +1,56 @@
+//! SOS1 and SOS2 constraints explicitly reformulated and solved with HiGHS.
+//!
+//! This is the portable-MILP counterpart to the native-Gurobi `sos` example.
+//!
+//! Run with:
+//! ```text
+//! cargo run -p oximo --example sos_reformulated --features highs
+//! ```
+
+use oximo::prelude::*;
+use oximo::{HighsOptions, solvers::Highs};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model = Model::new("sos_reformulated_example");
+
+    variable!(model, 0.0 <= choice_a <= 10.0);
+    variable!(model, 0.0 <= choice_b <= 10.0);
+    variable!(model, 0.0 <= choice_c <= 10.0);
+    variable!(model, 0.0 <= curve_0 <= 10.0);
+    variable!(model, 0.0 <= curve_1 <= 10.0);
+    variable!(model, 0.0 <= curve_2 <= 10.0);
+
+    // At most one choice variable may be nonzero.
+    sos_constraint!(model, one_choice, SOS1, [choice_a, choice_b, choice_c]);
+
+    // At most two curve variables may be nonzero, and they must be adjacent
+    // according to their weights.
+    sos_constraint!(model, adjacent_curve, SOS2, [(curve_0, 1.0), (curve_1, 2.0), (curve_2, 3.0),]);
+
+    objective!(
+        model,
+        Max,
+        choice_a + 2.0 * choice_b + 3.0 * choice_c + curve_0 + curve_1 + curve_2
+    );
+
+    // HiGHS has no native SOS support, so explicitly replace every active SOS
+    // with binary variables and linear Big-M rows.
+    //
+    // The finite member bounds are used as their individual Big-M values.
+    let reformulations = model.reformulate_sos(SosReformulationOptions::default())?;
+    println!("reformulated {} SOS constraints", reformulations.len());
+
+    let result = Highs.solve(&model, &HighsOptions::default())?;
+    println!("termination = {:?}", result.termination);
+    for (name, value) in [
+        ("choice_a", result.value_of(choice_a)),
+        ("choice_b", result.value_of(choice_b)),
+        ("choice_c", result.value_of(choice_c)),
+        ("curve_0", result.value_of(curve_0)),
+        ("curve_1", result.value_of(curve_1)),
+        ("curve_2", result.value_of(curve_2)),
+    ] {
+        println!("{name:>8} = {:.6}", value.unwrap_or_default());
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR adds support for SOS-to-MILP reformulation.
It also set the bases for future reformulations.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [ ] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [ ] `cargo test --features mosek` passes (requires MOSEK)
- [ ] `cargo test --features baron` passes (requires BARON)
