### PR TITLE
Unify linear term ownership using `Cow`

### DIFF
--- a/crates/oximo-autodiff/src/slot.rs
+++ b/crates/oximo-autodiff/src/slot.rs
@@ -21,7 +21,7 @@ pub struct FunctionSlot {
 #[derive(Clone, Debug)]
 pub enum SlotKind {
     /// Affine: constant gradient, zero Hessian.
-    Linear(LinearTerms),
+    Linear(LinearTerms<'static>),
     /// Degree-2 polynomial: affine gradient `Qx + c`, constant Hessian.
     /// `QuadraticTerms.hessian` follows the `0.5 x'Qx` convention
     Quadratic(QuadraticTerms),
@@ -37,7 +37,7 @@ impl FunctionSlot {
     /// Used for a feasibility problem's absent objective.
     pub fn zero() -> Self {
         Self {
-            kind: SlotKind::Linear(LinearTerms { coeffs: Vec::new(), constant: 0.0 }),
+            kind: SlotKind::Linear(LinearTerms { coeffs: Vec::new().into(), constant: 0.0 }),
             support: Vec::new(),
             hess_pairs: Vec::new(),
         }
@@ -75,7 +75,11 @@ impl FunctionSlot {
     fn closed_form(arena: &ExprArena, root: ExprId) -> Option<Self> {
         if let Some(linear) = extract_linear(arena, root) {
             let support = sorted_dedup(linear.coeffs.iter().map(|(v, _)| v.0));
-            return Some(Self { kind: SlotKind::Linear(linear), support, hess_pairs: Vec::new() });
+            return Some(Self {
+                kind: SlotKind::Linear(linear.into_owned()),
+                support,
+                hess_pairs: Vec::new(),
+            });
         }
         if let Some(quadratic) = extract_quadratic(arena, root) {
             let support = sorted_dedup(
@@ -128,13 +132,13 @@ fn sorted_dedup(vars: impl Iterator<Item = u32>) -> Vec<u32> {
 }
 
 /// `t.constant + t.coeffs * x`
-pub fn linear_value(t: &LinearTerms, x: &[f64]) -> f64 {
+pub fn linear_value(t: &LinearTerms<'_>, x: &[f64]) -> f64 {
     t.coeffs.iter().fold(t.constant, |acc, &(v, c)| acc + c * x[v.index()])
 }
 
 /// Add the (constant) gradient of `t` into `grad`, scaled by `scale`.
-pub fn linear_gradient_add(t: &LinearTerms, scale: f64, grad: &mut [f64]) {
-    for &(v, c) in &t.coeffs {
+pub fn linear_gradient_add(t: &LinearTerms<'_>, scale: f64, grad: &mut [f64]) {
+    for &(v, c) in t.coeffs.iter() {
         grad[v.index()] += scale * c;
     }
 }

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -541,7 +541,7 @@ fn write_bar_expr(bar: &mut String, arena: &ExprArena, id: ExprId) -> Result<(),
         ExprNode::Var(v) => write!(bar, "x{}", v.index()).unwrap(),
         ExprNode::Param(p) => write!(bar, "{}", fmt(arena.param_value(*p))).unwrap(),
         ExprNode::Linear { coeffs, constant } => {
-            let t = LinearTerms { coeffs: coeffs.clone().into(), constant: *constant };
+            let t = LinearTerms::borrowed(coeffs, *constant);
             write!(bar, "(").unwrap();
             write_linear(bar, &t, true);
             write!(bar, ")").unwrap();

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -215,7 +215,7 @@ fn run_baron(bar: &str, opts: &BaronOptions, exec: Option<&str>) -> Result<Baron
 /// [`write_equations`]) used to fold range duals back onto their
 /// `ConstraintId`, and the affine bound side of each explicit SOC constraint
 /// used to rescale its squared-row price to the norm form.
-type BarParts = (String, Vec<VarId>, Vec<ConstraintId>, Vec<LinearTerms>);
+type BarParts = (String, Vec<VarId>, Vec<ConstraintId>, Vec<LinearTerms<'static>>);
 
 fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError> {
     if model.has_active_sos_constraints() {
@@ -238,7 +238,9 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError
     write_starting_point(&mut bar, &vars);
     let soc_bounds = socs
         .iter()
-        .map(|s| extract_linear(&arena, s.bound).expect("SOC bound is validated affine"))
+        .map(|s| {
+            extract_linear(&arena, s.bound).expect("SOC bound is validated affine").into_owned()
+        })
         .collect();
     Ok((bar, var_order, con_order, soc_bounds))
 }
@@ -501,20 +503,20 @@ fn write_starting_point(bar: &mut String, vars: &[Variable]) {
 }
 
 /// Append the linear expression `t` to `bar` as a standalone BARON expression.
-fn write_linear(bar: &mut String, t: &LinearTerms, include_constant: bool) {
+fn write_linear(bar: &mut String, t: &LinearTerms<'_>, include_constant: bool) {
     let mut first = true;
-    for (v, coef) in &t.coeffs {
-        if *coef == 0.0 {
+    for &(v, coef) in t.coeffs.iter() {
+        if coef == 0.0 {
             continue;
         }
         let idx = v.index();
         if first {
-            write!(bar, "{}*x{idx}", fmt(*coef)).unwrap();
+            write!(bar, "{}*x{idx}", fmt(coef)).unwrap();
             first = false;
-        } else if *coef < 0.0 {
+        } else if coef < 0.0 {
             write!(bar, " - {}*x{idx}", fmt(-coef)).unwrap();
         } else {
-            write!(bar, " + {}*x{idx}", fmt(*coef)).unwrap();
+            write!(bar, " + {}*x{idx}", fmt(coef)).unwrap();
         }
     }
     if include_constant && t.constant != 0.0 {
@@ -539,7 +541,7 @@ fn write_bar_expr(bar: &mut String, arena: &ExprArena, id: ExprId) -> Result<(),
         ExprNode::Var(v) => write!(bar, "x{}", v.index()).unwrap(),
         ExprNode::Param(p) => write!(bar, "{}", fmt(arena.param_value(*p))).unwrap(),
         ExprNode::Linear { coeffs, constant } => {
-            let t = LinearTerms { coeffs: coeffs.clone(), constant: *constant };
+            let t = LinearTerms { coeffs: coeffs.clone().into(), constant: *constant };
             write!(bar, "(").unwrap();
             write_linear(bar, &t, true);
             write!(bar, ")").unwrap();
@@ -690,7 +692,7 @@ fn parse_solution(
     raw_log: Option<String>,
     var_order: &[VarId],
     con_order: &[ConstraintId],
-    soc_bounds: &[LinearTerms],
+    soc_bounds: &[LinearTerms<'_>],
 ) -> SolverResult {
     let tokens: Vec<&str> = tim.split_whitespace().collect();
     let int_at = |i: usize| tokens.get(i).and_then(|s| s.parse::<i64>().ok());

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -41,7 +41,7 @@ const PAR_ROW_THRESHOLD: usize = 256;
 /// The linear-or-conic view of one algebraic constraint.
 #[derive(Debug)]
 enum Row {
-    Lin(LinearTerms),
+    Lin(LinearTerms<'static>),
     Soc(SocForm),
 }
 
@@ -69,9 +69,9 @@ impl Rows {
     /// Append one `A` row `scale * t.coeffs` with right-hand side `rhs`, carrying
     /// no dual. The caller attaches one with `set_last_dual` when the row maps
     /// back to a constraint.
-    fn push(&mut self, t: &LinearTerms, scale: f64, rhs: f64) {
+    fn push(&mut self, t: &LinearTerms<'_>, scale: f64, rhs: f64) {
         let row = self.b.len();
-        for &(var, coef) in &t.coeffs {
+        for &(var, coef) in t.coeffs.iter() {
             self.a_trip.push((row, var.index(), scale * coef));
         }
         self.b.push(rhs);
@@ -279,7 +279,7 @@ fn classify_rows_with(model: &Model, parallel: Option<bool>) -> Result<Vec<Row>,
     let mut rows: Vec<Option<Row>> = (0..constraints.len()).map(|_| None).collect();
     let mut pending = Vec::new();
     for (index, constraint) in constraints.iter().enumerate() {
-        match extract_linear(arena_ref, constraint.lhs) {
+        match extract_linear(arena_ref, constraint.lhs).map(LinearTerms::into_owned) {
             Some(terms) => rows[index] = Some(Row::Lin(terms)),
             None => pending.push((index, constraint)),
         }

--- a/crates/oximo-core/src/soc.rs
+++ b/crates/oximo-core/src/soc.rs
@@ -38,8 +38,8 @@ pub struct SocConstraint {
 /// through a single shape.
 #[derive(Clone, Debug)]
 pub struct SocForm {
-    pub terms: Vec<LinearTerms>,
-    pub bound: LinearTerms,
+    pub terms: Vec<LinearTerms<'static>>,
+    pub bound: LinearTerms<'static>,
 }
 
 /// Extract and validate the diagonal quadratic form shared by SOC recognition
@@ -112,11 +112,13 @@ pub fn detect_soc(arena: &ExprArena, vars: &[Variable], c: &Constraint) -> Optio
         .into_iter()
         .filter_map(|(row, _, h)| {
             let coef = h / 2.0;
-            (coef > 0.0)
-                .then(|| LinearTerms { coeffs: vec![(row, (coef / n).sqrt())], constant: 0.0 })
+            (coef > 0.0).then(|| LinearTerms {
+                coeffs: vec![(row, (coef / n).sqrt())].into(),
+                constant: 0.0,
+            })
         })
         .collect();
-    let bound = LinearTerms { coeffs: vec![(t, 1.0)], constant: 0.0 };
+    let bound = LinearTerms { coeffs: vec![(t, 1.0)].into(), constant: 0.0 };
     Some(SocForm { terms, bound })
 }
 
@@ -124,7 +126,11 @@ pub fn detect_soc(arena: &ExprArena, vars: &[Variable], c: &Constraint) -> Optio
 /// are validated affine at registration, so this only returns `None` on a
 /// corrupted model (e.g. an `ExprId` from a different arena).
 pub fn explicit_soc_form(arena: &ExprArena, s: &SocConstraint) -> Option<SocForm> {
-    let terms = s.terms.iter().map(|&e| extract_linear(arena, e)).collect::<Option<Vec<_>>>()?;
-    let bound = extract_linear(arena, s.bound)?;
+    let terms = s
+        .terms
+        .iter()
+        .map(|&e| extract_linear(arena, e).map(LinearTerms::into_owned))
+        .collect::<Option<Vec<_>>>()?;
+    let bound = extract_linear(arena, s.bound).map(LinearTerms::into_owned)?;
     Some(SocForm { terms, bound })
 }

--- a/crates/oximo-core/tests/model.rs
+++ b/crates/oximo-core/tests/model.rs
@@ -417,7 +417,7 @@ fn rhs_expr_folded_into_lhs() {
     let arena = m.arena();
     let terms = extract_linear(&arena, algebraic[0].lhs).expect("linear");
     assert_eq!(terms.constant, -3.0);
-    let mut sorted = terms.coeffs.clone();
+    let mut sorted = terms.coeffs.into_owned();
     sorted.sort_by_key(|(v, _)| v.0);
     assert_eq!(sorted[0].1, 1.0);
     assert_eq!(sorted[1].1, -1.0);

--- a/crates/oximo-core/tests/sos.rs
+++ b/crates/oximo-core/tests/sos.rs
@@ -232,7 +232,8 @@ fn sos2_reformulation_uses_weight_order_and_adjacent_intervals() {
         extract_linear(&arena, rows[row].lhs)
             .unwrap()
             .coeffs
-            .into_iter()
+            .iter()
+            .copied()
             .collect::<std::collections::HashMap<_, _>>()
     };
 

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -1,13 +1,39 @@
+use std::borrow::Cow;
+
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use smallvec::smallvec;
 
 use crate::arena::{ExprArena, ExprId, ExprNode, VarId};
 
 /// Coefficients of a linear expression: `sum(coeff * var) + constant`.
+///
+/// The coefficient storage borrows directly from an [`ExprNode::Linear`] when
+/// possible and owns coefficients that must be synthesized while walking an
+/// expression tree. Call [`LinearTerms::into_owned`] before storing extracted
+/// terms beyond the lifetime of their [`ExprArena`].
 #[derive(Clone, Debug, Default)]
-pub struct LinearTerms {
-    pub coeffs: Vec<(VarId, f64)>,
+pub struct LinearTerms<'a> {
+    pub coeffs: Cow<'a, [(VarId, f64)]>,
     pub constant: f64,
+}
+
+impl<'a> LinearTerms<'a> {
+    /// Construct linear terms with owned coefficient storage.
+    pub fn owned(coeffs: Vec<(VarId, f64)>, constant: f64) -> Self {
+        Self { coeffs: Cow::Owned(coeffs), constant }
+    }
+
+    /// Construct linear terms borrowing coefficient storage.
+    pub fn borrowed(coeffs: &'a [(VarId, f64)], constant: f64) -> Self {
+        Self { coeffs: Cow::Borrowed(coeffs), constant }
+    }
+
+    /// Detach these terms from their borrowed source.
+    ///
+    /// This does not allocate when the coefficient storage is already owned.
+    pub fn into_owned(self) -> LinearTerms<'static> {
+        LinearTerms { coeffs: Cow::Owned(self.coeffs.into_owned()), constant: self.constant }
+    }
 }
 
 /// Accumulator that merges duplicate `(VarId, coeff)` terms while
@@ -36,8 +62,8 @@ impl CoeffAccum {
         }
     }
 
-    fn extend(&mut self, terms: impl IntoIterator<Item = (VarId, f64)>) {
-        for (v, c) in terms {
+    fn extend_from_slice(&mut self, terms: &[(VarId, f64)]) {
+        for &(v, c) in terms {
             self.add(v, c);
         }
     }
@@ -50,24 +76,30 @@ impl CoeffAccum {
 /// Try to interpret `id` as a linear expression. Returns `None` for any
 /// nonlinear node (Mul of two non-constants, Pow, transcendentals, ...).
 ///
-/// When `resolve_params` is set, a [`ExprNode::Param`] folds to its current
+/// When `resolve_params` is set, an [`ExprNode::Param`] folds to its current
 /// arena value and counts as a constant.
-fn as_linear(arena: &ExprArena, id: ExprId, resolve_params: bool) -> Option<LinearTerms> {
+fn as_linear<'a>(
+    arena: &'a ExprArena,
+    id: ExprId,
+    resolve_params: bool,
+) -> Option<LinearTerms<'a>> {
     match arena.get(id) {
-        ExprNode::Const(c) => Some(LinearTerms { coeffs: Vec::new(), constant: *c }),
+        ExprNode::Const(c) => Some(LinearTerms::borrowed(&[], *c)),
         ExprNode::Param(p) if resolve_params => {
-            Some(LinearTerms { coeffs: Vec::new(), constant: arena.param_value(*p) })
+            Some(LinearTerms::borrowed(&[], arena.param_value(*p)))
         }
-        ExprNode::Var(v) => Some(LinearTerms { coeffs: vec![(*v, 1.0)], constant: 0.0 }),
-        ExprNode::Linear { coeffs, constant } => {
-            Some(LinearTerms { coeffs: coeffs.clone(), constant: *constant })
+        ExprNode::Var(v) => {
+            Some(LinearTerms { coeffs: Cow::Owned(vec![(*v, 1.0)]), constant: 0.0 })
         }
+        ExprNode::Linear { coeffs, constant } => Some(LinearTerms::borrowed(coeffs, *constant)),
         ExprNode::Neg(inner) => {
             let inner = *inner;
-            as_linear(arena, inner, resolve_params).map(|mut t| {
-                t.coeffs.iter_mut().for_each(|(_, c)| *c = -*c);
-                t.constant = -t.constant;
-                t
+            as_linear(arena, inner, resolve_params).map(|t| {
+                let mut coeffs = t.coeffs.into_owned();
+                for (_, c) in &mut coeffs {
+                    *c = -*c;
+                }
+                LinearTerms { coeffs: Cow::Owned(coeffs), constant: -t.constant }
             })
         }
         ExprNode::Add(children) => {
@@ -75,15 +107,16 @@ fn as_linear(arena: &ExprArena, id: ExprId, resolve_params: bool) -> Option<Line
             let mut constant = 0.0;
             for &child in children {
                 let t = as_linear(arena, child, resolve_params)?;
-                acc.extend(t.coeffs);
+                acc.extend_from_slice(&t.coeffs);
                 constant += t.constant;
             }
-            Some(LinearTerms { coeffs: acc.into_coeffs(), constant })
+            Some(LinearTerms::owned(acc.into_coeffs(), constant))
         }
         ExprNode::Mul(children) => {
-            // Linear if and only if exactly one non-const child is linear and the rest are constants.
+            // Linear if and only if exactly one non-const child is linear and
+            // the rest are constants.
             let mut scalar = 1.0;
-            let mut linear: Option<LinearTerms> = None;
+            let mut linear: Option<LinearTerms<'a>> = None;
             for &child in children {
                 match arena.get(child) {
                     ExprNode::Const(c) => scalar *= c,
@@ -95,11 +128,13 @@ fn as_linear(arena: &ExprArena, id: ExprId, resolve_params: bool) -> Option<Line
                 }
             }
             Some(match linear {
-                None => LinearTerms { coeffs: Vec::new(), constant: scalar },
-                Some(mut t) => {
-                    t.coeffs.iter_mut().for_each(|(_, c)| *c *= scalar);
-                    t.constant *= scalar;
-                    t
+                None => LinearTerms::owned(Vec::new(), scalar),
+                Some(t) => {
+                    let mut coeffs = t.coeffs.into_owned();
+                    for (_, c) in &mut coeffs {
+                        *c *= scalar;
+                    }
+                    LinearTerms { coeffs: Cow::Owned(coeffs), constant: t.constant * scalar }
                 }
             })
         }
@@ -107,23 +142,25 @@ fn as_linear(arena: &ExprArena, id: ExprId, resolve_params: bool) -> Option<Line
     }
 }
 
-/// Materialize a linear-terms struct into a fresh `Linear` node in the arena.
-fn push_linear(arena: &mut ExprArena, mut t: LinearTerms) -> ExprId {
-    t.coeffs.retain(|(_, c)| *c != 0.0);
-    arena.push(ExprNode::Linear { coeffs: t.coeffs, constant: t.constant })
+/// Materialize linear terms into a fresh `Linear` node in the arena.
+fn push_linear(arena: &mut ExprArena, t: LinearTerms<'_>) -> ExprId {
+    let mut coeffs = t.coeffs.into_owned();
+    coeffs.retain(|(_, c)| *c != 0.0);
+    arena.push(ExprNode::Linear { coeffs, constant: t.constant })
 }
 
 /// Build `lhs + rhs`, preserving the linear fast-path when both sides are
 /// linear. Falls back to an n-ary `Add` node otherwise.
 pub(crate) fn add_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
     if let (Some(lt), Some(rt)) = (as_linear(arena, lhs, false), as_linear(arena, rhs, false)) {
+        let constant = lt.constant + rt.constant;
         let mut acc = CoeffAccum::with_capacity(lt.coeffs.len() + rt.coeffs.len());
-        acc.extend(lt.coeffs);
-        acc.extend(rt.coeffs);
-        return push_linear(
-            arena,
-            LinearTerms { coeffs: acc.into_coeffs(), constant: lt.constant + rt.constant },
-        );
+        acc.extend_from_slice(&lt.coeffs);
+        acc.extend_from_slice(&rt.coeffs);
+        let coeffs = acc.into_coeffs();
+        drop(lt);
+        drop(rt);
+        return push_linear(arena, LinearTerms { coeffs: Cow::Owned(coeffs), constant });
     }
     arena.push(ExprNode::Add(smallvec![lhs, rhs]))
 }
@@ -152,17 +189,23 @@ pub(crate) fn sub_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
 /// stay on the linear fast-path. Otherwise produce a generic n-ary `Mul`.
 pub(crate) fn mul_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
     if let ExprNode::Const(c) = *arena.get(lhs) {
-        if let Some(mut t) = as_linear(arena, rhs, false) {
-            t.coeffs.iter_mut().for_each(|(_, co)| *co *= c);
-            t.constant *= c;
-            return push_linear(arena, t);
+        if let Some(t) = as_linear(arena, rhs, false) {
+            let constant = t.constant * c;
+            let mut coeffs = t.coeffs.into_owned();
+            for (_, co) in &mut coeffs {
+                *co *= c;
+            }
+            return push_linear(arena, LinearTerms { coeffs: Cow::Owned(coeffs), constant });
         }
     }
     if let ExprNode::Const(c) = *arena.get(rhs) {
-        if let Some(mut t) = as_linear(arena, lhs, false) {
-            t.coeffs.iter_mut().for_each(|(_, co)| *co *= c);
-            t.constant *= c;
-            return push_linear(arena, t);
+        if let Some(t) = as_linear(arena, lhs, false) {
+            let constant = t.constant * c;
+            let mut coeffs = t.coeffs.into_owned();
+            for (_, co) in &mut coeffs {
+                *co *= c;
+            }
+            return push_linear(arena, LinearTerms { coeffs: Cow::Owned(coeffs), constant });
         }
     }
     arena.push(ExprNode::Mul(smallvec![lhs, rhs]))
@@ -174,11 +217,14 @@ pub(crate) fn mul_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
 pub(crate) fn div_into(arena: &mut ExprArena, num: ExprId, den: ExprId) -> ExprId {
     if let ExprNode::Const(c) = *arena.get(den) {
         if c != 0.0 {
-            if let Some(mut t) = as_linear(arena, num, false) {
+            if let Some(t) = as_linear(arena, num, false) {
                 let inv = 1.0 / c;
-                t.coeffs.iter_mut().for_each(|(_, co)| *co *= inv);
-                t.constant *= inv;
-                return push_linear(arena, t);
+                let constant = t.constant * inv;
+                let mut coeffs = t.coeffs.into_owned();
+                for (_, co) in &mut coeffs {
+                    *co *= inv;
+                }
+                return push_linear(arena, LinearTerms { coeffs: Cow::Owned(coeffs), constant });
             }
             let inv = arena.push(ExprNode::Const(1.0 / c));
             return mul_into(arena, num, inv);
@@ -189,28 +235,36 @@ pub(crate) fn div_into(arena: &mut ExprArena, num: ExprId, den: ExprId) -> ExprI
 
 /// Build `-rhs`, preserving linearity.
 pub(crate) fn neg_into(arena: &mut ExprArena, rhs: ExprId) -> ExprId {
-    if let Some(mut t) = as_linear(arena, rhs, false) {
-        t.coeffs.iter_mut().for_each(|(_, c)| *c = -*c);
-        t.constant = -t.constant;
-        return push_linear(arena, t);
+    if let Some(t) = as_linear(arena, rhs, false) {
+        let constant = -t.constant;
+        let mut coeffs = t.coeffs.into_owned();
+        for (_, c) in &mut coeffs {
+            *c = -*c;
+        }
+        return push_linear(arena, LinearTerms { coeffs: Cow::Owned(coeffs), constant });
     }
     arena.push(ExprNode::Neg(rhs))
 }
 
-/// Snapshot the linear terms of `id`, if any. Used by solver backends to
-/// extract LP coefficients without walking the tree themselves.
+/// Extract the linear terms of `id`, if any. Used by solver backends to extract
+/// LP coefficients without walking the tree themselves.
 ///
-/// Parameters are folded to their current arena values, so the returned
-/// coefficients reflect the latest [`ExprArena::set_param_value`] binding.
+/// The result borrows coefficients for a direct [`ExprNode::Linear`] and owns
+/// coefficients synthesized from a larger expression tree. Its lifetime is
+/// tied to `arena` in either case; call [`LinearTerms::into_owned`] to retain a
+/// snapshot independently of the arena.
+///
+/// Parameters are folded to their current arena values, so the returned terms
+/// reflect the latest [`ExprArena::set_param_value`] binding.
 ///
 /// [`ExprArena::set_param_value`]: crate::ExprArena::set_param_value
-pub fn extract_linear(arena: &ExprArena, id: ExprId) -> Option<LinearTerms> {
+pub fn extract_linear<'a>(arena: &'a ExprArena, id: ExprId) -> Option<LinearTerms<'a>> {
     as_linear(arena, id, true)
 }
 
 /// A nonlinear residual summand: the existing arena node `id`, taken with a
-/// leading negation when `neg` is set. Carrying the sign as a flag.
-/// Lets [`split_linear`] run without a mutable arena.
+/// leading negation when `neg` is set. Carrying the sign as a flag lets
+/// [`split_linear`] run without a mutable arena.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SignedExpr {
     pub id: ExprId,
@@ -224,11 +278,14 @@ pub struct SignedExpr {
 /// value(id) == sum_i coef_i * var_i + constant + sum_j (-1)^neg_j value(id_j)
 /// ```
 ///
-/// where the residual is empty when the whole expression is linear and
-/// otherwise lists the remaining nonlinear summands (each a pre-existing arena
-/// node, optionally negated). `LinearTerms` may have empty `coeffs` and
+/// The residual is empty when the whole expression is linear and otherwise
+/// lists the remaining nonlinear summands (each a pre-existing arena node,
+/// optionally negated). `LinearTerms` may have empty `coeffs` and
 /// `constant == 0.0` when the whole expression is purely nonlinear.
-pub fn split_linear(arena: &ExprArena, id: ExprId) -> (LinearTerms, Vec<SignedExpr>) {
+///
+/// As with [`extract_linear`], call [`LinearTerms::into_owned`] before retaining
+/// the linear terms independently of `arena`.
+pub fn split_linear<'a>(arena: &'a ExprArena, id: ExprId) -> (LinearTerms<'a>, Vec<SignedExpr>) {
     if let Some(lt) = as_linear(arena, id, true) {
         return (lt, Vec::new());
     }
@@ -245,13 +302,11 @@ pub fn split_linear(arena: &ExprArena, id: ExprId) -> (LinearTerms, Vec<SignedEx
             }
             ExprNode::Neg(inner) => sign_stack.push((*inner, -sign)),
             _ => {
-                if let Some(mut t) = as_linear(arena, cur, true) {
-                    if (sign - 1.0).abs() > 0.0 {
-                        t.coeffs.iter_mut().for_each(|(_, c)| *c *= sign);
-                        t.constant *= sign;
+                if let Some(t) = as_linear(arena, cur, true) {
+                    for &(v, c) in t.coeffs.iter() {
+                        lin.add(v, c * sign);
                     }
-                    lin.extend(t.coeffs);
-                    constant += t.constant;
+                    constant += t.constant * sign;
                 } else {
                     residual.push(SignedExpr { id: cur, neg: sign < 0.0 });
                 }
@@ -260,7 +315,7 @@ pub fn split_linear(arena: &ExprArena, id: ExprId) -> (LinearTerms, Vec<SignedEx
     }
     let mut coeffs = lin.into_coeffs();
     coeffs.retain(|(_, c)| *c != 0.0);
-    (LinearTerms { coeffs, constant }, residual)
+    (LinearTerms { coeffs: Cow::Owned(coeffs), constant }, residual)
 }
 
 /// Render the first nonlinear summand of `id` as a short infix string, resolving
@@ -288,6 +343,71 @@ mod tests {
     use crate::arena::{ExprArena, ExprNode, VarId};
 
     #[test]
+    fn direct_linear_extraction_borrows_arena_coefficients() {
+        let mut arena = ExprArena::new();
+        let id = arena.push(ExprNode::Linear {
+            coeffs: vec![(VarId(0), 2.0), (VarId(1), -3.0)],
+            constant: 4.0,
+        });
+        let expected = match arena.get(id) {
+            ExprNode::Linear { coeffs, .. } => coeffs.as_slice(),
+            _ => unreachable!(),
+        };
+
+        let terms = extract_linear(&arena, id).expect("linear");
+        let Cow::Borrowed(actual) = terms.coeffs else {
+            panic!("direct Linear extraction allocated coefficient storage");
+        };
+        assert!(std::ptr::eq(actual, expected));
+        assert!((terms.constant - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn merged_tree_extraction_owns_coefficients() {
+        let mut arena = ExprArena::new();
+        let x = arena.push(ExprNode::Var(VarId(0)));
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let sum = arena.push(ExprNode::Add(smallvec::smallvec![x, y, x]));
+
+        let terms = extract_linear(&arena, sum).expect("linear");
+        let Cow::Owned(coeffs) = terms.coeffs else {
+            panic!("merged expression did not own synthesized coefficients");
+        };
+        assert_eq!(coeffs, vec![(VarId(0), 2.0), (VarId(1), 1.0)]);
+    }
+
+    #[test]
+    fn into_owned_detaches_borrowed_terms_from_arena() {
+        let mut arena = ExprArena::new();
+        let id = arena.push(ExprNode::Linear { coeffs: vec![(VarId(0), 2.0)], constant: 1.0 });
+
+        let terms: LinearTerms<'static> = extract_linear(&arena, id).unwrap().into_owned();
+        arena.push(ExprNode::Const(5.0));
+
+        assert!(matches!(terms.coeffs, Cow::Owned(_)));
+        assert_eq!(terms.coeffs.as_ref(), &[(VarId(0), 2.0)]);
+        assert!((terms.constant - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn split_linear_preserves_borrowing_only_for_direct_linear_nodes() {
+        let mut arena = ExprArena::new();
+        let linear = arena.push(ExprNode::Linear { coeffs: vec![(VarId(0), 2.0)], constant: 1.0 });
+        let (direct, residual) = split_linear(&arena, linear);
+        assert!(matches!(direct.coeffs, Cow::Borrowed(_)));
+        assert!(residual.is_empty());
+
+        let y = arena.push(ExprNode::Var(VarId(1)));
+        let nonlinear = arena.push(ExprNode::Sin(y));
+        let mixed = arena.push(ExprNode::Add(smallvec::smallvec![linear, nonlinear]));
+        let (split, residual) = split_linear(&arena, mixed);
+        assert!(matches!(split.coeffs, Cow::Owned(_)));
+        assert_eq!(split.coeffs.as_ref(), &[(VarId(0), 2.0)]);
+        assert!((split.constant - 1.0).abs() < f64::EPSILON);
+        assert_eq!(residual, vec![SignedExpr { id: nonlinear, neg: false }]);
+    }
+
+    #[test]
     fn param_times_var_stays_symbolic_until_extracted() {
         // Build `price * x` through the operator helper. The parameter must NOT
         // be folded into a Linear node at build time (so it stays re-bindable)
@@ -299,7 +419,7 @@ mod tests {
         assert!(matches!(arena.get(prod), ExprNode::Mul(_)));
 
         let terms = extract_linear(&arena, prod).expect("linear");
-        assert_eq!(terms.coeffs, vec![(VarId(0), 3.0)]);
+        assert_eq!(&*terms.coeffs, &[(VarId(0), 3.0)][..]);
         assert!(terms.constant.abs() < f64::EPSILON);
     }
 
@@ -313,7 +433,7 @@ mod tests {
 
         arena.set_param_value(pid, 10.0);
         let terms = extract_linear(&arena, prod).expect("linear");
-        assert_eq!(terms.coeffs, vec![(VarId(0), 10.0)]);
+        assert_eq!(&*terms.coeffs, &[(VarId(0), 10.0)][..]);
     }
 
     #[test]
@@ -324,7 +444,7 @@ mod tests {
         let xnode = arena.push(ExprNode::Var(VarId(0)));
         let sum = add_into(&mut arena, price, xnode);
         let terms = extract_linear(&arena, sum).expect("linear");
-        assert_eq!(terms.coeffs, vec![(VarId(0), 1.0)]);
+        assert_eq!(&*terms.coeffs, &[(VarId(0), 1.0)][..]);
         assert!((terms.constant - 5.0).abs() < f64::EPSILON);
     }
 
@@ -339,9 +459,9 @@ mod tests {
         let sum = arena.push(ExprNode::Add(smallvec::smallvec![z, x, y, x]));
 
         let terms = extract_linear(&arena, sum).expect("linear");
-        assert_eq!(terms.coeffs, vec![(VarId(2), 1.0), (VarId(0), 2.0), (VarId(1), 1.0)]);
+        assert_eq!(&*terms.coeffs, &[(VarId(2), 1.0), (VarId(0), 2.0), (VarId(1), 1.0)][..]);
         assert!(terms.constant.abs() < f64::EPSILON);
-        assert_eq!(extract_linear(&arena, sum).unwrap().coeffs, terms.coeffs);
+        assert_eq!(&*extract_linear(&arena, sum).unwrap().coeffs, &*terms.coeffs);
     }
 
     #[test]
@@ -357,7 +477,7 @@ mod tests {
         let sum = arena.push(ExprNode::Add(ids.into_iter().collect()));
         let terms = extract_linear(&arena, sum).expect("linear");
         let expected: Vec<(VarId, f64)> = (0..n).map(|v| (VarId(v), 3.0)).collect();
-        assert_eq!(terms.coeffs, expected);
+        assert_eq!(&*terms.coeffs, expected.as_slice());
     }
 
     fn names(v: VarId) -> String {

--- a/crates/oximo-expr/src/render.rs
+++ b/crates/oximo-expr/src/render.rs
@@ -37,14 +37,22 @@ pub fn render_expr(arena: &ExprArena, id: ExprId, resolve: &impl Fn(VarId) -> St
 /// - the constant last.
 ///
 /// An empty expression renders as `0`.
-pub fn render_linear_terms(t: &LinearTerms, resolve: &impl Fn(VarId) -> String) -> String {
+pub fn render_linear_terms(t: &LinearTerms<'_>, resolve: &impl Fn(VarId) -> String) -> String {
     join_parts(&linear_parts(t, resolve))
 }
 
 /// Split a linear expression into signed summands, ready for [`join_parts`].
-fn linear_parts(t: &LinearTerms, resolve: &impl Fn(VarId) -> String) -> Vec<Part> {
-    let mut parts = Vec::with_capacity(t.coeffs.len() + 1);
-    for (v, c) in &t.coeffs {
+fn linear_parts(t: &LinearTerms<'_>, resolve: &impl Fn(VarId) -> String) -> Vec<Part> {
+    linear_parts_from_slice(&t.coeffs, t.constant, resolve)
+}
+
+fn linear_parts_from_slice(
+    coeffs: &[(VarId, f64)],
+    constant: f64,
+    resolve: &impl Fn(VarId) -> String,
+) -> Vec<Part> {
+    let mut parts = Vec::with_capacity(coeffs.len() + 1);
+    for (v, c) in coeffs {
         if *c == 0.0 {
             continue;
         }
@@ -56,8 +64,8 @@ fn linear_parts(t: &LinearTerms, resolve: &impl Fn(VarId) -> String) -> Vec<Part
         };
         parts.push((*c < 0.0, text));
     }
-    if t.constant != 0.0 {
-        parts.push((t.constant < 0.0, fmt_num(t.constant.abs())));
+    if constant != 0.0 {
+        parts.push((constant < 0.0, fmt_num(constant.abs())));
     }
     parts
 }
@@ -105,10 +113,9 @@ pub(crate) fn render_node(
                     ExprNode::Param(p) if arena.param_value(*p) < 0.0 => {
                         parts.push((true, fmt_num(-arena.param_value(*p))));
                     }
-                    ExprNode::Linear { coeffs, constant } => parts.extend(linear_parts(
-                        &LinearTerms { coeffs: coeffs.clone(), constant: *constant },
-                        resolve,
-                    )),
+                    ExprNode::Linear { coeffs, constant } => {
+                        parts.extend(linear_parts_from_slice(coeffs, *constant, resolve));
+                    }
                     _ => parts.push((false, render_node(arena, c, resolve, PREC_ADD))),
                 }
             }
@@ -135,8 +142,7 @@ pub(crate) fn render_node(
         ExprNode::Log(x) => (fmt_call("log", arena, *x, resolve), PREC_UNARY),
         ExprNode::Abs(x) => (fmt_call("abs", arena, *x, resolve), PREC_UNARY),
         ExprNode::Linear { coeffs, constant } => {
-            let parts =
-                linear_parts(&LinearTerms { coeffs: coeffs.clone(), constant: *constant }, resolve);
+            let parts = linear_parts_from_slice(coeffs, *constant, resolve);
             // A multi-term or negative-leading sum needs parens inside a product.
             let prec = match parts.as_slice() {
                 [(false, _)] => PREC_MUL,
@@ -178,8 +184,13 @@ mod tests {
         }
     }
 
-    fn lt(coeffs: Vec<(u32, f64)>, constant: f64) -> LinearTerms {
-        LinearTerms { coeffs: coeffs.into_iter().map(|(v, c)| (VarId(v), c)).collect(), constant }
+    fn lt(coeffs: Vec<(u32, f64)>, constant: f64) -> LinearTerms<'static> {
+        LinearTerms {
+            coeffs: std::borrow::Cow::Owned(
+                coeffs.into_iter().map(|(v, c)| (VarId(v), c)).collect(),
+            ),
+            constant,
+        }
     }
 
     #[test]

--- a/crates/oximo-expr/tests/arithmetic.rs
+++ b/crates/oximo-expr/tests/arithmetic.rs
@@ -38,9 +38,10 @@ fn linear_fast_path_handles_subtraction() {
     let y = make_var(&arena, 1);
 
     let combo = 4.0 * x - y - 1.0;
-    let terms = extract_linear(&arena.borrow(), combo.id).expect("must be linear");
+    let arena_ref = arena.borrow();
+    let terms = extract_linear(&arena_ref, combo.id).expect("must be linear");
     assert_eq!(terms.constant, -1.0);
-    let mut sorted = terms.coeffs;
+    let mut sorted = terms.coeffs.into_owned();
     sorted.sort_by_key(|(v, _)| v.0);
     assert_eq!(sorted, vec![(VarId(0), 4.0), (VarId(1), -1.0)]);
 }
@@ -71,9 +72,10 @@ fn negation_flips_coefficients() {
     let x = make_var(&arena, 0);
     let y = make_var(&arena, 1);
     let combo = -(2.0 * x + 3.0 * y + 5.0);
-    let terms = extract_linear(&arena.borrow(), combo.id).expect("linear");
+    let arena_ref = arena.borrow();
+    let terms = extract_linear(&arena_ref, combo.id).expect("linear");
     assert_eq!(terms.constant, -5.0);
-    let mut sorted = terms.coeffs;
+    let mut sorted = terms.coeffs.into_owned();
     sorted.sort_by_key(|(v, _)| v.0);
     assert_eq!(sorted, vec![(VarId(0), -2.0), (VarId(1), -3.0)]);
 }
@@ -84,8 +86,9 @@ fn dot_computes_weighted_sum() {
     let xs: Vec<_> = (0..3).map(|i| make_var(&arena, i)).collect();
     let weights = [2.0, 3.0, 5.0];
     let result = dot(&xs, &weights);
-    let terms = extract_linear(&arena.borrow(), result.id).expect("linear");
-    let mut sorted = terms.coeffs;
+    let arena_ref = arena.borrow();
+    let terms = extract_linear(&arena_ref, result.id).expect("linear");
+    let mut sorted = terms.coeffs.into_owned();
     sorted.sort_by_key(|(v, _)| v.0);
     assert_eq!(sorted, vec![(VarId(0), 2.0), (VarId(1), 3.0), (VarId(2), 5.0)]);
 }
@@ -194,10 +197,11 @@ fn large_sum_extracts_correctly() {
     let arena = RefCell::new(ExprArena::new());
     let vars: Vec<_> = (0..100).map(|i| make_var(&arena, i)).collect();
     let total: Expr = vars.iter().copied().sum();
-    let terms = extract_linear(&arena.borrow(), total.id).expect("linear");
+    let arena_ref = arena.borrow();
+    let terms = extract_linear(&arena_ref, total.id).expect("linear");
     assert_eq!(terms.constant, 0.0);
     assert_eq!(terms.coeffs.len(), 100);
-    for (_, c) in &terms.coeffs {
+    for (_, c) in terms.coeffs.iter() {
         assert!((*c - 1.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -1026,22 +1026,22 @@ fn write_model_and_solve(gms: &mut String, solve_type: &str, sense_kw: &str, has
 }
 
 /// Captured form of an expression for GAMS emission.
-enum ExprForm {
-    Linear(LinearTerms<'static>),
+enum ExprForm<'a> {
+    Linear(LinearTerms<'a>),
     Nonlinear(ExprId),
 }
 
-impl ExprForm {
-    fn from(arena: &ExprArena, id: ExprId) -> Self {
+impl<'a> ExprForm<'a> {
+    fn from(arena: &'a ExprArena, id: ExprId) -> Self {
         match extract_linear(arena, id) {
-            Some(t) => ExprForm::Linear(t.into_owned()),
+            Some(t) => ExprForm::Linear(t),
             None => ExprForm::Nonlinear(id),
         }
     }
 }
 
 /// Append a captured expression form to `gms`.
-fn write_form(gms: &mut String, arena: &ExprArena, form: &ExprForm, include_constant: bool) {
+fn write_form(gms: &mut String, arena: &ExprArena, form: &ExprForm<'_>, include_constant: bool) {
     match form {
         ExprForm::Linear(t) => write_linear(gms, t, include_constant),
         ExprForm::Nonlinear(id) => write_gams_expr(gms, arena, *id, true),
@@ -1093,7 +1093,7 @@ fn write_gams_expr(gms: &mut String, arena: &ExprArena, id: ExprId, leading_spac
         ExprNode::Var(v) => write!(gms, "v{}", v.index()).unwrap(),
         ExprNode::Param(p) => write!(gms, "{}", fmt(arena.param_value(*p))).unwrap(),
         ExprNode::Linear { coeffs, constant } => {
-            let t = LinearTerms { coeffs: coeffs.clone().into(), constant: *constant };
+            let t = LinearTerms::borrowed(coeffs, *constant);
             write!(gms, "(").unwrap();
             write_linear(gms, &t, true);
             write!(gms, " )").unwrap();

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -118,9 +118,11 @@ pub fn solve(
     // The affine bound side of each explicit SOC constraint, kept to rescale
     // the squared-form `eq_soc{i}` marginal back to the norm form after the
     // solve (see `parseoximo_solution`).
-    let soc_bounds: Vec<LinearTerms> = socs
+    let soc_bounds: Vec<LinearTerms<'static>> = socs
         .iter()
-        .map(|s| extract_linear(&arena, s.bound).expect("SOC bound is validated affine"))
+        .map(|s| {
+            extract_linear(&arena, s.bound).expect("SOC bound is validated affine").into_owned()
+        })
         .collect();
 
     drop(arena);
@@ -300,7 +302,7 @@ fn write_soc_marginal_puts(gms: &mut String, n: usize) {
 #[expect(clippy::too_many_lines)]
 fn parseoximo_solution(
     content: &str,
-    soc_bounds: &[LinearTerms],
+    soc_bounds: &[LinearTerms<'_>],
     mixed_integer: bool,
     elapsed: std::time::Duration,
     raw_log: Option<String>,
@@ -1025,14 +1027,14 @@ fn write_model_and_solve(gms: &mut String, solve_type: &str, sense_kw: &str, has
 
 /// Captured form of an expression for GAMS emission.
 enum ExprForm {
-    Linear(LinearTerms),
+    Linear(LinearTerms<'static>),
     Nonlinear(ExprId),
 }
 
 impl ExprForm {
     fn from(arena: &ExprArena, id: ExprId) -> Self {
         match extract_linear(arena, id) {
-            Some(t) => ExprForm::Linear(t),
+            Some(t) => ExprForm::Linear(t.into_owned()),
             None => ExprForm::Nonlinear(id),
         }
     }
@@ -1050,20 +1052,20 @@ fn write_form(gms: &mut String, arena: &ExprArena, form: &ExprForm, include_cons
 /// When `include_constant` is true, the constant term is included; otherwise
 /// only variable terms are emitted (used for constraints where the constant is
 /// folded into the RHS).
-fn write_linear(gms: &mut String, t: &LinearTerms, include_constant: bool) {
+fn write_linear(gms: &mut String, t: &LinearTerms<'_>, include_constant: bool) {
     let mut first = true;
-    for (v, coef) in &t.coeffs {
-        if *coef == 0.0 {
+    for &(v, coef) in t.coeffs.iter() {
+        if coef == 0.0 {
             continue;
         }
         let idx = v.index();
         if first {
-            write!(gms, " {}*v{idx}", fmt(*coef)).unwrap();
+            write!(gms, " {}*v{idx}", fmt(coef)).unwrap();
             first = false;
-        } else if *coef < 0.0 {
+        } else if coef < 0.0 {
             write!(gms, " - {}*v{idx}", fmt(-coef)).unwrap();
         } else {
-            write!(gms, " + {}*v{idx}", fmt(*coef)).unwrap();
+            write!(gms, " + {}*v{idx}", fmt(coef)).unwrap();
         }
     }
     if include_constant && t.constant != 0.0 {
@@ -1091,7 +1093,7 @@ fn write_gams_expr(gms: &mut String, arena: &ExprArena, id: ExprId, leading_spac
         ExprNode::Var(v) => write!(gms, "v{}", v.index()).unwrap(),
         ExprNode::Param(p) => write!(gms, "{}", fmt(arena.param_value(*p))).unwrap(),
         ExprNode::Linear { coeffs, constant } => {
-            let t = LinearTerms { coeffs: coeffs.clone(), constant: *constant };
+            let t = LinearTerms { coeffs: coeffs.clone().into(), constant: *constant };
             write!(gms, "(").unwrap();
             write_linear(gms, &t, true);
             write!(gms, " )").unwrap();
@@ -1433,7 +1435,7 @@ mod tests {
     #[test]
     fn soc_marginal_is_rescaled_to_norm_form() {
         let content = "STATUS=1\nSOLVESTAT=1\nOBJVAL=-1.0\n0=-1.0\n1=1.5\nZ0=-0.75\n";
-        let bounds = vec![LinearTerms { coeffs: vec![(VarId(1), 1.0)], constant: 0.5 }];
+        let bounds = vec![LinearTerms { coeffs: vec![(VarId(1), 1.0)].into(), constant: 0.5 }];
         let r = parseoximo_solution(content, &bounds, false, std::time::Duration::ZERO, None);
         let z0 = r.soc_dual_of(SocConstraintId(0)).expect("SOC dual missing");
         assert!((z0 - 3.0).abs() < 1e-9, "z0 = {z0}");

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -475,7 +475,7 @@ pub(crate) struct ConstraintHandle {
 pub(crate) struct SocHandle {
     pub quadratic: gurobi_rs::QConstr,
     pub bound_sign: gurobi_rs::Constr,
-    pub bound: LinearTerms,
+    pub bound: LinearTerms<'static>,
 }
 
 /// Add every model constraint, returning the per-constraint row handle.
@@ -513,7 +513,7 @@ fn add_constraints(
         if let Some((sense, rhs)) = c.as_single() {
             if let Some(t) = extract_linear(arena, c.lhs) {
                 let mut expr = LinExpr::new();
-                for (v, coeff) in t.coeffs {
+                for &(v, coeff) in t.coeffs.iter() {
                     expr.add_term(coeff, gurobi_vars[v.index()]);
                 }
                 singles.push(PendingSingle {
@@ -529,7 +529,7 @@ fn add_constraints(
         } else if c.is_range() {
             if let Some(t) = extract_linear(arena, c.lhs) {
                 let mut expr = LinExpr::new();
-                for (v, coeff) in t.coeffs {
+                for &(v, coeff) in t.coeffs.iter() {
                     expr.add_term(coeff, gurobi_vars[v.index()]);
                 }
                 ranges.push(PendingRange {
@@ -651,13 +651,13 @@ fn add_soc_rows(
             gurobi_model.add_qconstr(s.name.as_str(), c!(q <= 0.0)).map_err(map_gurobi_err)?;
 
         let mut e = LinExpr::new();
-        for &(v, co) in &b.coeffs {
+        for &(v, co) in b.coeffs.iter() {
             e.add_term(co, gurobi_vars[v.index()]);
         }
         let sign_name = format!("{}_sign", s.name);
         let sign_row =
             gurobi_model.add_constr(&sign_name, c!(e >= -b.constant)).map_err(map_gurobi_err)?;
-        rows.push(SocHandle { quadratic: qrow, bound_sign: sign_row, bound: b });
+        rows.push(SocHandle { quadratic: qrow, bound_sign: sign_row, bound: b.into_owned() });
     }
     Ok(rows)
 }
@@ -671,7 +671,7 @@ fn add_squared_affine(
 ) {
     for (i, &(vi, ci)) in t.coeffs.iter().enumerate() {
         q.add_qterm(sign * ci * ci, gurobi_vars[vi.index()], gurobi_vars[vi.index()]);
-        for &(vj, cj) in &t.coeffs[i + 1..] {
+        for &(vj, cj) in &t.coeffs.as_ref()[i + 1..] {
             q.add_qterm(sign * 2.0 * ci * cj, gurobi_vars[vi.index()], gurobi_vars[vj.index()]);
         }
         if t.constant != 0.0 {
@@ -769,7 +769,7 @@ fn set_objective(
     };
     if let Some(t) = extract_linear(arena, obj_expr) {
         let mut e = LinExpr::new();
-        for (v, c) in t.coeffs {
+        for &(v, c) in t.coeffs.iter() {
             e.add_term(c, gurobi_vars[v.index()]);
         }
         // Gurobi's set_objective absorbs LinExpr offsets into ObjCon, so we do

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -320,8 +320,8 @@ fn objective_terms(
         Ok((coeffs, quad.constant, cols))
     } else {
         let lin = extract_linear(arena, obj_expr).ok_or_else(nonlinear)?;
-        for (v, c) in &lin.coeffs {
-            coeffs[v.index()] = *c;
+        for &(v, c) in lin.coeffs.iter() {
+            coeffs[v.index()] = c;
         }
         Ok((coeffs, lin.constant, Vec::new()))
     }
@@ -512,11 +512,11 @@ pub mod benchmark_support {
         primal.len() + reduced_costs.len() + dual.len()
     }
 
-    fn extract(
-        arena: &ExprArena,
+    fn extract<'a>(
+        arena: &'a ExprArena,
         vars: &[Variable],
         c: &oximo_core::Constraint,
-    ) -> Result<LinearTerms, SolverError> {
+    ) -> Result<LinearTerms<'a>, SolverError> {
         extract_linear(arena, c.lhs).ok_or_else(|| SolverError::Nonlinear {
             location: format!("constraint {:?}", c.name),
             term: describe_nonlinear_term(arena, c.lhs, &|v| var_name(vars, v))

--- a/crates/oximo-io/src/nl/analyze.rs
+++ b/crates/oximo-io/src/nl/analyze.rs
@@ -22,7 +22,7 @@ use crate::error::IoError;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Row {
-    pub(crate) linear: LinearTerms,
+    pub(crate) linear: LinearTerms<'static>,
     /// Nonlinear summands of the body, empty when the row is purely linear.
     pub(crate) residual: Vec<SignedExpr>,
 }
@@ -88,7 +88,7 @@ impl Analysis {
         for c in constraints {
             let (linear, residual) = split_linear(arena, c.lhs);
             let mut all = FxHashSet::default();
-            for (v, _) in &linear.coeffs {
+            for (v, _) in linear.coeffs.iter() {
                 all.insert(*v);
             }
             if !residual.is_empty() {
@@ -102,7 +102,7 @@ impl Analysis {
                     all.insert(*v);
                 }
             }
-            cons.push(Row { linear, residual });
+            cons.push(Row { linear: linear.into_owned(), residual });
             let start = cons_vars.len();
             cons_vars.extend(all);
             cons_vars[start..].sort_by_key(|v| v.0);
@@ -111,7 +111,7 @@ impl Analysis {
 
         let (obj_linear, obj_residual) = split_linear(arena, objective.expr);
         let mut obj_all = FxHashSet::default();
-        for (v, _) in &obj_linear.coeffs {
+        for (v, _) in obj_linear.coeffs.iter() {
             obj_all.insert(*v);
         }
         if !obj_residual.is_empty() {
@@ -125,7 +125,7 @@ impl Analysis {
                 obj_all.insert(*v);
             }
         }
-        let obj = Row { linear: obj_linear, residual: obj_residual };
+        let obj = Row { linear: obj_linear.into_owned(), residual: obj_residual };
 
         Ok(Self {
             cons,
@@ -294,7 +294,7 @@ pub mod benchmark_support {
             collect_vars(arena, r.id, &mut nonlinear)?;
         }
         all.extend(nonlinear.iter().copied());
-        Ok((Row { linear, residual }, sorted(all), nonlinear))
+        Ok((Row { linear: linear.into_owned(), residual }, sorted(all), nonlinear))
     }
 
     fn build(
@@ -336,7 +336,7 @@ pub mod benchmark_support {
             collect_vars(arena, residual.id, &mut nl_vars_o)?;
         }
         obj_all.extend(nl_vars_o.iter().copied());
-        let obj = Row { linear: obj_linear, residual: obj_residual };
+        let obj = Row { linear: obj_linear.into_owned(), residual: obj_residual };
         let obj_vars = sorted(obj_all);
         Ok(Analysis { cons, obj, cons_vars, cons_var_offsets, obj_vars, nl_vars_c, nl_vars_o })
     }

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -254,10 +254,10 @@ fn append_soc(
 fn put_afe(
     task: &mut TaskCB,
     afe: i64,
-    terms: &LinearTerms,
+    terms: &LinearTerms<'_>,
     scratch: &mut TaskScratch,
 ) -> Result<(), SolverError> {
-    fill_linear_buffers(&terms.coeffs, scratch)?;
+    fill_linear_buffers(terms.coeffs.as_ref(), scratch)?;
     task.put_afe_f_row(afe, &scratch.indices, &scratch.values).map_err(backend)?;
     task.put_afe_g(afe, terms.constant).map_err(backend)
 }

--- a/crates/oximo-pounce/src/convex.rs
+++ b/crates/oximo-pounce/src/convex.rs
@@ -252,7 +252,7 @@ impl Problem {
     }
 }
 
-fn push_row(out: &mut Vec<Triplet>, row: usize, terms: &LinearTerms, scale: f64) {
+fn push_row(out: &mut Vec<Triplet>, row: usize, terms: &LinearTerms<'_>, scale: f64) {
     out.extend(
         terms.coeffs.iter().map(|&(var, value)| Triplet::new(row, var.index(), scale * value)),
     );

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -346,7 +346,8 @@ impl DerivativeOracle for HybridOracle {
                 SlotKind::Linear(terms) => {
                     let positions =
                         &self.jac_linear_scatter[linear_k..linear_k + terms.coeffs.len()];
-                    for (&position, &(_, coefficient)) in positions.iter().zip(&terms.coeffs) {
+                    for (&position, &(_, coefficient)) in positions.iter().zip(terms.coeffs.iter())
+                    {
                         row[position] += coefficient;
                     }
                     linear_k += terms.coeffs.len();

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -67,8 +67,8 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
                     .unwrap_or_else(|| "<nonlinear>".into()),
             })?;
             let mut by_id = vec![0.0; vars.len()];
-            for (v, c) in &lin.coeffs {
-                by_id[v.index()] = *c;
+            for &(v, c) in lin.coeffs.iter() {
+                by_id[v.index()] = c;
             }
             (by_id, lin.constant)
         }


### PR DESCRIPTION
## Description

Borrow coefficients directly from `Linear` arena nodes and own coefficients synthesized while walking expression trees.
`LinearTerms` now has a lifetime parameter and stores coefficients in `Cow`, so this is a breaking change.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features mosek` passes (requires MOSEK)
- [x] `cargo test --features baron` passes (requires BARON)