### PR TITLE
oximo-pounce(bugfix): reject semi-domain variables when using POUNCE …

### DIFF
--- a/crates/oximo-pounce/src/persistent.rs
+++ b/crates/oximo-pounce/src/persistent.rs
@@ -8,7 +8,7 @@ use oximo_solver::{Solver, SolverError, SolverResult};
 
 use crate::convex::{self, Route};
 use crate::options::PounceOptions;
-use crate::translate::{WarmStart, assemble, run_nlp_with_retries, setup};
+use crate::translate::{WarmStart, assemble, reject_semi_domains, run_nlp_with_retries, setup};
 
 #[cfg(feature = "enzyme")]
 use crate::exact as backend;
@@ -82,6 +82,8 @@ impl PouncePersistent {
         if model.has_active_sos_constraints() {
             return Err(SolverError::UnsupportedSos);
         }
+        reject_semi_domains(model)?;
+
         let route = convex::route(model, opts)?;
         if route == Route::Nlp {
             return self.solve_nlp(model, opts);

--- a/crates/oximo-pounce/src/translate.rs
+++ b/crates/oximo-pounce/src/translate.rs
@@ -67,17 +67,31 @@ pub(crate) struct Outcome {
     pub raw_log: Option<String>,
 }
 
+pub(crate) fn reject_semi_domains(model: &Model) -> Result<(), SolverError> {
+    let vars = model.variables();
+    if let Some(v) = vars.iter().find(|v| v.domain.semi_threshold().is_some()) {
+        return Err(SolverError::Backend(format!(
+            "variable {} has a semicontinuous/semi-integer domain, \
+                which POUNCE does not support",
+            v.name
+        )));
+    }
+    Ok(())
+}
+
 /// Translate `model`, solve with POUNCE (cold), and map the outcome.
 ///
 /// # Errors
 ///
-/// [`SolverError::UnsupportedKind`] for integer/cone model kinds and
+/// [`SolverError::UnsupportedKind`] for integer/cone model kinds,
+/// [`SolverError::Backend`] for a model with semi-continuous/semi-integer variables and
 /// [`SolverError::Core`] for a model with neither an objective nor a declared
 /// feasibility problem.
 pub fn solve(model: &Model, opts: &PounceOptions) -> Result<SolverResult, SolverError> {
     if model.has_active_sos_constraints() {
         return Err(SolverError::UnsupportedSos);
     }
+    reject_semi_domains(model)?;
     let route = crate::convex::route(model, opts)?;
     if route != crate::convex::Route::Nlp {
         return crate::convex::solve(model, opts, route);

--- a/crates/oximo-pounce/tests/solve_pounce.rs
+++ b/crates/oximo-pounce/tests/solve_pounce.rs
@@ -752,3 +752,29 @@ fn persistent_error_discards_resident_state() {
     assert!(format!("{solver:?}").contains("resident: false"));
     assert!(solver.solve(&m, &PounceOptions::default()).unwrap().has_solution());
 }
+
+#[test]
+fn semi_domains_are_rejected_consistently() {
+    for (label, model) in
+        [("semi-continuous", semi_model(false)), ("semi-integer", semi_model(true))]
+    {
+        let result = Pounce.solve(&model, &PounceOptions::default()).unwrap_err();
+        assert!(matches!(result, SolverError::Backend(_)), "{label} cold: {result}");
+
+        let mut persistent = Pounce.persistent();
+        let result = persistent.solve(&model, &PounceOptions::default()).unwrap_err();
+        assert!(matches!(result, SolverError::Backend(_)), "{label} persistent: {result}");
+    }
+}
+
+fn semi_model(integral: bool) -> Model {
+    let m = Model::new("semi");
+    if integral {
+        variable!(m, s <= 10, SemiInt(5.0));
+        objective!(m, Min, s);
+    } else {
+        variable!(m, s <= 10.0, SemiCont(5.0));
+        objective!(m, Min, s);
+    }
+    m
+}


### PR DESCRIPTION

## Description

- Raise a `SolverError::Backend` error when pounce is used with semi-domain variables. Error is raised via a function called `reject_semi_domains`, similarly to Mosek and Clarabel backend. 


## Checklist

- [ x] I have added tests that cover my changes
- [x ] I have run `cargo fmt` and `cargo clippy` to ensure code quality


## Related Issues

Closes #83 