### PR TITLE
oximo-core: add Domain.is_integer and Default behavior unit tests

### DIFF
--- a/crates/oximo-core/src/domain.rs
+++ b/crates/oximo-core/src/domain.rs
@@ -35,6 +35,7 @@ impl fmt::Display for Domain {
 
 impl Domain {
     /// Whether this domain is integer-valued (Integer, Binary, SemiInteger)
+    #[must_use]
     pub fn is_integer(self) -> bool {
         matches!(self, Self::Integer | Self::Binary | Self::SemiInteger { .. })
     }
@@ -42,6 +43,7 @@ impl Domain {
     /// The semicontinuity gap floor: `Some(threshold)` for `SemiContinuous` /
     /// `SemiInteger`, `None` otherwise. Such a variable takes either 0 or a
     /// value `>= threshold`, so backends emit `threshold` as the lower bound.
+    #[must_use]
     pub fn semi_threshold(self) -> Option<f64> {
         match self {
             Self::SemiContinuous { threshold } | Self::SemiInteger { threshold } => Some(threshold),
@@ -77,5 +79,23 @@ mod tests {
             ["real", "integer", "binary", "semi-continuous(3)", "semi-integer(2.5)"]
         );
         assert!(labels.iter().all(|label| label.is_ascii()));
+    }
+
+    #[test]
+    fn default_domain_is_real() {
+        assert_eq!(Domain::default(), Domain::Real);
+    }
+
+    #[test]
+    fn integer_domains_are_integer() {
+        assert!(Domain::Integer.is_integer());
+        assert!(Domain::Binary.is_integer());
+        assert!(Domain::SemiInteger { threshold: 2.0 }.is_integer());
+    }
+
+    #[test]
+    fn non_integer_domains_are_not_integer() {
+        assert!(!Domain::Real.is_integer());
+        assert!(!Domain::SemiContinuous { threshold: 2.0 }.is_integer());
     }
 }


### PR DESCRIPTION
## Description

## Changes Made : 
Hello, here is a small PR to :

1. add three unit tests to  `crates/oximo-core/src/domain.rs`
- two for testing `Default.is_integer method`
- one to test default domain is `REAL`

2. add two `must_use` attributes to the Domain methods. Your recent commit history makes me think you want to add them everywhere it makes sense now. 

## Suggestions : 
- Add a CHANGELOG.md
- Move the Display implementation for Domain after the Domain definition (convention)



## Checklist
- [x ] I have run `cargo fmt` and `cargo clippy` to ensure code quality


## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/66