### PR TITLE
fix(fix_var): add assert_fixable call in fix_var function to avoid no…

### DIFF
--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -383,8 +383,8 @@ impl Model {
     ///
     /// # Panics
     ///
-    /// Panics if `e` is not a bare variable handle or if the variable belongs
-    /// to an SOS constraint that has already been reformulated.
+    /// Panics if `e` is not a bare variable handle, or on anything
+    /// [`Self::fix_var`] rejects.
     pub fn fix(&self, e: Expr<'_>, value: f64) {
         let id = e.var_id().expect("Model::fix expects a single-variable expression");
         self.fix_var(id, value);
@@ -394,12 +394,16 @@ impl Model {
     ///
     /// # Panics
     ///
-    /// Panics if the variable belongs to an SOS constraint that has already
-    /// been reformulated, because its bounds are embedded in generated rows.
+    /// Panics if `value` is not a feasible fixing for the variable (non-finite,
+    /// fractional on an integer domain, outside its bounds, or inside a
+    /// semicontinuity gap), or if the variable belongs to an SOS constraint that
+    /// has already been reformulated, because its bounds are embedded in
+    /// generated rows.
     pub fn fix_var(&self, id: VarId, value: f64) {
         self.assert_sos_member_bounds_mutable(id);
         let mut vars = self.variables.borrow_mut();
         let v = &mut vars[id.index()];
+        crate::var::assert_fixable(&v.name, v.domain, v.lb, v.ub, value);
         v.lb = value;
         v.ub = value;
         drop(vars);

--- a/crates/oximo-core/src/var.rs
+++ b/crates/oximo-core/src/var.rs
@@ -25,6 +25,28 @@ pub fn var_name(vars: &[Variable], v: VarId) -> String {
     vars.get(v.index()).map_or_else(|| format!("variable #{}", v.index()), |x| x.name.to_string())
 }
 
+/// To be fixable,  the value is finite, integral when the domain is integer-valued,
+/// and within `[lb, ub]`. A semicontinuous/semiinteger variable is 0 or at least its
+/// threshold
+pub(crate) fn assert_fixable(name: &str, domain: Domain, lb: f64, ub: f64, value: f64) {
+    assert!(value.is_finite(), "cannot fix variable {name:?} to the non-finite value {value}");
+    assert!(
+        !domain.is_integer() || value.fract() == 0.0,
+        "cannot fix {domain} variable {name:?} to the fractional value {value}"
+    );
+    let semi_zero = domain.semi_threshold().is_some() && value == 0.0;
+    assert!(
+        semi_zero || (lb <= value && value <= ub),
+        "cannot fix variable {name:?} to {value}, outside its bounds [{lb}, {ub}]"
+    );
+    if let Some(threshold) = domain.semi_threshold() {
+        assert!(
+            value == 0.0 || value >= threshold,
+            "cannot fix {domain} variable {name:?} to {value}: it must be 0 or at least {threshold}"
+        );
+    }
+}
+
 /// Builder backing the `variable!` macro. Configure bounds / domain, then call
 /// [`Self::build`] to register the variable and obtain an `Expr` handle.
 #[must_use = "VarBuilder does nothing until you call .build()"]
@@ -65,7 +87,16 @@ impl<'a> VarBuilder<'a> {
         self
     }
 
+    /// Fix the variable to `value`, i.e. `bounds(value, value)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` is not a feasible fixing for the domain and bounds set
+    /// so far: non-finite, fractional on an integer domain, outside the bounds,
+    /// or inside a semicontinuity gap. A `.domain(..)` or bound call placed after
+    /// this one is not re-checked; the `variable!` macro always emits them first.
     pub fn fix(self, value: f64) -> Self {
+        assert_fixable(&self.name, self.domain, self.lb, self.ub, value);
         self.bounds(value, value)
     }
 

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -272,6 +272,78 @@ fn fix_var_mutates_bounds_post_build() {
 }
 
 #[test]
+#[should_panic(expected = "cannot fix integer variable \"y\" to the fractional value 0.3")]
+fn fix_rejects_a_fractional_value_on_an_integer_variable() {
+    let m = Model::new("fix_fractional");
+    variable!(m, 0.0 <= y <= 1, Int);
+    m.fix(y, 0.3);
+}
+
+#[test]
+#[should_panic(expected = "cannot fix binary variable \"z\" to the fractional value 0.3")]
+fn fix_rejects_a_fractional_value_on_a_binary_variable() {
+    let m = Model::new("fix_fractional_binary");
+    variable!(m, z, Bin);
+    m.fix(z, 0.3);
+}
+
+#[test]
+fn fix_accepts_an_int_value_on_an_int_variable() {
+    let m = Model::new("fix_integral");
+    variable!(m, 0.0 <= y <= 20.0, Int);
+    m.fix(y, 1.0);
+    let vars = m.variables();
+    assert_eq!(vars[0].lb, 1.0);
+    assert_eq!(vars[0].ub, 1.0);
+}
+
+#[test]
+#[should_panic(expected = "cannot fix variable \"x\" to 7, outside its bounds [0, 5]")]
+fn fix_rejects_a_value_outside_the_declared_bounds() {
+    let m = Model::new("fix_outside_bounds");
+    variable!(m, 0.0 <= x <= 5.0);
+    m.fix(x, 7.0);
+}
+
+#[test]
+#[should_panic(expected = "cannot fix variable \"x\" to the non-finite value NaN")]
+fn fix_rejects_a_non_finite_value() {
+    let m = Model::new("fix_non_finite");
+    variable!(m, x);
+    m.fix(x, f64::NAN);
+}
+
+#[test]
+fn fix_accepts_zero_on_a_semicontinuous_variable() {
+    let m = Model::new("fix_semi_zero");
+    variable!(m, 2.0 <= s <= 8.0, SemiCont(2.0));
+    m.fix(s, 0.0);
+    let vars = m.variables();
+    assert_eq!(vars[0].lb, 0.0);
+    assert_eq!(vars[0].ub, 0.0);
+}
+
+#[test]
+#[should_panic(
+    expected = "cannot fix semi-continuous(2) variable \"s\" to 1: it must be 0 or at least 2"
+)]
+fn fix_rejects_a_value_inside_the_semicontinuity_gap() {
+    let m = Model::new("fix_semi_gap");
+    variable!(m, s, SemiCont(2.0));
+    m.fix(s, 1.0);
+}
+
+#[test]
+#[should_panic(
+    expected = "cannot fix semi-integer(2) variable \"s\" to 1: it must be 0 or at least 2"
+)]
+fn fix_rejects_a_value_inside_the_semiinteger_gap() {
+    let m = Model::new("fix_semi_gap");
+    variable!(m, s, SemiInt(2.0));
+    m.fix(s, 1.0);
+}
+
+#[test]
 fn fix_pins_var_expr_and_indexed_entry() {
     let m = Model::new("fix_expr");
     variable!(m, 0.0 <= x <= 10.0);


### PR DESCRIPTION

## Description

Add an assert function  (`assert_fixable`) to tell if a variable is fixable. Prevent the user from : 
- fixing an integer var to a fractional value
- fixing a continous var outside its bounds
- fixing a semi-{int, cont} var to a value below threshold  != 0

Called in `Model.fix_var `and` Var.fix `

Add tests `crates/oximo-core/tests/model.rs`


## Checklist

- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality

