### PR TITLE
oximo-autodiff: Reuse merged Hessian patterns for seed

### DIFF
--- a/crates/oximo-autodiff/src/evaluator.rs
+++ b/crates/oximo-autodiff/src/evaluator.rs
@@ -19,7 +19,8 @@ use crate::slot::{
     quadratic_value,
 };
 use crate::sparsity::{
-    SparsityWorkspace, hessian_lagrangian_structure, jacobian_structure, star_hessian_coloring,
+    SparsityWorkspace, hessian_lagrangian_patterns, hessian_lagrangian_structure,
+    jacobian_structure, star_hessian_coloring,
 };
 use crate::tape::Tape;
 
@@ -187,14 +188,14 @@ impl NlpEvaluator {
         drop(arena);
 
         let jac_structure = jacobian_structure(&constraints);
-        let hess_structure =
-            hessian_lagrangian_structure(std::iter::once(&objective).chain(&constraints));
+        let (hess_structure, nl_pattern) =
+            hessian_lagrangian_patterns(std::iter::once(&objective).chain(&constraints));
 
         let obj_hess_pos = quad_scatter_positions(&objective, &hess_structure);
         let con_hess_pos =
             constraints.iter().map(|s| quad_scatter_positions(s, &hess_structure)).collect();
 
-        let seeds = build_seeds(&objective, &constraints, &hess_structure);
+        let seeds = build_seeds(&nl_pattern, &hess_structure);
 
         let max_regs = std::iter::once(&objective)
             .chain(&constraints)
@@ -696,28 +697,22 @@ fn quad_scatter_positions(slot: &FunctionSlot, hess: &[(usize, usize)]) -> Vec<u
 /// The quadratic entries in `hess_structure` are filled in
 /// closed form and must neither constrain the grouping nor
 /// receive `hv` values.
-fn build_seeds(
-    objective: &FunctionSlot,
-    constraints: &[FunctionSlot],
-    hess_structure: &[(usize, usize)],
-) -> Vec<Seed> {
-    let mut nl_pattern: Vec<(usize, usize)> = std::iter::once(objective)
-        .chain(constraints)
-        .filter(|s| s.is_nonlinear())
-        .flat_map(|s| s.hess_pairs.iter().map(|&(r, c)| (r as usize, c as usize)))
-        .collect();
-    nl_pattern.sort_unstable();
-    nl_pattern.dedup();
-
+fn build_seeds(nl_pattern: &[(usize, usize)], hess_structure: &[(usize, usize)]) -> Vec<Seed> {
     // Star-color the nonlinear pattern.
-    let coloring = star_hessian_coloring(&nl_pattern);
+    let coloring = star_hessian_coloring(nl_pattern);
     let mut seeds: Vec<Seed> =
         coloring.groups.into_iter().map(|cols| Seed { cols, fills: Vec::new() }).collect();
+    let mut hess_pos = 0;
     for (&(row, col), &(group, hv_row)) in nl_pattern.iter().zip(&coloring.recover) {
-        let pos = hess_structure
-            .binary_search(&(row, col))
-            .expect("nonlinear entry is in the merged pattern by construction");
-        seeds[group].fills.push((pos, hv_row));
+        while hess_structure[hess_pos] < (row, col) {
+            hess_pos += 1;
+        }
+        assert_eq!(
+            hess_structure[hess_pos],
+            (row, col),
+            "nonlinear entry is in the merged pattern by construction"
+        );
+        seeds[group].fills.push((hess_pos, hv_row));
     }
     seeds
 }

--- a/crates/oximo-autodiff/src/sparsity.rs
+++ b/crates/oximo-autodiff/src/sparsity.rs
@@ -12,6 +12,8 @@ use crate::slot::{FunctionSlot, SlotKind};
 // Keeps the dense triangular pair bitmap at or below 64 KiB. Wider expressions
 // use sparse rows and pairs so memory follows actual structural nonzeros.
 const DENSE_SPARSITY_MAX_VARS: usize = 1_024;
+type HessianPattern = Vec<(usize, usize)>;
+type HessianPatterns = (HessianPattern, Option<HessianPattern>);
 
 /// Sorted, deduplicated indices of the variables appearing under `root`.
 pub fn variable_support(arena: &ExprArena, root: ExprId) -> Vec<u32> {
@@ -702,8 +704,24 @@ where
     I: IntoIterator<Item = &'a FunctionSlot>,
 {
     let slots: Vec<_> = slots.into_iter().collect();
+    hessian_patterns_impl(&slots, false).0
+}
+
+/// Build the merged Hessian pattern and the nonlinear-only subset in one pass
+/// over the slots.
+#[cfg(feature = "enzyme")]
+pub(crate) fn hessian_lagrangian_patterns<'a, I>(slots: I) -> (HessianPattern, HessianPattern)
+where
+    I: IntoIterator<Item = &'a FunctionSlot>,
+{
+    let slots: Vec<_> = slots.into_iter().collect();
+    let (full, nonlinear) = hessian_patterns_impl(&slots, true);
+    (full, nonlinear.expect("nonlinear pattern requested"))
+}
+
+fn hessian_patterns_impl(slots: &[&FunctionSlot], include_nonlinear: bool) -> HessianPatterns {
     let mut max_variable = None;
-    for slot in &slots {
+    for slot in slots {
         match &slot.kind {
             SlotKind::Linear(_) => {}
             SlotKind::Quadratic(q) => {
@@ -723,7 +741,8 @@ where
         let variables = max_variable.map_or(0, |index| index + 1);
         let pair_count = variables * (variables + 1) / 2;
         let mut pairs = vec![0; words_for(pair_count)];
-        for slot in &slots {
+        let mut nonlinear_pairs = include_nonlinear.then(|| vec![0; words_for(pair_count)]);
+        for slot in slots {
             match &slot.kind {
                 SlotKind::Linear(_) => {}
                 SlotKind::Quadratic(q) => {
@@ -734,6 +753,9 @@ where
                 SlotKind::Nonlinear(_) => {
                     for &(r, c) in &slot.hess_pairs {
                         set_pair(&mut pairs, r as usize, c as usize);
+                        if let Some(ref mut nonlinear_pairs) = nonlinear_pairs {
+                            set_pair(nonlinear_pairs, r as usize, c as usize);
+                        }
                     }
                 }
             }
@@ -746,10 +768,22 @@ where
                 }
             }
         }
-        return entries;
+        let nonlinear_entries = nonlinear_pairs.map(|pairs| {
+            let mut entries = Vec::new();
+            for row in 0..variables {
+                for col in 0..=row {
+                    if has_bit(&pairs, row * (row + 1) / 2 + col) {
+                        entries.push((row, col));
+                    }
+                }
+            }
+            entries
+        });
+        return (entries, nonlinear_entries);
     }
 
     let mut entries = FxHashSet::default();
+    let mut nonlinear_entries = include_nonlinear.then(FxHashSet::default);
     for slot in slots {
         match &slot.kind {
             SlotKind::Linear(_) => {}
@@ -759,13 +793,22 @@ where
                 }
             }
             SlotKind::Nonlinear(_) => {
-                entries.extend(slot.hess_pairs.iter().map(|&(r, c)| (r as usize, c as usize)));
+                let pairs = slot.hess_pairs.iter().map(|&(r, c)| (r as usize, c as usize));
+                entries.extend(pairs.clone());
+                if let Some(ref mut nonlinear_entries) = nonlinear_entries {
+                    nonlinear_entries.extend(pairs);
+                }
             }
         }
     }
     let mut entries: Vec<_> = entries.into_iter().collect();
     entries.sort_unstable();
-    entries
+    let nonlinear_entries = nonlinear_entries.map(|entries| {
+        let mut entries: Vec<_> = entries.into_iter().collect();
+        entries.sort_unstable();
+        entries
+    });
+    (entries, nonlinear_entries)
 }
 
 /// Direct-recovery coloring of a symmetric Hessian pattern.


### PR DESCRIPTION
## Description

Reuse merged Hessian patterns for seed

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)