### PR TITLE
Synchronized expression-arena + Parallel large index model construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1665,7 @@ dependencies = [
 name = "oximo-expr"
 version = "0.6.0"
 dependencies = [
+ "parking_lot",
  "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
@@ -1765,6 +1775,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2243,6 +2276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2352,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seq-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ rustc-hash       = "2.1"
 ndarray          = "0.17"
 thiserror        = "2.0"
 num-traits       = "0.2"
+parking_lot      = "0.12"
 highs            = "2.4"
 gurobi-rs        = { version = "1.0.0", features = ["gurobi13"] }
 mosek            = "11.2"

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -46,7 +46,7 @@ The modeling surface is a set of macros: `variable!`, `constraint!`, `objective!
 `sum!`, `set!`, and `param!`. Each expands to the underlying typed model operations,
 so there is no runtime cost and full compile-time type/borrow checking is preserved.
 
-`Model` uses interior mutability (`RefCell`), so a macro can take `&m`, register
+`Model` uses interior mutability, so a macro can take `&m`, register
 variables/constraints, and the `variable!`-introduced bindings (`x`, `y`, ...) are
 locals you can use immediately.
 
@@ -68,7 +68,7 @@ m.constraints()     // ModelConstraints<'_>
 m.constraints().algebraic()          // typed algebraic registry
 m.constraints().second_order_cones() // typed explicit-SOC registry
 m.constraints().special_ordered_sets() // typed SOS registry
-m.arena()          // Ref<'_, ExprArena>
+m.arena()          // ExprArenaSnapshot<'_>
 m.kind()           // ModelKind, cached, invalidated on change
 m.try_objective()  // Result<Objective, Error>
 m.variable_id("x") // Option<VarId>
@@ -133,6 +133,10 @@ variable!(m, lower[k] <= w[k in i] <= upper[k]);
 // Filtered family: keep only matching keys (no trivial elements built).
 variable!(m, d[(i, j) in rc if i == j] >= 0.0);
 ```
+
+Large indexed variable, parameter, algebraic, range, SOC, and SOS families are
+prepared in parallel when the family is large enough, then registered serially
+in set iteration order.
 
 ## Domain
 

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -195,19 +195,18 @@ impl<'a, K, F, const N: usize> Index<[usize; N]> for IndexedFamily<'a, K, F> {
     }
 }
 
-/// Build [`Storage`] from a family's keys and optional dense axes, registering
-/// each element through `make`.
+/// Build [`Storage`] from ordered keys and their already-registered handles.
 pub(crate) fn build_storage<'a>(
     keys: Vec<IndexKey>,
     axes: Option<Box<[Axis]>>,
-    mut make: impl FnMut(&IndexKey) -> Expr<'a>,
+    values: Vec<Expr<'a>>,
 ) -> Storage<'a> {
+    assert_eq!(keys.len(), values.len(), "indexed storage key/value length mismatch");
     if let Some(axes) = axes {
         let total = keys.len();
         let mut data: Vec<Option<Expr<'a>>> = vec![None; total];
         let mut kept: Vec<Option<IndexKey>> = vec![None; total];
-        for key in keys {
-            let expr = make(&key);
+        for (key, expr) in keys.into_iter().zip(values) {
             let off = grid_offset(&axes, &key).expect("dense grid key out of range");
             data[off] = Some(expr);
             kept[off] = Some(key);
@@ -216,11 +215,7 @@ pub(crate) fn build_storage<'a>(
         let kept = kept.into_iter().map(|o| o.expect("dense grid had a gap")).collect();
         Storage::Dense { data, keys: kept, axes }
     } else {
-        let mut entries = FxHashMap::default();
-        for key in keys {
-            let expr = make(&key);
-            entries.insert(key, expr);
-        }
+        let entries = keys.into_iter().zip(values).collect::<FxHashMap<_, _>>();
         Storage::Sparse(entries)
     }
 }

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -47,8 +47,8 @@ pub use var::{VarBuilder, Variable, var_name};
 // Re-export the expression handle so downstream code does not need a separate
 // `oximo-expr` import.
 pub use oximo_expr::{
-    EvalError, Expr, ExprArena, ExprId, ExprNode, ParamId, VarId, describe_nonlinear_term, dot,
-    render_expr, render_linear_terms,
+    EvalError, Expr, ExprArena, ExprArenaCell, ExprArenaSnapshot, ExprArenaWriteGuard, ExprId,
+    ExprNode, ParamId, VarId, describe_nonlinear_term, dot, render_expr, render_linear_terms,
 };
 
 pub use oximo_macros::{

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use oximo_expr::{
-    EvalError, Expr, ExprArena, ExprArenaCell, ExprArenaSnapshot, ExprClass, ExprId, ParamId, VarId,
-    classify,
+    EvalError, Expr, ExprArena, ExprArenaCell, ExprArenaSnapshot, ExprClass, ExprId, ExprIdRemap,
+    ParamId, VarId, classify,
 };
 use rayon::prelude::*;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use smol_str::SmolStr;
 
 use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
@@ -25,6 +25,20 @@ use crate::sos::{
 use crate::var::{VarBuilder, Variable};
 
 const PAR_KIND_THRESHOLD: usize = 256;
+const PAR_INDEXED_METADATA_THRESHOLD: usize = 1_024;
+const PAR_INDEXED_ALGEBRAIC_THRESHOLD: usize = 512;
+const PAR_INDEXED_RANGE_THRESHOLD: usize = 512;
+const PAR_INDEXED_SOC_THRESHOLD: usize = 256;
+const PAR_INDEXED_SOS_THRESHOLD: usize = 512;
+
+fn indexed_parallel(len: usize, forced: Option<bool>, threshold: usize) -> bool {
+    forced.unwrap_or(len >= threshold && rayon::current_num_threads() > 1)
+}
+
+fn indexed_chunk_size(len: usize) -> usize {
+    let chunks = rayon::current_num_threads().saturating_mul(4).max(1);
+    len.div_ceil(chunks).max(1)
+}
 
 fn arena_key(arena: &ExprArenaCell) -> usize {
     std::ptr::from_ref(arena) as usize
@@ -32,6 +46,124 @@ fn arena_key(arena: &ExprArenaCell) -> usize {
 
 fn assert_expr_arena(expr: Expr<'_>, expected: usize) {
     assert_eq!(arena_key(expr.arena), expected, "expression belongs to a different model");
+}
+
+fn validate_batch_names<V>(
+    existing: &FxHashMap<SmolStr, V>,
+    names: impl IntoIterator<Item = SmolStr>,
+    kind: &str,
+) {
+    let mut batch = FxHashSet::default();
+    for name in names {
+        assert!(!existing.contains_key(&name), "{kind} name {name:?} already registered");
+        assert!(batch.insert(name.clone()), "{kind} name {name:?} occurs more than once");
+    }
+}
+
+#[derive(Debug)]
+struct PendingVar {
+    key: IndexKey,
+    name: SmolStr,
+    lb: f64,
+    ub: f64,
+}
+
+#[derive(Debug)]
+struct PendingParam {
+    key: IndexKey,
+    name: SmolStr,
+    value: f64,
+}
+
+#[derive(Debug)]
+struct PendingConstraint {
+    name: SmolStr,
+    lhs: ExprId,
+    lower: f64,
+    upper: f64,
+}
+
+impl PendingConstraint {
+    fn from_expr(name: SmolStr, constraint: ConstraintExpr<'_>) -> Self {
+        let (lower, upper) = match constraint.sense {
+            Sense::Le => (f64::NEG_INFINITY, constraint.rhs),
+            Sense::Ge => (constraint.rhs, f64::INFINITY),
+            Sense::Eq => (constraint.rhs, constraint.rhs),
+        };
+        assert!(
+            !lower.is_nan() && !upper.is_nan(),
+            "constraint {name:?} has NaN bound (lower={lower}, upper={upper})"
+        );
+        Self { name, lhs: constraint.lhs.id, lower, upper }
+    }
+
+    fn remap(&mut self, remap: ExprIdRemap) {
+        self.lhs = remap.apply(self.lhs);
+    }
+}
+
+fn prepare_range<'a, B1: IntoRhs<'a>, B2: IntoRhs<'a>>(
+    name: String,
+    mid: Expr<'a>,
+    lo: B1,
+    hi: B2,
+) -> Vec<PendingConstraint> {
+    if let (Some(lower), Some(upper)) = (lo.const_bound(), hi.const_bound())
+        && mid.__class() == ExprClass::Linear
+    {
+        assert!(
+            !lower.is_nan() && !upper.is_nan(),
+            "constraint {name:?} has NaN bound (lower={lower}, upper={upper})"
+        );
+        vec![PendingConstraint { name: name.into(), lhs: mid.id, lower, upper }]
+    } else {
+        vec![
+            PendingConstraint::from_expr(format!("{name}_lo").into(), mid.ge(lo)),
+            PendingConstraint::from_expr(format!("{name}_hi").into(), mid.le(hi)),
+        ]
+    }
+}
+
+#[derive(Debug)]
+struct PendingSoc {
+    name: SmolStr,
+    terms: Vec<ExprId>,
+    bound: ExprId,
+}
+
+impl PendingSoc {
+    fn remap(&mut self, remap: ExprIdRemap) {
+        for term in &mut self.terms {
+            *term = remap.apply(*term);
+        }
+        self.bound = remap.apply(self.bound);
+    }
+}
+
+fn prepare_soc<'a>(
+    name: SmolStr,
+    terms: impl IntoIterator<Item = Expr<'a>>,
+    bound: Expr<'a>,
+) -> PendingSoc {
+    let terms: Vec<ExprId> = terms
+        .into_iter()
+        .map(|term| {
+            assert!(
+                term.__class() == ExprClass::Linear,
+                "SOC constraint {name:?} has a non-affine term"
+            );
+            term.id
+        })
+        .collect();
+    assert!(!terms.is_empty(), "SOC constraint {name:?} has no terms");
+    assert!(bound.__class() == ExprClass::Linear, "SOC constraint {name:?} has a non-affine bound");
+    PendingSoc { name, terms, bound: bound.id }
+}
+
+#[derive(Debug)]
+struct PendingSos {
+    name: SmolStr,
+    members: Vec<SosMember>,
 }
 
 /// The kind of mathematical program a `Model` represents.
@@ -335,6 +467,38 @@ impl Model {
         Expr::from_var(&self.arena, id)
     }
 
+    fn register_vars_batch<'a>(&'a self, items: &[PendingVar], domain: Domain) -> Vec<Expr<'a>> {
+        let mut names = self.var_names.borrow_mut();
+        validate_batch_names(&names, items.iter().map(|item| item.name.clone()), "variable");
+        let mut vars = self.variables.borrow_mut();
+        let final_count = vars.len().checked_add(items.len()).expect("variable count overflow");
+        if final_count > 0 {
+            u32::try_from(final_count - 1).expect("variable count overflow");
+        }
+        vars.reserve(items.len());
+        names.reserve(items.len());
+
+        let mut arena = self.arena.borrow_mut();
+        arena.__reserve_nodes(items.len());
+        let mut handles = Vec::with_capacity(items.len());
+        for item in items {
+            let id = VarId(u32::try_from(vars.len()).expect("variable count overflow"));
+            vars.push(Variable {
+                id,
+                name: item.name.clone(),
+                domain,
+                lb: item.lb,
+                ub: item.ub,
+                initial: None,
+            });
+            names.insert(item.name.clone(), id);
+            let node = arena.var(id);
+            handles.push(Expr::new(node, &self.arena));
+        }
+        self.cached_kind.set(None);
+        handles
+    }
+
     /// Macro-facing entry point backing the indexed form of the `variable!`
     /// macro. Not part of the stable public API.
     #[doc(hidden)]
@@ -353,6 +517,7 @@ impl Model {
             lb_by: None,
             ub_by: None,
             domain: Domain::Real,
+            parallel: None,
             _k: PhantomData,
         }
     }
@@ -523,6 +688,8 @@ impl Model {
     /// (`param!(m, cost[i in items] = data[i])`). Registers one scalar parameter
     /// per key, evaluating `value` on the typed key, and returns an
     /// [`IndexedParam`]. Not part of the stable public API.
+    /// Large families may evaluate `value` concurrently, so it must be safe to
+    /// call from multiple worker threads.
     ///
     /// # Panics
     ///
@@ -532,22 +699,73 @@ impl Model {
         &'a self,
         name: impl Into<String>,
         set: &Set<K>,
-        mut value: F,
+        value: F,
     ) -> IndexedParam<'a, K>
     where
         K: FromIndexKey,
-        F: FnMut(K) -> f64,
+        F: Fn(K) -> f64 + Send + Sync,
     {
-        let base = name.into();
+        self.indexed_param_with(name.into(), set, &value, None)
+    }
+
+    fn indexed_param_with<'a, K, F>(
+        &'a self,
+        base: String,
+        set: &Set<K>,
+        value: &F,
+        forced_parallel: Option<bool>,
+    ) -> IndexedParam<'a, K>
+    where
+        K: FromIndexKey,
+        F: Fn(K) -> f64 + Send + Sync,
+    {
         let axes = set.axes().map(Box::from);
         let keys: Vec<IndexKey> = set.iter().collect();
-        let make = |key: &IndexKey| -> Expr<'a> {
-            let pname: SmolStr = format_index_name(&base, key).into();
-            let v = value(K::from_index_key(key));
-            self.register_param(pname, v)
+        if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_METADATA_THRESHOLD) {
+            let handles = keys
+                .iter()
+                .map(|key| {
+                    let name: SmolStr = format_index_name(&base, key).into();
+                    self.register_param(name, value(K::from_index_key(key)))
+                })
+                .collect();
+            let storage = build_storage(keys, axes, handles);
+            return IndexedFamily { storage, _marker: PhantomData };
+        }
+        let prepare = |key: &IndexKey| PendingParam {
+            key: key.clone(),
+            name: format_index_name(&base, key).into(),
+            value: value(K::from_index_key(key)),
         };
-        let storage = build_storage(keys, axes, make);
+        let prepared: Vec<_> = keys.par_iter().map(prepare).collect();
+        let handles = self.register_params_batch(&prepared);
+        let keys = prepared.into_iter().map(|item| item.key).collect();
+        let storage = build_storage(keys, axes, handles);
         IndexedFamily { storage, _marker: PhantomData }
+    }
+
+    fn register_params_batch<'a>(&'a self, items: &[PendingParam]) -> Vec<Expr<'a>> {
+        let mut names = self.param_names.borrow_mut();
+        validate_batch_names(&names, items.iter().map(|item| item.name.clone()), "parameter");
+        let mut params = self.parameters.borrow_mut();
+        let mut arena = self.arena.borrow_mut();
+        let final_count = params.len().checked_add(items.len()).expect("parameter count overflow");
+        if final_count > 0 {
+            u32::try_from(final_count - 1).expect("parameter count overflow");
+        }
+        params.reserve(items.len());
+        names.reserve(items.len());
+        arena.__reserve_nodes(items.len());
+
+        let mut handles = Vec::with_capacity(items.len());
+        for item in items {
+            let id = arena.new_param(item.value);
+            let node = arena.param(id);
+            params.push(Parameter { id, name: item.name.clone() });
+            names.insert(item.name.clone(), id);
+            handles.push(Expr::new(node, &self.arena));
+        }
+        handles
     }
 
     /// Re-bind the parameter at `key` of an indexed family to `value`. Takes
@@ -681,6 +899,32 @@ impl Model {
         id
     }
 
+    fn register_constraints_batch(&self, items: Vec<PendingConstraint>) {
+        let mut names = self.constraint_names.borrow_mut();
+        validate_batch_names(&names, items.iter().map(|item| item.name.clone()), "constraint");
+        let mut constraints = self.constraints.borrow_mut();
+        let final_count =
+            constraints.len().checked_add(items.len()).expect("constraint count overflow");
+        if final_count > 0 {
+            u32::try_from(final_count - 1).expect("constraint count overflow");
+        }
+        constraints.reserve(items.len());
+        names.reserve(items.len());
+        for item in items {
+            let id =
+                ConstraintId(u32::try_from(constraints.len()).expect("constraint count overflow"));
+            constraints.push(Constraint {
+                name: item.name.clone(),
+                lhs: item.lhs,
+                lower: item.lower,
+                upper: item.upper,
+                active: true,
+            });
+            names.insert(item.name, id);
+        }
+        self.cached_kind.set(None);
+    }
+
     /// A fresh unique auto-name `_c{n}`, skipping any a user already took.
     fn next_auto_name(&self) -> SmolStr {
         loop {
@@ -729,17 +973,75 @@ impl Model {
     /// (any [`FromIndexKey`]: `i64`, `i32`, `usize`, `String`, raw `IndexKey`, or
     /// tuples up to arity 4). Not part of the stable public API.
     #[doc(hidden)]
-    pub fn __add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set<K>, mut rule: F)
+    pub fn __add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set<K>, rule: F)
     where
         K: FromIndexKey,
-        F: FnMut(K) -> ConstraintExpr<'a>,
+        F: Fn(K) -> ConstraintExpr<'a> + Send + Sync,
     {
-        for key in set {
-            let typed = K::from_index_key(&key);
-            let c = rule(typed);
-            let name: SmolStr = format_index_name(name_prefix, &key).into();
-            self.__add_constraint(name, c);
+        self.add_constraints_over_with(name_prefix, set, &rule, None);
+    }
+
+    fn add_constraints_over_with<'a, K, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        rule: &F,
+        forced_parallel: Option<bool>,
+    ) where
+        K: FromIndexKey,
+        F: Fn(K) -> ConstraintExpr<'a> + Send + Sync,
+    {
+        let keys: Vec<IndexKey> = set.iter().collect();
+        if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_ALGEBRAIC_THRESHOLD) {
+            for key in &keys {
+                let constraint = rule(K::from_index_key(key));
+                self.assert_expr_belongs(constraint.lhs);
+                let name: SmolStr = format_index_name(name_prefix, key).into();
+                self.__add_constraint(name, constraint);
+            }
+            return;
         }
+
+        let arena = &self.arena;
+        let expected_arena = arena_key(arena);
+        let mut batch = arena.__begin_batch();
+        let snapshot = batch.snapshot();
+        let chunk_size = indexed_chunk_size(keys.len());
+        let mut forks: Vec<_> = keys
+            .par_chunks(chunk_size)
+            .map(|chunk| {
+                arena.__with_fork(snapshot.clone(), || {
+                    chunk
+                        .iter()
+                        .map(|key| {
+                            let name = format_index_name(name_prefix, key).into();
+                            let constraint = rule(K::from_index_key(key));
+                            assert_expr_arena(constraint.lhs, expected_arena);
+                            PendingConstraint::from_expr(name, constraint)
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        drop(snapshot);
+        {
+            let existing = self.constraint_names.borrow();
+            validate_batch_names(
+                &existing,
+                forks.iter().flat_map(|fork| fork.value.iter().map(|item| item.name.clone())),
+                "constraint",
+            );
+        }
+        let remaps = batch.merge(&mut forks);
+        let mut pending = Vec::with_capacity(keys.len());
+        for (mut fork, remap) in forks.into_iter().zip(remaps) {
+            for item in &mut fork.value {
+                item.remap(remap);
+            }
+            pending.extend(fork.value);
+        }
+        drop(batch);
+        self.register_constraints_batch(pending);
     }
 
     /// Macro-facing entry point for a two-sided range `lo <= mid <= hi`.
@@ -799,18 +1101,77 @@ impl Model {
         &'a self,
         name: &str,
         set: &Set<K>,
-        mut rule: F,
+        rule: F,
     ) where
         K: FromIndexKey,
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
-        F: FnMut(K) -> (Expr<'a>, B1, B2),
+        F: Fn(K) -> (Expr<'a>, B1, B2) + Send + Sync,
     {
-        for key in set {
-            let (mid, lo, hi) = rule(K::from_index_key(&key));
-            let row_name = format_index_name(name, &key);
-            self.__add_range(&row_name, mid, lo, hi);
+        self.add_range_constraints_over_with(name, set, &rule, None);
+    }
+
+    fn add_range_constraints_over_with<'a, K, B1, B2, F>(
+        &'a self,
+        name: &str,
+        set: &Set<K>,
+        rule: &F,
+        forced_parallel: Option<bool>,
+    ) where
+        K: FromIndexKey,
+        B1: IntoRhs<'a>,
+        B2: IntoRhs<'a>,
+        F: Fn(K) -> (Expr<'a>, B1, B2) + Send + Sync,
+    {
+        let keys: Vec<IndexKey> = set.iter().collect();
+        if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_RANGE_THRESHOLD) {
+            for key in &keys {
+                let (mid, lo, hi) = rule(K::from_index_key(key));
+                self.assert_expr_belongs(mid);
+                self.__add_range(&format_index_name(name, key), mid, lo, hi);
+            }
+            return;
         }
+
+        let arena = &self.arena;
+        let expected_arena = arena_key(arena);
+        let mut batch = arena.__begin_batch();
+        let snapshot = batch.snapshot();
+        let chunk_size = indexed_chunk_size(keys.len());
+        let mut forks: Vec<_> = keys
+            .par_chunks(chunk_size)
+            .map(|chunk| {
+                arena.__with_fork(snapshot.clone(), || {
+                    chunk
+                        .iter()
+                        .flat_map(|key| {
+                            let (mid, lo, hi) = rule(K::from_index_key(key));
+                            assert_expr_arena(mid, expected_arena);
+                            prepare_range(format_index_name(name, key), mid, lo, hi)
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        drop(snapshot);
+        {
+            let existing = self.constraint_names.borrow();
+            validate_batch_names(
+                &existing,
+                forks.iter().flat_map(|fork| fork.value.iter().map(|item| item.name.clone())),
+                "constraint",
+            );
+        }
+        let remaps = batch.merge(&mut forks);
+        let mut pending = Vec::with_capacity(keys.len().saturating_mul(2));
+        for (mut fork, remap) in forks.into_iter().zip(remaps) {
+            for item in &mut fork.value {
+                item.remap(remap);
+            }
+            pending.extend(fork.value);
+        }
+        drop(batch);
+        self.register_constraints_batch(pending);
     }
 
     /// Unified view of every algebraic, explicit SOC, and SOS constraint
@@ -885,6 +1246,32 @@ impl Model {
         id
     }
 
+    fn register_soc_batch(&self, items: Vec<PendingSoc>) {
+        let mut names = self.soc_names.borrow_mut();
+        validate_batch_names(&names, items.iter().map(|item| item.name.clone()), "SOC constraint");
+        let mut constraints = self.soc_constraints.borrow_mut();
+        let final_count =
+            constraints.len().checked_add(items.len()).expect("SOC constraint count overflow");
+        if final_count > 0 {
+            u32::try_from(final_count - 1).expect("SOC constraint count overflow");
+        }
+        constraints.reserve(items.len());
+        names.reserve(items.len());
+        for item in items {
+            let id = SocConstraintId(
+                u32::try_from(constraints.len()).expect("SOC constraint count overflow"),
+            );
+            constraints.push(SocConstraint {
+                name: item.name.clone(),
+                terms: item.terms,
+                bound: item.bound,
+                active: true,
+            });
+            names.insert(item.name, id);
+        }
+        self.cached_kind.set(None);
+    }
+
     /// A fresh unique auto-name `_soc{n}` in the SOC namespace, skipping any a
     /// user already took. Shares `auto_seq` with [`Self::next_auto_name`]; the
     /// prefixes differ, so the two namespaces never collide.
@@ -920,18 +1307,85 @@ impl Model {
         &'a self,
         name_prefix: &str,
         set: &Set<K>,
-        mut rule: F,
+        rule: F,
     ) where
         K: FromIndexKey,
         T: IntoIterator<Item = Expr<'a>>,
-        F: FnMut(K) -> (T, Expr<'a>),
+        F: Fn(K) -> (T, Expr<'a>) + Send + Sync,
     {
-        for key in set {
-            let typed = K::from_index_key(&key);
-            let (terms, bound) = rule(typed);
-            let name: SmolStr = format_index_name(name_prefix, &key).into();
-            self.add_soc_constraint(name, terms, bound);
+        self.add_soc_constraints_over_with(name_prefix, set, &rule, None);
+    }
+
+    fn add_soc_constraints_over_with<'a, K, T, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        rule: &F,
+        forced_parallel: Option<bool>,
+    ) where
+        K: FromIndexKey,
+        T: IntoIterator<Item = Expr<'a>>,
+        F: Fn(K) -> (T, Expr<'a>) + Send + Sync,
+    {
+        let keys: Vec<IndexKey> = set.iter().collect();
+        if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_SOC_THRESHOLD) {
+            for key in &keys {
+                let name: SmolStr = format_index_name(name_prefix, key).into();
+                let (terms, bound) = rule(K::from_index_key(key));
+                let terms: Vec<_> = terms.into_iter().collect();
+                for &term in &terms {
+                    self.assert_expr_belongs(term);
+                }
+                self.assert_expr_belongs(bound);
+                self.add_soc_constraint(name, terms, bound);
+            }
+            return;
         }
+
+        let arena = &self.arena;
+        let expected_arena = arena_key(arena);
+        let mut batch = arena.__begin_batch();
+        let snapshot = batch.snapshot();
+        let chunk_size = indexed_chunk_size(keys.len());
+        let mut forks: Vec<_> = keys
+            .par_chunks(chunk_size)
+            .map(|chunk| {
+                arena.__with_fork(snapshot.clone(), || {
+                    chunk
+                        .iter()
+                        .map(|key| {
+                            let name = format_index_name(name_prefix, key).into();
+                            let (terms, bound) = rule(K::from_index_key(key));
+                            assert_expr_arena(bound, expected_arena);
+                            let terms: Vec<_> = terms.into_iter().collect();
+                            for &term in &terms {
+                                assert_expr_arena(term, expected_arena);
+                            }
+                            prepare_soc(name, terms, bound)
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        drop(snapshot);
+        {
+            let existing = self.soc_names.borrow();
+            validate_batch_names(
+                &existing,
+                forks.iter().flat_map(|fork| fork.value.iter().map(|item| item.name.clone())),
+                "SOC constraint",
+            );
+        }
+        let remaps = batch.merge(&mut forks);
+        let mut pending = Vec::with_capacity(keys.len());
+        for (mut fork, remap) in forks.into_iter().zip(remaps) {
+            for item in &mut fork.value {
+                item.remap(remap);
+            }
+            pending.extend(fork.value);
+        }
+        drop(batch);
+        self.register_soc_batch(pending);
     }
 
     /// Typed explicit-SOC registry for specialized backend passes.
@@ -990,6 +1444,94 @@ impl Model {
         by_name.insert(name, id);
         self.cached_kind.set(None);
         SosConstraintHandle { model: self, id }
+    }
+
+    fn register_sos_batch(&self, sos_type: SosType, items: Vec<PendingSos>) {
+        let mut names = self.sos_names.borrow_mut();
+        validate_batch_names(&names, items.iter().map(|item| item.name.clone()), "SOS constraint");
+        let mut constraints = self.sos_constraints.borrow_mut();
+        let final_count =
+            constraints.len().checked_add(items.len()).expect("SOS constraint count overflow");
+        if final_count > 0 {
+            u32::try_from(final_count - 1).expect("SOS constraint count overflow");
+        }
+        constraints.reserve(items.len());
+        names.reserve(items.len());
+        for item in items {
+            let id = SosConstraintId(
+                u32::try_from(constraints.len()).expect("SOS constraint count overflow"),
+            );
+            constraints.push(SosConstraint {
+                name: item.name.clone(),
+                sos_type,
+                members: item.members,
+                active: true,
+            });
+            names.insert(item.name, id);
+        }
+        self.cached_kind.set(None);
+    }
+
+    fn register_sos_one(&self, sos_type: SosType, item: PendingSos) {
+        let mut names = self.sos_names.borrow_mut();
+        assert!(
+            !names.contains_key(&item.name),
+            "SOS constraint name {:?} already registered",
+            item.name
+        );
+        let mut constraints = self.sos_constraints.borrow_mut();
+        let id = SosConstraintId(
+            u32::try_from(constraints.len()).expect("SOS constraint count overflow"),
+        );
+        constraints.push(SosConstraint {
+            name: item.name.clone(),
+            sos_type,
+            members: item.members,
+            active: true,
+        });
+        names.insert(item.name, id);
+        self.cached_kind.set(None);
+    }
+
+    fn add_pending_sos_over(
+        &self,
+        keys: Vec<IndexKey>,
+        sos_type: SosType,
+        forced_parallel: Option<bool>,
+        prepare: impl Fn(&IndexKey) -> PendingSos + Send + Sync,
+    ) {
+        if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_SOS_THRESHOLD) {
+            for key in &keys {
+                self.register_sos_one(sos_type, prepare(key));
+            }
+            return;
+        }
+
+        let arena = &self.arena;
+        let batch = arena.__begin_batch();
+        let snapshot = batch.snapshot();
+        let chunk_size = indexed_chunk_size(keys.len());
+        let forks: Vec<_> = keys
+            .par_chunks(chunk_size)
+            .map(|chunk| {
+                arena.__with_fork(snapshot.clone(), || {
+                    chunk.iter().map(&prepare).collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        drop(snapshot);
+        {
+            let existing = self.sos_names.borrow();
+            validate_batch_names(
+                &existing,
+                forks.iter().flat_map(|fork| fork.value.iter().map(|item| item.name.clone())),
+                "SOS constraint",
+            );
+        }
+        // Valid SOS members contain only VarIds, so no expression-root remap is needed.
+        drop(batch);
+        let pending = forks.into_iter().flat_map(|fork| fork.value).collect();
+        self.register_sos_batch(sos_type, pending);
     }
 
     /// Register an SOS1 or SOS2 constraint with consecutive positional
@@ -1057,17 +1599,42 @@ impl Model {
         name_prefix: &str,
         set: &Set<K>,
         sos_type: SosType,
-        mut rule: F,
+        rule: F,
     ) where
         K: FromIndexKey,
         T: IntoIterator<Item = (Expr<'a>, f64)>,
-        F: FnMut(K) -> T,
+        F: Fn(K) -> T + Send + Sync,
     {
-        for key in set {
-            let typed = K::from_index_key(&key);
-            let name: SmolStr = format_index_name(name_prefix, &key).into();
-            self.add_sos_constraint(name, sos_type, rule(typed));
-        }
+        self.add_sos_constraints_over_with(name_prefix, set, sos_type, &rule, None);
+    }
+
+    fn add_sos_constraints_over_with<'a, K, T, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        sos_type: SosType,
+        rule: &F,
+        forced_parallel: Option<bool>,
+    ) where
+        K: FromIndexKey,
+        T: IntoIterator<Item = (Expr<'a>, f64)>,
+        F: Fn(K) -> T + Send + Sync,
+    {
+        let keys: Vec<IndexKey> = set.iter().collect();
+        let expected_arena = arena_key(&self.arena);
+        self.add_pending_sos_over(keys, sos_type, forced_parallel, |key| {
+            let name: SmolStr = format_index_name(name_prefix, key).into();
+            let members: Vec<_> = rule(K::from_index_key(key))
+                .into_iter()
+                .map(|(expr, weight)| {
+                    assert_expr_arena(expr, expected_arena);
+                    let variable = expr.var_id().expect("SOS members must be bare variables");
+                    SosMember { variable, weight }
+                })
+                .collect();
+            validate_members(&name, &members);
+            PendingSos { name, members }
+        });
     }
 
     #[doc(hidden)]
@@ -1076,17 +1643,47 @@ impl Model {
         name_prefix: &str,
         set: &Set<K>,
         sos_type: SosType,
-        mut rule: F,
+        rule: F,
     ) where
         K: FromIndexKey,
         T: IntoIterator<Item = Expr<'a>>,
-        F: FnMut(K) -> T,
+        F: Fn(K) -> T + Send + Sync,
     {
-        for key in set {
-            let typed = K::from_index_key(&key);
-            let name: SmolStr = format_index_name(name_prefix, &key).into();
-            self.add_sos_constraint_auto_weights(name, sos_type, rule(typed));
-        }
+        self.add_sos_constraints_over_auto_weights_with(name_prefix, set, sos_type, &rule, None);
+    }
+
+    fn add_sos_constraints_over_auto_weights_with<'a, K, T, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        sos_type: SosType,
+        rule: &F,
+        forced_parallel: Option<bool>,
+    ) where
+        K: FromIndexKey,
+        T: IntoIterator<Item = Expr<'a>>,
+        F: Fn(K) -> T + Send + Sync,
+    {
+        let keys: Vec<IndexKey> = set.iter().collect();
+        let expected_arena = arena_key(&self.arena);
+        self.add_pending_sos_over(keys, sos_type, forced_parallel, |key| {
+            let name: SmolStr = format_index_name(name_prefix, key).into();
+            let members: Vec<_> = rule(K::from_index_key(key))
+                .into_iter()
+                .enumerate()
+                .map(|(index, expr)| {
+                    let weight = index
+                        .checked_add(1)
+                        .and_then(|index| u32::try_from(index).ok())
+                        .expect("SOS member count exceeds positional weight range");
+                    assert_expr_arena(expr, expected_arena);
+                    let variable = expr.var_id().expect("SOS members must be bare variables");
+                    SosMember { variable, weight: f64::from(weight) }
+                })
+                .collect();
+            validate_members(&name, &members);
+            PendingSos { name, members }
+        });
     }
 
     pub fn sos_constraints(&self) -> Ref<'_, Vec<SosConstraint>> {
@@ -1297,7 +1894,7 @@ impl Model {
 /// `flow[2]` as separate scalar variables in the model. Call `.build()` to get
 /// an [`IndexedVar`] that maps each key to its [`Expr`] handle. Bounds and
 /// domain set here apply uniformly to every scalar in the collection.
-type BoundFn<'a> = Box<dyn Fn(&IndexKey) -> f64 + 'a>;
+type BoundFn<'a> = Box<dyn Fn(&IndexKey) -> f64 + Send + Sync + 'a>;
 
 #[must_use = "IndexedVarBuilder does nothing until you call .build()"]
 pub struct IndexedVarBuilder<'a, K = IndexKey> {
@@ -1310,6 +1907,7 @@ pub struct IndexedVarBuilder<'a, K = IndexKey> {
     lb_by: Option<BoundFn<'a>>,
     ub_by: Option<BoundFn<'a>>,
     domain: Domain,
+    parallel: Option<bool>,
     _k: PhantomData<fn() -> K>,
 }
 
@@ -1353,6 +1951,7 @@ impl<'a, K> IndexedVarBuilder<'a, K> {
     where
         K: FromIndexKey,
         F: Fn(K) -> f64 + 'a,
+        F: Send + Sync,
     {
         self.lb_by = Some(Box::new(move |k: &IndexKey| f(K::from_index_key(k))));
         self
@@ -1369,6 +1968,7 @@ impl<'a, K> IndexedVarBuilder<'a, K> {
     where
         K: FromIndexKey,
         F: Fn(K) -> f64 + 'a,
+        F: Send + Sync,
     {
         self.ub_by = Some(Box::new(move |k: &IndexKey| f(K::from_index_key(k))));
         self
@@ -1393,17 +1993,40 @@ impl<'a, K> IndexedVarBuilder<'a, K> {
     /// # Panics
     /// Panics if a scalar variable name collides with one already registered.
     pub fn build(self) -> IndexedVar<'a, K> {
-        let Self { model, base_name, keys, axes, lb, ub, lb_by, ub_by, domain, _k } = self;
+        let Self { model, base_name, keys, axes, lb, ub, lb_by, ub_by, domain, parallel, _k } =
+            self;
 
-        let make = |key: &IndexKey| -> Expr<'a> {
-            let scalar_name: SmolStr = format_index_name(&base_name, key).into();
-            let lo = lb_by.as_ref().map_or(lb, |f| f(key));
-            let hi = ub_by.as_ref().map_or(ub, |f| f(key));
-            model.__var(scalar_name).lb(lo).ub(hi).domain(domain).build()
+        if !indexed_parallel(keys.len(), parallel, PAR_INDEXED_METADATA_THRESHOLD) {
+            let handles = keys
+                .iter()
+                .map(|key| {
+                    let scalar_name: SmolStr = format_index_name(&base_name, key).into();
+                    let lo = lb_by.as_ref().map_or(lb, |f| f(key));
+                    let hi = ub_by.as_ref().map_or(ub, |f| f(key));
+                    model.__var(scalar_name).lb(lo).ub(hi).domain(domain).build()
+                })
+                .collect();
+            let storage = build_storage(keys, axes, handles);
+            return IndexedFamily { storage, _marker: PhantomData };
+        }
+
+        let prepare = |key: &IndexKey| PendingVar {
+            key: key.clone(),
+            name: format_index_name(&base_name, key).into(),
+            lb: lb_by.as_ref().map_or(lb, |f| f(key)),
+            ub: ub_by.as_ref().map_or(ub, |f| f(key)),
         };
-
-        let storage = build_storage(keys, axes, make);
+        let prepared: Vec<_> = keys.par_iter().map(prepare).collect();
+        let handles = model.register_vars_batch(&prepared, domain);
+        let keys = prepared.into_iter().map(|item| item.key).collect();
+        let storage = build_storage(keys, axes, handles);
         IndexedFamily { storage, _marker: PhantomData }
+    }
+
+    #[cfg(any(test, feature = "benchmark-support"))]
+    fn parallel_for_benchmark(mut self, parallel: bool) -> Self {
+        self.parallel = Some(parallel);
+        self
     }
 }
 
@@ -1481,11 +2104,89 @@ pub mod benchmark_support {
     pub fn infer(model: &Model, parallel: bool) -> ModelKind {
         model.infer_kind(parallel)
     }
+
+    #[derive(Copy, Clone, Debug)]
+    pub enum IndexedBuildCase {
+        Variables,
+        Parameters,
+        Algebraic,
+        Range,
+        Soc,
+        Sos,
+    }
+
+    /// Build and immediately inspect a fresh indexed model so Criterion measures
+    /// construction rather than solver translation.
+    pub fn indexed_build(rows: usize, case: IndexedBuildCase, parallel: bool) -> usize {
+        let model = Model::new("indexed_build_bench");
+        let keys = Set::range(0..rows);
+        match case {
+            IndexedBuildCase::Variables => {
+                let x = model
+                    .__indexed_var("x", &keys)
+                    .lb_by(|i: usize| -(i as f64))
+                    .ub_by(|i: usize| i as f64 + 1.0)
+                    .parallel_for_benchmark(parallel)
+                    .build();
+                std::hint::black_box(x.len());
+            }
+            IndexedBuildCase::Parameters => {
+                let value = |i: usize| i as f64 + 1.0;
+                let p = model.indexed_param_with("p".to_owned(), &keys, &value, Some(parallel));
+                std::hint::black_box(p.len());
+            }
+            IndexedBuildCase::Algebraic => {
+                let x = model.__indexed_var("x", &keys).parallel_for_benchmark(parallel).build();
+                let rule = |i: usize| (2.0 * x[i] + 1.0).le(i as f64 + 10.0);
+                model.add_constraints_over_with("c", &keys, &rule, Some(parallel));
+            }
+            IndexedBuildCase::Range => {
+                let x = model.__indexed_var("x", &keys).parallel_for_benchmark(parallel).build();
+                let rule = |i: usize| (x[i] + 1.0, -(i as f64), i as f64 + 10.0);
+                model.add_range_constraints_over_with("r", &keys, &rule, Some(parallel));
+            }
+            IndexedBuildCase::Soc => {
+                let x = model.__indexed_var("x", &keys).parallel_for_benchmark(parallel).build();
+                let y = model.__indexed_var("y", &keys).parallel_for_benchmark(parallel).build();
+                let t = model.__var("t").lb(0.0).build();
+                let rule = |i: usize| ([x[i] + 1.0, y[i] - 1.0], t + i as f64 + 1.0);
+                model.add_soc_constraints_over_with("q", &keys, &rule, Some(parallel));
+            }
+            IndexedBuildCase::Sos => {
+                let x = model.__indexed_var("x", &keys).parallel_for_benchmark(parallel).build();
+                let y = model.__indexed_var("y", &keys).parallel_for_benchmark(parallel).build();
+                let rule = |i: usize| [(x[i], 1.0), (y[i], 2.0)];
+                model.add_sos_constraints_over_with(
+                    "s",
+                    &keys,
+                    SosType::Sos1,
+                    &rule,
+                    Some(parallel),
+                );
+            }
+        }
+        model.num_variables()
+            + model.num_parameters()
+            + model.num_constraints()
+            + model.arena().len()
+    }
+
+    /// Scalar construction guardrail for the parallel-safe arena migration.
+    pub fn scalar_build(rows: usize) -> usize {
+        let model = Model::new("scalar_build_bench");
+        for i in 0..rows {
+            let x = model.__var(format!("x{i}")).build();
+            model.__add_constraint(format!("c{i}"), (2.0 * x + 1.0).le(i as f64 + 10.0));
+        }
+        model.num_variables() + model.num_constraints() + model.arena().len()
+    }
 }
 
 #[cfg(test)]
 #[expect(clippy::cast_precision_loss)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
     use oximo_expr::extract_linear;
 
     use super::*;
@@ -1565,6 +2266,16 @@ mod tests {
         m.set_param(param, 2.0);
         assert!((snapshot.param_value(id) - 1.0).abs() < f64::EPSILON);
         assert!((m.param_value(id) - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    #[should_panic(expected = "different model")]
+    fn indexed_constraints_reject_foreign_expression_arenas() {
+        let target = Model::new("target");
+        let foreign = Model::new("foreign");
+        let x = foreign.__var("x").build();
+        let keys = Set::range(0..1024);
+        target.add_constraints_over_with("c", &keys, &|_| x.le(1.0), Some(true));
     }
 
     #[test]
@@ -1721,5 +2432,153 @@ mod tests {
         let arena = model.arena();
         assert_eq!(model.kind(), ModelKind::LP);
         assert!(matches!(arena.get(x.id), oximo_expr::ExprNode::Var(_)));
+    }
+
+    #[test]
+    fn indexed_build_forced_parallel_matches_serial_for_every_family() {
+        #[derive(Debug, PartialEq)]
+        struct Digest {
+            variables: Vec<String>,
+            parameters: Vec<(String, f64)>,
+            rows: Vec<String>,
+            typed: Vec<String>,
+            arena_len: usize,
+        }
+
+        fn digest(parallel: bool) -> Digest {
+            let model = Model::new("indexed_parity");
+            let keys = Set::range(0..128usize);
+            let x = model
+                .__indexed_var("x", &keys)
+                .lb_by(|i: usize| -(i as f64))
+                .ub_by(|i: usize| i as f64 + 10.0)
+                .parallel_for_benchmark(parallel)
+                .build();
+            let y = model.__indexed_var("y", &keys).parallel_for_benchmark(parallel).build();
+            let values = |i: usize| i as f64 + 0.5;
+            let p = model.indexed_param_with("p".to_owned(), &keys, &values, Some(parallel));
+
+            let algebraic = |i: usize| (2.0 * x[i] + p[i]).le(i as f64 + 20.0);
+            model.add_constraints_over_with("c", &keys, &algebraic, Some(parallel));
+            let ranges = |i: usize| (y[i] + 1.0, -(i as f64), i as f64 + 5.0);
+            model.add_range_constraints_over_with("r", &keys, &ranges, Some(parallel));
+            let symbolic_ranges = |i: usize| (x[i] + 2.0, -p[i], p[i] + 3.0);
+            model.add_range_constraints_over_with("sr", &keys, &symbolic_ranges, Some(parallel));
+            let t = model.__var("t").lb(0.0).build();
+            let cones = |i: usize| ([x[i] + 1.0, y[i] - 1.0], t + p[i]);
+            model.add_soc_constraints_over_with("q", &keys, &cones, Some(parallel));
+            let explicit_sos = |i: usize| [(x[i], 1.0), (y[i], 2.0)];
+            model.add_sos_constraints_over_with(
+                "s",
+                &keys,
+                SosType::Sos1,
+                &explicit_sos,
+                Some(parallel),
+            );
+            let auto_sos = |i: usize| [x[i], y[i]];
+            model.add_sos_constraints_over_auto_weights_with(
+                "a",
+                &keys,
+                SosType::Sos2,
+                &auto_sos,
+                Some(parallel),
+            );
+
+            let variables = model
+                .variables()
+                .iter()
+                .map(|variable| {
+                    format!(
+                        "{}:{:?}:{}:{}:{}",
+                        variable.name, variable.id, variable.lb, variable.ub, variable.domain
+                    )
+                })
+                .collect();
+            let parameters = model
+                .parameters()
+                .iter()
+                .map(|parameter| (parameter.name.to_string(), model.param_value(parameter.id)))
+                .collect();
+            let arena = model.arena();
+            let constraints = model.constraints();
+            let rows = constraints
+                .algebraic()
+                .iter()
+                .map(|constraint| {
+                    let terms = extract_linear(&arena, constraint.lhs).unwrap();
+                    format!(
+                        "{}:{:?}:{}:{}:{}",
+                        constraint.name,
+                        terms.coeffs,
+                        terms.constant,
+                        constraint.lower,
+                        constraint.upper
+                    )
+                })
+                .collect();
+            let mut typed = constraints
+                .second_order_cones()
+                .iter()
+                .map(|constraint| {
+                    let terms: Vec<_> = constraint
+                        .terms
+                        .iter()
+                        .map(|&term| extract_linear(&arena, term).unwrap().into_owned())
+                        .collect();
+                    let bound = extract_linear(&arena, constraint.bound).unwrap().into_owned();
+                    format!("{}:{terms:?}:{bound:?}", constraint.name)
+                })
+                .collect::<Vec<_>>();
+            typed.extend(
+                constraints
+                    .special_ordered_sets()
+                    .iter()
+                    .map(|constraint| format!("{constraint:?}")),
+            );
+            let arena_len = arena.len();
+            Digest { variables, parameters, rows, typed, arena_len }
+        }
+
+        assert_eq!(digest(false), digest(true));
+    }
+
+    #[test]
+    fn parallel_duplicate_name_failure_does_not_mutate_model_or_arena() {
+        let model = Model::new("indexed_atomicity");
+        let x = model.__var("x").build();
+        let duplicate_keys = Set::from_ints([0usize, 0]);
+        let arena_len = model.arena().len();
+        let rule = |i: usize| (x + i as f64).le(1.0);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            model.add_constraints_over_with("dup", &duplicate_keys, &rule, Some(true));
+        }));
+        assert!(result.is_err());
+        assert_eq!(model.num_constraints(), 0);
+        assert_eq!(model.arena().len(), arena_len);
+
+        model.__add_constraint("after", x.le(2.0));
+        assert_eq!(model.constraint_id("after"), Some(ConstraintId(0)));
+    }
+
+    #[test]
+    fn parallel_callback_panic_does_not_mutate_model_or_arena() {
+        let model = Model::new("indexed_callback_atomicity");
+        let x = model.__var("x").build();
+        let keys = Set::range(0..128usize);
+        let arena_len = model.arena().len();
+        let rule = |i: usize| {
+            let constraint = (x + i as f64).le(1.0);
+            assert_ne!(i, 17, "deliberate callback panic");
+            constraint
+        };
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            model.add_constraints_over_with("panic", &keys, &rule, Some(true));
+        }));
+        assert!(result.is_err());
+        assert_eq!(model.num_constraints(), 0);
+        assert_eq!(model.arena().len(), arena_len);
+
+        model.__add_constraint("after", x.le(2.0));
+        assert_eq!(model.constraint_id("after"), Some(ConstraintId(0)));
     }
 }

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -954,6 +954,7 @@ impl Model {
         lower: f64,
         upper: f64,
     ) -> ConstraintId {
+        self.assert_expr_belongs(lhs);
         self.register_constraint(name.into(), lhs.id, lower, upper)
     }
 
@@ -1071,6 +1072,7 @@ impl Model {
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
     {
+        self.assert_expr_belongs(mid);
         if let Some((lower, upper)) = self.collapse_bounds(mid.id, &lo, &hi) {
             self.register_constraint(self.next_auto_name(), mid.id, lower, upper);
         } else {

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -2,7 +2,10 @@ use std::cell::{Cell, Ref, RefCell};
 use std::fmt;
 use std::marker::PhantomData;
 
-use oximo_expr::{EvalError, Expr, ExprArena, ExprClass, ExprId, ParamId, VarId, classify};
+use oximo_expr::{
+    EvalError, Expr, ExprArena, ExprArenaCell, ExprArenaSnapshot, ExprClass, ExprId, ParamId, VarId,
+    classify,
+};
 use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use smol_str::SmolStr;
@@ -22,6 +25,14 @@ use crate::sos::{
 use crate::var::{VarBuilder, Variable};
 
 const PAR_KIND_THRESHOLD: usize = 256;
+
+fn arena_key(arena: &ExprArenaCell) -> usize {
+    std::ptr::from_ref(arena) as usize
+}
+
+fn assert_expr_arena(expr: Expr<'_>, expected: usize) {
+    assert_eq!(arena_key(expr.arena), expected, "expression belongs to a different model");
+}
 
 /// The kind of mathematical program a `Model` represents.
 ///
@@ -148,11 +159,12 @@ impl ModelConstraints<'_> {
 /// `Model` uses interior mutability so the builder API can take `&self`
 /// references.
 ///
-/// Variables, constraints, and the objective are added through
-/// `RefCell`s under the hood.
+/// Registries use `RefCell`s. The expression arena uses synchronized interior
+/// mutability and isolated worker forks while large indexed families are
+/// prepared in parallel.
 pub struct Model {
     pub name: SmolStr,
-    pub(crate) arena: RefCell<ExprArena>,
+    pub(crate) arena: ExprArenaCell,
     pub(crate) variables: RefCell<Vec<Variable>>,
     pub(crate) var_names: RefCell<FxHashMap<SmolStr, VarId>>,
     pub(crate) parameters: RefCell<Vec<Parameter>>,
@@ -173,6 +185,10 @@ pub struct Model {
 }
 
 impl Model {
+    fn assert_expr_belongs(&self, expr: Expr<'_>) {
+        assert_expr_arena(expr, arena_key(&self.arena));
+    }
+
     /// Deep-copy every registry while preserving stable IDs.
     pub(crate) fn clone_preserving_ids_with_capacity(
         &self,
@@ -207,7 +223,7 @@ impl Model {
 
         Self {
             name: self.name.clone(),
-            arena: RefCell::new(
+            arena: ExprArenaCell::new(
                 self.arena.borrow().__clone_with_additional_capacity(additional_expr_nodes),
             ),
             variables: RefCell::new(cloned_variables),
@@ -252,7 +268,7 @@ impl Model {
     pub fn new(name: impl Into<SmolStr>) -> Self {
         Self {
             name: name.into(),
-            arena: RefCell::new(ExprArena::new()),
+            arena: ExprArenaCell::new(ExprArena::new()),
             variables: RefCell::new(Vec::new()),
             var_names: RefCell::new(FxHashMap::default()),
             parameters: RefCell::new(Vec::new()),
@@ -349,7 +365,12 @@ impl Model {
         self.variables.borrow()
     }
 
-    pub fn arena(&self) -> Ref<'_, ExprArena> {
+    /// Return an immutable copy-on-write snapshot of the expression arena.
+    ///
+    /// The snapshot is cheap to create, but it is not live.
+    /// Subsequent model mutations (including parameter rebinding) are
+    /// not visible through a snapshot that is already held.
+    pub fn arena(&self) -> ExprArenaSnapshot<'_> {
         self.arena.borrow()
     }
 
@@ -623,6 +644,7 @@ impl Model {
         name: impl Into<SmolStr>,
         c: ConstraintExpr<'_>,
     ) -> ConstraintId {
+        self.assert_expr_belongs(c.lhs);
         let (lower, upper) = match c.sense {
             Sense::Le => (f64::NEG_INFINITY, c.rhs),
             Sense::Ge => (c.rhs, f64::INFINITY),
@@ -731,6 +753,7 @@ impl Model {
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
     {
+        self.assert_expr_belongs(mid);
         if let Some((lower, upper)) = self.collapse_bounds(mid.id, &lo, &hi) {
             self.register_constraint(name.into(), mid.id, lower, upper);
         } else {
@@ -836,6 +859,7 @@ impl Model {
         let terms: Vec<ExprId> = terms
             .into_iter()
             .map(|e| {
+                self.assert_expr_belongs(e);
                 assert!(
                     classify(&arena, e.id) == ExprClass::Linear,
                     "SOC constraint {name:?} has a non-affine term"
@@ -844,6 +868,7 @@ impl Model {
             })
             .collect();
         assert!(!terms.is_empty(), "SOC constraint {name:?} has no terms");
+        self.assert_expr_belongs(bound);
         assert!(
             classify(&arena, bound.id) == ExprClass::Linear,
             "SOC constraint {name:?} has a non-affine bound"
@@ -1114,6 +1139,7 @@ impl Model {
     }
 
     fn set_objective(&self, expr: Expr<'_>, sense: ObjectiveSense) {
+        self.assert_expr_belongs(expr);
         *self.objective.borrow_mut() = Some(Objective { expr: expr.id, sense });
         self.objective_declared.set(true);
         self.cached_kind.set(None);
@@ -1531,6 +1557,17 @@ mod tests {
     }
 
     #[test]
+    fn arena_snapshot_is_not_live_after_parameter_rebind() {
+        let m = Model::new("snapshot");
+        let param = m.__param("p", 1.0);
+        let id = param.param_id().unwrap();
+        let snapshot = m.arena();
+        m.set_param(param, 2.0);
+        assert!((snapshot.param_value(id) - 1.0).abs() < f64::EPSILON);
+        assert!((m.param_value(id) - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn set_param_invalidates_kind_cache() {
         let m = Model::new("p");
         let p = m.__param("p", 1.0);
@@ -1673,5 +1710,16 @@ mod tests {
         }
         assert_eq!(nlp.infer_kind(false), ModelKind::NLP);
         assert_eq!(nlp.infer_kind(false), nlp.infer_kind(true));
+    }
+
+    #[test]
+    fn arena_snapshot_allows_nested_model_reads() {
+        let model = Model::new("nested_reads");
+        let x = model.__var("x").build();
+        model.__minimize(x);
+
+        let arena = model.arena();
+        assert_eq!(model.kind(), ModelKind::LP);
+        assert!(matches!(arena.get(x.id), oximo_expr::ExprNode::Var(_)));
     }
 }

--- a/crates/oximo-expr/Cargo.toml
+++ b/crates/oximo-expr/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 smallvec = { workspace = true, features = ["union"] }
 rustc-hash.workspace = true
 thiserror.workspace = true
+parking_lot.workspace = true
 
 [lints]
 workspace = true

--- a/crates/oximo-expr/README.md
+++ b/crates/oximo-expr/README.md
@@ -2,21 +2,27 @@
 
 Arena-allocated expression tree for [oximo](https://github.com/oximo-rs/oximo).
 
-All expressions in oximo are nodes in a single `ExprArena` owned by the `Model`. User code holds lightweight `Expr` handles, a `(ExprId, &RefCell<ExprArena>)` pair. Copying an `Expr` copies an ID, not a subtree. Operator overloads collapse linear combinations into a single `Linear` node so LP/MILP construction never traverses an `Add(Mul(Const, Var), ...)` tree.
+All expressions in oximo are nodes in a single `ExprArena` owned by the `Model` through an `ExprArenaCell`. User code holds lightweight `Expr` handles, an `(ExprId, &ExprArenaCell)` pair. Copying an `Expr` copies an ID, not a subtree. Operator overloads collapse linear combinations into a single `Linear` node so LP/MILP construction never traverses an `Add(Mul(Const, Var), ...)` tree.
+
+`ExprArenaCell` provides synchronized interior mutability, so expression handles can be shared by indexed-family callbacks. Large indexed builds use isolated worker-local arena forks and merge their nodes in set order before serial model registration. Ordinary scalar expression construction keeps the same arena-backed API.
+
+`ExprArenaCell::borrow()` returns an `ExprArenaSnapshot`, a cheap immutable
+copy-on-write snapshot.
 
 This crate is the fundamental layer. End users depend on `oximo-core`, which re-exports all types from here so a separate `oximo-expr` import is not needed.
 
 ## Key types
 
-| Type          | Description                                             |
-|---------------|---------------------------------------------------------|
-| `ExprArena`   | Backing store, a typed `Vec<ExprNode>`                  |
-| `ExprId`      | Newtype `u32` index into an arena                       |
-| `ExprNode`    | Enum of all node kinds (see below)                      |
-| `Expr<'a>`    | Lightweight handle: `id` + borrow of the arena. `Copy`. |
-| `VarId`       | Opaque variable index                                   |
-| `ParamId`     | Opaque parameter index                                  |
-| `LinearTerms` | Extracted `Vec<(VarId, f64)>` + constant                |
+| Type            | Description                                             |
+|-----------------|---------------------------------------------------------|
+| `ExprArena`     | Contiguous backing store of `ExprNode` values           |
+| `ExprArenaCell` | Synchronized owner used by expression handles           |
+| `ExprId`        | Newtype `u32` index into an arena                       |
+| `ExprNode`      | Enum of all node kinds (see below)                      |
+| `Expr<'a>`      | Lightweight handle: `id` + borrow of the arena. `Copy`. |
+| `VarId`         | Opaque variable index                                   |
+| `ParamId`       | Opaque parameter index                                  |
+| `LinearTerms`   | Extracted `Vec<(VarId, f64)>` + constant                |
 
 ### `ExprNode` variants
 

--- a/crates/oximo-expr/src/arena.rs
+++ b/crates/oximo-expr/src/arena.rs
@@ -1,3 +1,10 @@
+use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -56,8 +63,8 @@ pub enum ExprNode {
 
 #[derive(Clone, Debug, Default)]
 pub struct ExprArena {
-    nodes: Vec<ExprNode>,
-    param_values: Vec<f64>,
+    nodes: Arc<Vec<ExprNode>>,
+    param_values: Arc<Vec<f64>>,
 }
 
 impl ExprArena {
@@ -66,7 +73,7 @@ impl ExprArena {
     }
 
     pub fn with_capacity(cap: usize) -> Self {
-        Self { nodes: Vec::with_capacity(cap), param_values: Vec::new() }
+        Self { nodes: Arc::new(Vec::with_capacity(cap)), param_values: Arc::new(Vec::new()) }
     }
 
     /// Clone this arena while reserving room for nodes that will immediately
@@ -76,13 +83,18 @@ impl ExprArena {
     pub fn __clone_with_additional_capacity(&self, additional_nodes: usize) -> Self {
         let mut nodes = Vec::with_capacity(self.nodes.len().saturating_add(additional_nodes));
         nodes.extend_from_slice(&self.nodes);
-        Self { nodes, param_values: self.param_values.clone() }
+        Self { nodes: Arc::new(nodes), param_values: Arc::new(self.param_values.as_ref().clone()) }
     }
 
     /// Reserve room for additional expression nodes without changing IDs.
     #[doc(hidden)]
     pub fn __reserve_nodes(&mut self, additional: usize) {
-        self.nodes.reserve(additional);
+        Arc::make_mut(&mut self.nodes).reserve(additional);
+    }
+
+    #[doc(hidden)]
+    pub(crate) fn __append_nodes(&mut self, nodes: Vec<ExprNode>) {
+        Arc::make_mut(&mut self.nodes).extend(nodes);
     }
 
     #[inline]
@@ -100,7 +112,7 @@ impl ExprArena {
     /// Panics if the number of expressions exceeds `u32::MAX` (expression arena overflow).
     pub fn push(&mut self, node: ExprNode) -> ExprId {
         let id = ExprId(u32::try_from(self.nodes.len()).expect("expression arena overflow"));
-        self.nodes.push(node);
+        Arc::make_mut(&mut self.nodes).push(node);
         id
     }
 
@@ -111,7 +123,7 @@ impl ExprArena {
 
     #[inline]
     pub fn get_mut(&mut self, id: ExprId) -> &mut ExprNode {
-        &mut self.nodes[id.index()]
+        &mut Arc::make_mut(&mut self.nodes)[id.index()]
     }
 
     pub fn nodes(&self) -> &[ExprNode] {
@@ -139,7 +151,7 @@ impl ExprArena {
     /// Panics if the number of parameters exceeds `u32::MAX`.
     pub fn new_param(&mut self, value: f64) -> ParamId {
         let id = ParamId(u32::try_from(self.param_values.len()).expect("parameter arena overflow"));
-        self.param_values.push(value);
+        Arc::make_mut(&mut self.param_values).push(value);
         id
     }
 
@@ -172,10 +184,643 @@ impl ExprArena {
     /// Panics if `p` was not allocated by [`Self::new_param`] on this arena.
     #[inline]
     pub fn set_param_value(&mut self, p: ParamId, value: f64) {
-        self.param_values[p.index()] = value;
+        Arc::make_mut(&mut self.param_values)[p.index()] = value;
     }
 
     pub fn linear(&mut self, coeffs: Vec<(VarId, f64)>, constant: f64) -> ExprId {
         self.push(ExprNode::Linear { coeffs, constant })
+    }
+}
+
+/// Read/push surface shared by the canonical and worker-local arenas.
+pub(crate) trait ArenaAccess {
+    fn get(&self, id: ExprId) -> &ExprNode;
+    fn param_value(&self, id: ParamId) -> f64;
+    fn push(&mut self, node: ExprNode) -> ExprId;
+
+    fn constant(&mut self, value: f64) -> ExprId {
+        self.push(ExprNode::Const(value))
+    }
+
+    fn var(&mut self, id: VarId) -> ExprId {
+        self.push(ExprNode::Var(id))
+    }
+}
+
+impl ArenaAccess for ExprArena {
+    fn get(&self, id: ExprId) -> &ExprNode {
+        self.get(id)
+    }
+
+    fn param_value(&self, id: ParamId) -> f64 {
+        self.param_value(id)
+    }
+
+    fn push(&mut self, node: ExprNode) -> ExprId {
+        self.push(node)
+    }
+}
+
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct FrozenExprArena {
+    nodes: Arc<Vec<ExprNode>>,
+    param_values: Arc<Vec<f64>>,
+}
+
+impl FrozenExprArena {
+    fn len(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+#[derive(Debug)]
+struct ForkedExprArena {
+    base: FrozenExprArena,
+    nodes: Vec<ExprNode>,
+}
+
+impl ForkedExprArena {
+    fn new(base: FrozenExprArena) -> Self {
+        Self { base, nodes: Vec::new() }
+    }
+}
+
+impl ArenaAccess for ForkedExprArena {
+    fn get(&self, id: ExprId) -> &ExprNode {
+        let index = id.index();
+        if index < self.base.nodes.len() {
+            &self.base.nodes[index]
+        } else {
+            &self.nodes[index - self.base.nodes.len()]
+        }
+    }
+
+    fn param_value(&self, id: ParamId) -> f64 {
+        self.base.param_values[id.index()]
+    }
+
+    fn push(&mut self, node: ExprNode) -> ExprId {
+        let index =
+            self.base.nodes.len().checked_add(self.nodes.len()).expect("expression arena overflow");
+        let id = ExprId(u32::try_from(index).expect("expression arena overflow"));
+        self.nodes.push(node);
+        id
+    }
+}
+
+struct ActiveFork {
+    arena_key: usize,
+    arena: ForkedExprArena,
+}
+
+thread_local! {
+    static ACTIVE_FORKS: RefCell<Vec<ActiveFork>> = const { RefCell::new(Vec::new()) };
+    static HELD_WRITE_GUARDS: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+
+const WRITE_REENTRY_MESSAGE: &str = "expression arena write guard re-entered on the same thread";
+const BATCH_ACTIVE: u8 = 1 << 0;
+const WRITE_GUARD_ACTIVE: u8 = 1 << 1;
+
+struct InstalledWriteGuard {
+    arena_key: usize,
+}
+
+impl InstalledWriteGuard {
+    fn new(arena_key: usize) -> Self {
+        HELD_WRITE_GUARDS.with(|guards| {
+            let mut guards = guards.borrow_mut();
+            assert!(!guards.contains(&arena_key), "{WRITE_REENTRY_MESSAGE}");
+            guards.push(arena_key);
+        });
+        Self { arena_key }
+    }
+}
+
+impl Drop for InstalledWriteGuard {
+    fn drop(&mut self) {
+        HELD_WRITE_GUARDS.with(|guards| {
+            let mut guards = guards.borrow_mut();
+            let position = guards
+                .iter()
+                .rposition(|&arena_key| arena_key == self.arena_key)
+                .expect("expression arena write guard routing state missing");
+            guards.remove(position);
+        });
+    }
+}
+
+/// Parallel-safe owner used by [`crate::Expr`] handles.
+///
+/// Ordinary construction writes the canonical arena. Indexed batch builders
+/// temporarily route expression operations to worker-local forks and merge the
+/// resulting nodes in deterministic index order.
+#[derive(Debug, Default)]
+pub struct ExprArenaCell {
+    inner: Mutex<ExprArena>,
+    state: AtomicU8,
+}
+
+impl ExprArenaCell {
+    pub fn new(arena: ExprArena) -> Self {
+        Self { inner: Mutex::new(arena), state: AtomicU8::new(0) }
+    }
+
+    /// Take a cheap immutable snapshot of the canonical arena.
+    ///
+    /// The returned value is not a live read lock.
+    /// Later writes are isolated by copy-on-write and are not
+    /// visible through this snapshot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an indexed batch is active. Snapshot reads cannot observe a
+    /// worker-local fork and would otherwise wait on the canonical arena lock
+    /// held by the batch.
+    pub fn borrow(&self) -> ExprArenaSnapshot<'_> {
+        let state = self.state.load(Ordering::Acquire);
+        assert!(
+            state & BATCH_ACTIVE == 0,
+            "expression arena snapshot requested during an active indexed batch"
+        );
+        self.assert_no_write_reentry(state);
+        ExprArenaSnapshot { arena: self.inner.lock().clone(), _cell: PhantomData }
+    }
+
+    /// Mutably borrow the canonical expression arena.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an indexed batch is active, because its worker-local forks
+    /// must see a stable canonical snapshot until they are merged, or if this
+    /// thread already holds a write guard for this arena.
+    pub fn borrow_mut(&self) -> ExprArenaWriteGuard<'_> {
+        let state = self.state.load(Ordering::Acquire);
+        assert!(
+            state & BATCH_ACTIVE == 0,
+            "expression arena accessed outside its indexed worker during an active batch"
+        );
+        self.assert_no_write_reentry(state);
+        let guard = self.inner.lock();
+        self.state.fetch_or(WRITE_GUARD_ACTIVE, Ordering::Release);
+        ExprArenaWriteGuard { cell: self, _installed: InstalledWriteGuard::new(self.key()), guard }
+    }
+
+    fn key(&self) -> usize {
+        std::ptr::from_ref(self) as usize
+    }
+
+    #[inline]
+    fn assert_no_write_reentry(&self, state: u8) {
+        // Avoid touching thread-local state unless a public guard is alive.
+        // If another thread owns that guard, the lookup is harmless and we
+        // preserve the mutex's normal blocking behavior.
+        if state & WRITE_GUARD_ACTIVE != 0 {
+            let key = self.key();
+            HELD_WRITE_GUARDS.with(|guards| {
+                assert!(!guards.borrow().contains(&key), "{WRITE_REENTRY_MESSAGE}");
+            });
+        }
+    }
+
+    pub(crate) fn with_ref<R>(&self, f: impl FnOnce(&dyn ArenaAccess) -> R) -> R {
+        let state = self.state.load(Ordering::Acquire);
+        if state & BATCH_ACTIVE == 0 {
+            self.assert_no_write_reentry(state);
+            let arena = self.inner.lock();
+            return f(&*arena);
+        }
+
+        let mut f = Some(f);
+        let local = ACTIVE_FORKS.with(|forks| {
+            let forks = forks.borrow();
+            forks
+                .iter()
+                .rfind(|fork| fork.arena_key == self.key())
+                .map(|fork| f.take().expect("arena callback already consumed")(&fork.arena))
+        });
+        if let Some(result) = local {
+            return result;
+        }
+        panic!("expression arena accessed outside its indexed worker during an active batch");
+    }
+
+    pub(crate) fn with_mut<R>(&self, f: impl FnOnce(&mut dyn ArenaAccess) -> R) -> R {
+        let state = self.state.load(Ordering::Acquire);
+        if state & BATCH_ACTIVE == 0 {
+            self.assert_no_write_reentry(state);
+            let mut arena = self.inner.lock();
+            return f(&mut *arena);
+        }
+
+        let mut f = Some(f);
+        let local = ACTIVE_FORKS.with(|forks| {
+            let mut forks = forks.borrow_mut();
+            forks
+                .iter_mut()
+                .rfind(|fork| fork.arena_key == self.key())
+                .map(|fork| f.take().expect("arena callback already consumed")(&mut fork.arena))
+        });
+        if let Some(result) = local {
+            return result;
+        }
+        panic!("expression arena accessed outside its indexed worker during an active batch");
+    }
+
+    #[doc(hidden)]
+    pub fn __begin_batch(&self) -> ExprArenaBatchGuard<'_> {
+        let state = self.state.load(Ordering::Acquire);
+        self.assert_no_write_reentry(state);
+        assert!(
+            self.state.fetch_or(BATCH_ACTIVE, Ordering::AcqRel) & BATCH_ACTIVE == 0,
+            "nested expression arena batches are not supported"
+        );
+        ExprArenaBatchGuard { cell: self, arena: self.inner.lock() }
+    }
+
+    /// Run a worker callback against a private fork of `base`.
+    ///
+    /// This is an internal batching primitive. The callback must not start a
+    /// nested batch for this arena or access the arena from another thread.
+    /// Such access is rejected while the batch is active.
+    #[doc(hidden)]
+    pub fn __with_fork<R>(&self, base: FrozenExprArena, f: impl FnOnce() -> R) -> ForkOutput<R> {
+        let key = self.key();
+        ACTIVE_FORKS.with(|forks| {
+            let mut forks = forks.borrow_mut();
+            assert!(
+                !forks.iter().any(|fork| fork.arena_key == key),
+                "nested expression forks for one arena are not supported"
+            );
+            forks.push(ActiveFork { arena_key: key, arena: ForkedExprArena::new(base) });
+        });
+        let mut installed = InstalledFork { arena_key: key, armed: true };
+        let value = f();
+        let arena = installed.take();
+        ForkOutput { value, base: arena.base, nodes: arena.nodes }
+    }
+}
+
+struct InstalledFork {
+    arena_key: usize,
+    armed: bool,
+}
+
+impl InstalledFork {
+    fn take(&mut self) -> ForkedExprArena {
+        self.armed = false;
+        ACTIVE_FORKS.with(|forks| {
+            let mut forks = forks.borrow_mut();
+            let position = forks
+                .iter()
+                .rposition(|fork| fork.arena_key == self.arena_key)
+                .expect("active expression fork missing");
+            forks.remove(position).arena
+        })
+    }
+}
+
+impl Drop for InstalledFork {
+    fn drop(&mut self) {
+        if self.armed {
+            ACTIVE_FORKS.with(|forks| {
+                let mut forks = forks.borrow_mut();
+                if let Some(position) =
+                    forks.iter().rposition(|fork| fork.arena_key == self.arena_key)
+                {
+                    forks.remove(position);
+                }
+            });
+        }
+    }
+}
+
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct ForkOutput<T> {
+    pub value: T,
+    base: FrozenExprArena,
+    nodes: Vec<ExprNode>,
+}
+
+#[derive(Copy, Clone, Debug)]
+#[doc(hidden)]
+pub struct ExprIdRemap {
+    local_base: usize,
+    local_len: usize,
+    global_base: usize,
+}
+
+impl ExprIdRemap {
+    fn validate(self, id: ExprId) {
+        let index = id.index();
+        if index >= self.local_base {
+            assert!(
+                index - self.local_base < self.local_len,
+                "expression fork returned an unknown node"
+            );
+        }
+    }
+
+    /// Translate an expression ID produced by one worker fork to its merged ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` refers neither to the fork's canonical base nor to a node
+    /// created by that fork, or if the remapped ID exceeds `u32::MAX`.
+    pub fn apply(self, id: ExprId) -> ExprId {
+        let index = id.index();
+        if index < self.local_base {
+            return id;
+        }
+        self.validate(id);
+        let local = index - self.local_base;
+        ExprId(u32::try_from(self.global_base + local).expect("expression arena overflow"))
+    }
+}
+
+/// Immutable copy-on-write snapshot of an [`ExprArenaCell`].
+pub struct ExprArenaSnapshot<'a> {
+    arena: ExprArena,
+    _cell: PhantomData<&'a ExprArenaCell>,
+}
+
+impl std::fmt::Debug for ExprArenaSnapshot<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.arena.fmt(f)
+    }
+}
+
+impl Deref for ExprArenaSnapshot<'_> {
+    type Target = ExprArena;
+
+    fn deref(&self) -> &Self::Target {
+        &self.arena
+    }
+}
+
+pub struct ExprArenaWriteGuard<'a> {
+    // Remove the thread-local marker before unlocking the mutex. There is no
+    // user code between field drops, so another operation cannot observe the
+    // short transition.
+    cell: &'a ExprArenaCell,
+    _installed: InstalledWriteGuard,
+    guard: MutexGuard<'a, ExprArena>,
+}
+
+impl Drop for ExprArenaWriteGuard<'_> {
+    fn drop(&mut self) {
+        self.cell.state.fetch_and(!WRITE_GUARD_ACTIVE, Ordering::Release);
+    }
+}
+
+impl std::fmt::Debug for ExprArenaWriteGuard<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.guard.fmt(f)
+    }
+}
+
+impl Deref for ExprArenaWriteGuard<'_> {
+    type Target = ExprArena;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl DerefMut for ExprArenaWriteGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+#[doc(hidden)]
+pub struct ExprArenaBatchGuard<'a> {
+    cell: &'a ExprArenaCell,
+    arena: MutexGuard<'a, ExprArena>,
+}
+
+impl std::fmt::Debug for ExprArenaBatchGuard<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExprArenaBatchGuard").field("arena", &self.arena).finish()
+    }
+}
+
+impl ExprArenaBatchGuard<'_> {
+    pub fn snapshot(&self) -> FrozenExprArena {
+        FrozenExprArena {
+            nodes: Arc::clone(&self.arena.nodes),
+            param_values: Arc::clone(&self.arena.param_values),
+        }
+    }
+
+    /// Append worker-fork nodes in slice order and return each fork's ID map.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a fork was created from a different snapshot or the merged
+    /// expression arena would exceed `u32::MAX` nodes.
+    pub fn merge<T>(&mut self, forks: &mut [ForkOutput<T>]) -> Vec<ExprIdRemap> {
+        let initial_len = self.arena.len();
+        let additional = forks.iter().map(|fork| fork.nodes.len()).sum::<usize>();
+        let final_len =
+            self.arena.len().checked_add(additional).expect("expression arena overflow");
+        if final_len > 0 {
+            u32::try_from(final_len - 1).expect("expression arena overflow");
+        }
+        let mut remaps = Vec::with_capacity(forks.len());
+        let mut global_base = initial_len;
+        for fork in forks.iter() {
+            assert!(
+                Arc::ptr_eq(&fork.base.nodes, &self.arena.nodes)
+                    && Arc::ptr_eq(&fork.base.param_values, &self.arena.param_values),
+                "expression fork used a stale arena snapshot"
+            );
+            remaps.push(ExprIdRemap {
+                local_base: fork.base.len(),
+                local_len: fork.nodes.len(),
+                global_base,
+            });
+            global_base += fork.nodes.len();
+        }
+
+        // Validate every child reference before changing the canonical arena.
+        // This keeps merge failure-atomic even if a worker returned an ID that
+        // was not part of its fork.
+        for (fork, remap) in forks.iter().zip(&remaps) {
+            for node in &fork.nodes {
+                validate_node(node, *remap);
+            }
+        }
+
+        let mut staged = Vec::with_capacity(additional);
+        for (fork, remap) in forks.iter_mut().zip(&remaps) {
+            for node in &mut fork.nodes {
+                remap_node(node, *remap);
+            }
+            staged.append(&mut fork.nodes);
+        }
+        self.arena.__reserve_nodes(additional);
+        self.arena.__append_nodes(staged);
+        remaps
+    }
+}
+
+fn validate_node(node: &ExprNode, remap: ExprIdRemap) {
+    match node {
+        ExprNode::Add(children) | ExprNode::Mul(children) => {
+            for child in children {
+                remap.validate(*child);
+            }
+        }
+        ExprNode::Neg(child)
+        | ExprNode::Sin(child)
+        | ExprNode::Cos(child)
+        | ExprNode::Exp(child)
+        | ExprNode::Log(child)
+        | ExprNode::Abs(child) => remap.validate(*child),
+        ExprNode::Pow(left, right) | ExprNode::Div(left, right) => {
+            remap.validate(*left);
+            remap.validate(*right);
+        }
+        ExprNode::Const(_) | ExprNode::Var(_) | ExprNode::Param(_) | ExprNode::Linear { .. } => {}
+    }
+}
+
+impl Drop for ExprArenaBatchGuard<'_> {
+    fn drop(&mut self) {
+        self.cell.state.fetch_and(!BATCH_ACTIVE, Ordering::Release);
+    }
+}
+
+fn remap_node(node: &mut ExprNode, remap: ExprIdRemap) {
+    match node {
+        ExprNode::Add(children) | ExprNode::Mul(children) => {
+            for child in children {
+                *child = remap.apply(*child);
+            }
+        }
+        ExprNode::Neg(child)
+        | ExprNode::Sin(child)
+        | ExprNode::Cos(child)
+        | ExprNode::Exp(child)
+        | ExprNode::Log(child)
+        | ExprNode::Abs(child) => *child = remap.apply(*child),
+        ExprNode::Pow(left, right) | ExprNode::Div(left, right) => {
+            *left = remap.apply(*left);
+            *right = remap.apply(*right);
+        }
+        ExprNode::Const(_) | ExprNode::Var(_) | ExprNode::Param(_) | ExprNode::Linear { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+    use crate::{Expr, evaluate, extract_linear};
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn expression_handles_are_send_and_sync() {
+        assert_send_sync::<Expr<'static>>();
+        assert_send_sync::<ExprArenaCell>();
+    }
+
+    #[test]
+    fn write_guard_reentry_panics_and_cleans_up_instead_of_blocking() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let x = Expr::from_var(&cell, VarId(0));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = cell.borrow_mut();
+            std::hint::black_box(x + 1.0);
+        }));
+
+        assert!(result.is_err());
+        let constant = Expr::constant(&cell, 4.0);
+        assert!(matches!(cell.borrow().get(constant.id), ExprNode::Const(4.0)));
+    }
+
+    #[test]
+    fn forked_nodes_merge_and_remap_in_order() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let x = Expr::from_var(&cell, VarId(0));
+        let y = Expr::from_var(&cell, VarId(1));
+        let mut batch = cell.__begin_batch();
+        let snapshot = batch.snapshot();
+        let mut forks = vec![cell.__with_fork(snapshot.clone(), || {
+            let nonlinear = (x.sin() * y.cos()).exp();
+            let quotient = nonlinear / (x.abs() + 2.0);
+            quotient.powi(2)
+        })];
+        drop(snapshot);
+        let remaps = batch.merge(&mut forks);
+        let root = remaps[0].apply(forks[0].value.id);
+        drop(batch);
+
+        let arena = cell.borrow();
+        let values: &[f64] = &[0.5, 0.25];
+        let value = evaluate(&arena, root, &values).unwrap();
+        let expected = ((0.5_f64.sin() * 0.25_f64.cos()).exp() / 2.5).powi(2);
+        assert!((value - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn merged_linear_node_still_supports_borrowed_extraction() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let x = Expr::from_var(&cell, VarId(0));
+        let mut batch = cell.__begin_batch();
+        let snapshot = batch.snapshot();
+        let mut forks = vec![cell.__with_fork(snapshot.clone(), || 3.0 * x + 2.0)];
+        drop(snapshot);
+        let remaps = batch.merge(&mut forks);
+        let root = remaps[0].apply(forks[0].value.id);
+        drop(batch);
+
+        let arena = cell.borrow();
+        let terms = extract_linear(&arena, root).unwrap();
+        assert!(matches!(terms.coeffs, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(terms.coeffs.as_ref(), &[(VarId(0), 3.0)]);
+        assert!((terms.constant - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn panicking_fork_cleans_up_routing_state() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let batch = cell.__begin_batch();
+            let snapshot = batch.snapshot();
+            let _: ForkOutput<()> = cell.__with_fork(snapshot, || panic!("worker failed"));
+            drop(batch);
+        }));
+        assert!(result.is_err());
+        let constant = Expr::constant(&cell, 4.0);
+        assert!(matches!(cell.borrow().get(constant.id), ExprNode::Const(4.0)));
+    }
+
+    #[test]
+    #[should_panic(expected = "snapshot requested during an active indexed batch")]
+    fn snapshot_read_during_batch_is_rejected_instead_of_blocking() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let _batch = cell.__begin_batch();
+        let _snapshot = cell.borrow();
+    }
+
+    #[test]
+    #[should_panic(expected = "stale arena snapshot")]
+    fn merge_rejects_same_length_but_different_snapshot() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let other = ExprArenaCell::new(ExprArena::new());
+        let batch = cell.__begin_batch();
+        let other_batch = other.__begin_batch();
+        let stale = other_batch.snapshot();
+        drop(other_batch);
+        let mut forks = vec![cell.__with_fork(stale, || Expr::constant(&cell, 1.0))];
+        let mut batch = batch;
+        let _ = batch.merge(&mut forks);
     }
 }

--- a/crates/oximo-expr/src/arena.rs
+++ b/crates/oximo-expr/src/arena.rs
@@ -221,7 +221,7 @@ impl ArenaAccess for ExprArena {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[doc(hidden)]
 pub struct FrozenExprArena {
     nodes: Arc<Vec<ExprNode>>,
@@ -654,6 +654,13 @@ impl ExprArenaBatchGuard<'_> {
             }
         }
 
+        // The remaps retain the fork base lengths needed by remap_node and
+        // ExprIdRemap::apply. Release the base snapshots before reserving so
+        // Arc::make_mut can extend the canonical node vector in place.
+        for fork in forks.iter_mut() {
+            drop(std::mem::take(&mut fork.base));
+        }
+
         let mut staged = Vec::with_capacity(additional);
         for (fork, remap) in forks.iter_mut().zip(&remaps) {
             for node in &mut fork.nodes {
@@ -767,6 +774,22 @@ mod tests {
         let value = evaluate(&arena, root, &values).unwrap();
         let expected = ((0.5_f64.sin() * 0.25_f64.cos()).exp() / 2.5).powi(2);
         assert!((value - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn merge_releases_fork_base_before_reserving() {
+        let cell = ExprArenaCell::new(ExprArena::new());
+        let mut batch = cell.__begin_batch();
+        let snapshot = batch.snapshot();
+        let mut forks = vec![cell.__with_fork(snapshot.clone(), || Expr::constant(&cell, 1.0))];
+        drop(snapshot);
+        let nodes = Arc::as_ptr(&batch.arena.nodes);
+
+        let remaps = batch.merge(&mut forks);
+
+        assert_eq!(Arc::as_ptr(&batch.arena.nodes), nodes);
+        assert_eq!(remaps[0].local_base, 0);
+        assert_eq!(remaps[0].local_len, 1);
     }
 
     #[test]

--- a/crates/oximo-expr/src/classify.rs
+++ b/crates/oximo-expr/src/classify.rs
@@ -1,4 +1,4 @@
-use crate::arena::{ExprArena, ExprId, ExprNode};
+use crate::arena::{ArenaAccess, ExprArena, ExprId, ExprNode};
 
 /// Highest-degree polynomial class an expression belongs to, ignoring constant
 /// folding. Used by backends to pick between linear, quadratic, and general
@@ -52,7 +52,7 @@ impl Degree {
     }
 }
 
-fn degree(arena: &ExprArena, id: ExprId) -> Degree {
+fn degree(arena: &(impl ArenaAccess + ?Sized), id: ExprId) -> Degree {
     match arena.get(id) {
         ExprNode::Const(_) | ExprNode::Param(_) => Degree::Zero,
         ExprNode::Var(_) | ExprNode::Linear { .. } => Degree::One,
@@ -109,6 +109,10 @@ fn degree(arena: &ExprArena, id: ExprId) -> Degree {
 /// least one degree-2 term), or Nonlinear (transcendentals, non-integer powers,
 /// or polynomial degree > 2).
 pub fn classify(arena: &ExprArena, id: ExprId) -> ExprClass {
+    classify_access(arena, id)
+}
+
+pub(crate) fn classify_access(arena: &(impl ArenaAccess + ?Sized), id: ExprId) -> ExprClass {
     match degree(arena, id) {
         Degree::Zero | Degree::One => ExprClass::Linear,
         Degree::Two => ExprClass::Quadratic,

--- a/crates/oximo-expr/src/handle.rs
+++ b/crates/oximo-expr/src/handle.rs
@@ -1,16 +1,15 @@
-use std::cell::RefCell;
-
-use crate::arena::{ExprArena, ExprId, ExprNode, ParamId, VarId};
+use crate::arena::{ExprArenaCell, ExprId, ExprNode, ParamId, VarId};
+use crate::classify::{ExprClass, classify_access};
 
 /// Lightweight handle to a node in an [`ExprArena`].
 ///
-/// Carries a borrow of the arena (wrapped in `RefCell` so operator overloads
-/// can push new nodes during arithmetic). `Expr` is `Copy`, so users freely
-/// reuse a variable handle in many constraints.
+/// Carries a borrow of the arena cell so operator overloads can push new nodes
+/// during arithmetic. `Expr` is `Copy`, so users freely reuse a variable
+/// handle in many constraints.
 #[derive(Copy, Clone)]
 pub struct Expr<'a> {
     pub id: ExprId,
-    pub arena: &'a RefCell<ExprArena>,
+    pub arena: &'a ExprArenaCell,
 }
 
 impl std::fmt::Debug for Expr<'_> {
@@ -21,36 +20,41 @@ impl std::fmt::Debug for Expr<'_> {
 
 impl<'a> Expr<'a> {
     #[inline]
-    pub fn new(id: ExprId, arena: &'a RefCell<ExprArena>) -> Self {
+    pub fn new(id: ExprId, arena: &'a ExprArenaCell) -> Self {
         Self { id, arena }
     }
 
-    pub fn constant(arena: &'a RefCell<ExprArena>, v: f64) -> Self {
-        let id = arena.borrow_mut().constant(v);
+    pub fn constant(arena: &'a ExprArenaCell, v: f64) -> Self {
+        let id = arena.with_mut(|arena| arena.constant(v));
         Self::new(id, arena)
     }
 
-    pub fn from_var(arena: &'a RefCell<ExprArena>, v: VarId) -> Self {
-        let id = arena.borrow_mut().var(v);
+    pub fn from_var(arena: &'a ExprArenaCell, v: VarId) -> Self {
+        let id = arena.with_mut(|arena| arena.var(v));
         Self::new(id, arena)
+    }
+
+    #[inline]
+    pub(crate) fn assert_same_arena(self, other: Self) {
+        assert!(std::ptr::eq(self.arena, other.arena), "expressions belong to different arenas");
     }
 
     /// If this handle is a bare variable, return its [`VarId`].
     /// `None` for compound expressions (sums, products, constants, ...).
     pub fn var_id(self) -> Option<VarId> {
-        match self.arena.borrow().get(self.id) {
+        self.arena.with_ref(|arena| match arena.get(self.id) {
             ExprNode::Var(id) => Some(*id),
             _ => None,
-        }
+        })
     }
 
     /// If this handle is a bare parameter, return its [`ParamId`].
     /// `None` for compound expressions.
     pub fn param_id(self) -> Option<ParamId> {
-        match self.arena.borrow().get(self.id) {
+        self.arena.with_ref(|arena| match arena.get(self.id) {
             ExprNode::Param(id) => Some(*id),
             _ => None,
-        }
+        })
     }
 
     /// Re-bind the parameter this handle references to `value`. Takes effect on
@@ -65,64 +69,66 @@ impl<'a> Expr<'a> {
     }
 
     pub fn pow(self, exponent: Self) -> Self {
-        let id = self.arena.borrow_mut().push(ExprNode::Pow(self.id, exponent.id));
+        self.assert_same_arena(exponent);
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Pow(self.id, exponent.id)));
         Self::new(id, self.arena)
     }
 
     pub fn powi(self, n: i32) -> Self {
-        let id = {
-            let mut a = self.arena.borrow_mut();
-            let exp_id = a.constant(f64::from(n));
-            a.push(ExprNode::Pow(self.id, exp_id))
-        };
+        let id = self.arena.with_mut(|arena| {
+            let exp_id = arena.constant(f64::from(n));
+            arena.push(ExprNode::Pow(self.id, exp_id))
+        });
         Self::new(id, self.arena)
     }
 
     pub fn powf(self, n: f64) -> Self {
-        let id = {
-            let mut a = self.arena.borrow_mut();
-            let exp_id = a.constant(n);
-            a.push(ExprNode::Pow(self.id, exp_id))
-        };
+        let id = self.arena.with_mut(|arena| {
+            let exp_id = arena.constant(n);
+            arena.push(ExprNode::Pow(self.id, exp_id))
+        });
         Self::new(id, self.arena)
     }
 
     pub fn sin(self) -> Self {
-        let id = self.arena.borrow_mut().push(ExprNode::Sin(self.id));
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Sin(self.id)));
         Self::new(id, self.arena)
     }
 
     pub fn cos(self) -> Self {
-        let id = self.arena.borrow_mut().push(ExprNode::Cos(self.id));
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Cos(self.id)));
         Self::new(id, self.arena)
     }
 
     pub fn exp(self) -> Self {
-        let id = self.arena.borrow_mut().push(ExprNode::Exp(self.id));
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Exp(self.id)));
         Self::new(id, self.arena)
     }
 
     pub fn log(self) -> Self {
-        let id = self.arena.borrow_mut().push(ExprNode::Log(self.id));
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Log(self.id)));
         Self::new(id, self.arena)
     }
 
     pub fn abs(self) -> Self {
-        let id = self.arena.borrow_mut().push(ExprNode::Abs(self.id));
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Abs(self.id)));
         Self::new(id, self.arena)
+    }
+
+    #[doc(hidden)]
+    pub fn __class(self) -> ExprClass {
+        self.arena.with_ref(|arena| classify_access(arena, self.id))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::Expr;
-    use crate::arena::ExprArena;
+    use crate::arena::{ExprArena, ExprArenaCell};
 
     #[test]
     fn set_param_value_rebinds_through_handle() {
-        let arena = RefCell::new(ExprArena::new());
+        let arena = ExprArenaCell::new(ExprArena::new());
         let pid = arena.borrow_mut().new_param(0.05);
         let node = arena.borrow_mut().param(pid);
         let p = Expr::new(node, &arena);
@@ -134,8 +140,18 @@ mod tests {
     #[test]
     #[should_panic(expected = "bare parameter handle")]
     fn set_param_value_panics_on_non_param() {
-        let arena = RefCell::new(ExprArena::new());
+        let arena = ExprArenaCell::new(ExprArena::new());
         let c = Expr::constant(&arena, 1.0);
         c.set_param_value(3.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "different arenas")]
+    fn combining_different_arenas_is_rejected() {
+        let left_arena = ExprArenaCell::new(ExprArena::new());
+        let right_arena = ExprArenaCell::new(ExprArena::new());
+        let left = Expr::constant(&left_arena, 1.0);
+        let right = Expr::constant(&right_arena, 2.0);
+        let _ = left + right;
     }
 }

--- a/crates/oximo-expr/src/handle.rs
+++ b/crates/oximo-expr/src/handle.rs
@@ -1,7 +1,7 @@
 use crate::arena::{ExprArenaCell, ExprId, ExprNode, ParamId, VarId};
 use crate::classify::{ExprClass, classify_access};
 
-/// Lightweight handle to a node in an [`ExprArena`].
+/// Lightweight handle to a node in an [`ExprArenaCell`].
 ///
 /// Carries a borrow of the arena cell so operator overloads can push new nodes
 /// during arithmetic. `Expr` is `Copy`, so users freely reuse a variable

--- a/crates/oximo-expr/src/lib.rs
+++ b/crates/oximo-expr/src/lib.rs
@@ -12,7 +12,10 @@ mod render;
 mod simplify;
 mod visit;
 
-pub use arena::{ExprArena, ExprId, ExprNode, ParamId, VarId};
+pub use arena::{
+    ExprArena, ExprArenaBatchGuard, ExprArenaCell, ExprArenaSnapshot, ExprArenaWriteGuard, ExprId,
+    ExprIdRemap, ExprNode, ForkOutput, FrozenExprArena, ParamId, VarId,
+};
 pub use classify::{ExprClass, classify};
 pub use eval::{EvalContext, EvalError, evaluate};
 pub use handle::Expr;

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use smallvec::smallvec;
 
-use crate::arena::{ExprArena, ExprId, ExprNode, VarId};
+use crate::arena::{ArenaAccess, ExprArena, ExprId, ExprNode, VarId};
 
 /// Coefficients of a linear expression: `sum(coeff * var) + constant`.
 ///
@@ -78,8 +78,8 @@ impl CoeffAccum {
 ///
 /// When `resolve_params` is set, an [`ExprNode::Param`] folds to its current
 /// arena value and counts as a constant.
-fn as_linear<'a>(
-    arena: &'a ExprArena,
+fn as_linear<'a, A: ArenaAccess + ?Sized>(
+    arena: &'a A,
     id: ExprId,
     resolve_params: bool,
 ) -> Option<LinearTerms<'a>> {
@@ -143,7 +143,7 @@ fn as_linear<'a>(
 }
 
 /// Materialize linear terms into a fresh `Linear` node in the arena.
-fn push_linear(arena: &mut ExprArena, t: LinearTerms<'_>) -> ExprId {
+fn push_linear(arena: &mut (impl ArenaAccess + ?Sized), t: LinearTerms<'_>) -> ExprId {
     let mut coeffs = t.coeffs.into_owned();
     coeffs.retain(|(_, c)| *c != 0.0);
     arena.push(ExprNode::Linear { coeffs, constant: t.constant })
@@ -151,7 +151,11 @@ fn push_linear(arena: &mut ExprArena, t: LinearTerms<'_>) -> ExprId {
 
 /// Build `lhs + rhs`, preserving the linear fast-path when both sides are
 /// linear. Falls back to an n-ary `Add` node otherwise.
-pub(crate) fn add_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
+pub(crate) fn add_into(
+    arena: &mut (impl ArenaAccess + ?Sized),
+    lhs: ExprId,
+    rhs: ExprId,
+) -> ExprId {
     if let (Some(lt), Some(rt)) = (as_linear(arena, lhs, false), as_linear(arena, rhs, false)) {
         let constant = lt.constant + rt.constant;
         let mut acc = CoeffAccum::with_capacity(lt.coeffs.len() + rt.coeffs.len());
@@ -171,7 +175,7 @@ pub(crate) fn add_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
 ///
 /// # Panics
 /// Panics if `ids` is empty (callers supply at least one term).
-pub(crate) fn add_n(arena: &mut ExprArena, ids: &[ExprId]) -> ExprId {
+pub(crate) fn add_n(arena: &mut (impl ArenaAccess + ?Sized), ids: &[ExprId]) -> ExprId {
     match ids {
         [] => panic!("add_n on an empty term list"),
         [one] => *one,
@@ -180,14 +184,22 @@ pub(crate) fn add_n(arena: &mut ExprArena, ids: &[ExprId]) -> ExprId {
 }
 
 /// Build `lhs - rhs`. Same linear fast-path as `add_into`.
-pub(crate) fn sub_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
+pub(crate) fn sub_into(
+    arena: &mut (impl ArenaAccess + ?Sized),
+    lhs: ExprId,
+    rhs: ExprId,
+) -> ExprId {
     let neg = neg_into(arena, rhs);
     add_into(arena, lhs, neg)
 }
 
 /// Build `lhs * rhs`. If either side is constant and the other is linear, we
 /// stay on the linear fast-path. Otherwise produce a generic n-ary `Mul`.
-pub(crate) fn mul_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprId {
+pub(crate) fn mul_into(
+    arena: &mut (impl ArenaAccess + ?Sized),
+    lhs: ExprId,
+    rhs: ExprId,
+) -> ExprId {
     if let ExprNode::Const(c) = *arena.get(lhs) {
         if let Some(t) = as_linear(arena, rhs, false) {
             let constant = t.constant * c;
@@ -214,7 +226,11 @@ pub(crate) fn mul_into(arena: &mut ExprArena, lhs: ExprId, rhs: ExprId) -> ExprI
 /// Build `num / den`. If `den` is a nonzero constant `c`, fold to `num * (1/c)`
 /// so a constant-denominator division stays on the linear fast-path. Otherwise
 /// produce a `Div` node (always nonlinear, even when the numerator is linear).
-pub(crate) fn div_into(arena: &mut ExprArena, num: ExprId, den: ExprId) -> ExprId {
+pub(crate) fn div_into(
+    arena: &mut (impl ArenaAccess + ?Sized),
+    num: ExprId,
+    den: ExprId,
+) -> ExprId {
     if let ExprNode::Const(c) = *arena.get(den) {
         if c != 0.0 {
             if let Some(t) = as_linear(arena, num, false) {
@@ -234,7 +250,7 @@ pub(crate) fn div_into(arena: &mut ExprArena, num: ExprId, den: ExprId) -> ExprI
 }
 
 /// Build `-rhs`, preserving linearity.
-pub(crate) fn neg_into(arena: &mut ExprArena, rhs: ExprId) -> ExprId {
+pub(crate) fn neg_into(arena: &mut (impl ArenaAccess + ?Sized), rhs: ExprId) -> ExprId {
     if let Some(t) = as_linear(arena, rhs, false) {
         let constant = -t.constant;
         let mut coeffs = t.coeffs.into_owned();

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -10,7 +10,8 @@ use crate::linear::{add_into, add_n, div_into, mul_into, neg_into, sub_into};
 impl<'a> Add for Expr<'a> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        let id = add_into(&mut self.arena.borrow_mut(), self.id, rhs.id);
+        self.assert_same_arena(rhs);
+        let id = self.arena.with_mut(|arena| add_into(arena, self.id, rhs.id));
         Self::new(id, self.arena)
     }
 }
@@ -18,7 +19,8 @@ impl<'a> Add for Expr<'a> {
 impl<'a> Sub for Expr<'a> {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        let id = sub_into(&mut self.arena.borrow_mut(), self.id, rhs.id);
+        self.assert_same_arena(rhs);
+        let id = self.arena.with_mut(|arena| sub_into(arena, self.id, rhs.id));
         Self::new(id, self.arena)
     }
 }
@@ -26,7 +28,8 @@ impl<'a> Sub for Expr<'a> {
 impl<'a> Mul for Expr<'a> {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        let id = mul_into(&mut self.arena.borrow_mut(), self.id, rhs.id);
+        self.assert_same_arena(rhs);
+        let id = self.arena.with_mut(|arena| mul_into(arena, self.id, rhs.id));
         Self::new(id, self.arena)
     }
 }
@@ -34,7 +37,8 @@ impl<'a> Mul for Expr<'a> {
 impl<'a> Div for Expr<'a> {
     type Output = Self;
     fn div(self, rhs: Self) -> Self {
-        let id = div_into(&mut self.arena.borrow_mut(), self.id, rhs.id);
+        self.assert_same_arena(rhs);
+        let id = self.arena.with_mut(|arena| div_into(arena, self.id, rhs.id));
         Self::new(id, self.arena)
     }
 }
@@ -42,7 +46,7 @@ impl<'a> Div for Expr<'a> {
 impl<'a> Neg for Expr<'a> {
     type Output = Self;
     fn neg(self) -> Self {
-        let id = neg_into(&mut self.arena.borrow_mut(), self.id);
+        let id = self.arena.with_mut(|arena| neg_into(arena, self.id));
         Self::new(id, self.arena)
     }
 }
@@ -57,11 +61,10 @@ macro_rules! impl_scalar_ops {
         impl<'a> Add<$scalar> for Expr<'a> {
             type Output = Self;
             fn add(self, rhs: $scalar) -> Self {
-                let id = {
-                    let mut a = self.arena.borrow_mut();
-                    let rhs_id = a.constant($to_f64(rhs));
-                    add_into(&mut a, self.id, rhs_id)
-                };
+                let id = self.arena.with_mut(|arena| {
+                    let rhs_id = arena.constant($to_f64(rhs));
+                    add_into(arena, self.id, rhs_id)
+                });
                 Self::new(id, self.arena)
             }
         }
@@ -76,11 +79,10 @@ macro_rules! impl_scalar_ops {
         impl<'a> Sub<$scalar> for Expr<'a> {
             type Output = Self;
             fn sub(self, rhs: $scalar) -> Self {
-                let id = {
-                    let mut a = self.arena.borrow_mut();
-                    let rhs_id = a.constant($to_f64(rhs));
-                    sub_into(&mut a, self.id, rhs_id)
-                };
+                let id = self.arena.with_mut(|arena| {
+                    let rhs_id = arena.constant($to_f64(rhs));
+                    sub_into(arena, self.id, rhs_id)
+                });
                 Self::new(id, self.arena)
             }
         }
@@ -88,11 +90,10 @@ macro_rules! impl_scalar_ops {
         impl<'a> Sub<Expr<'a>> for $scalar {
             type Output = Expr<'a>;
             fn sub(self, rhs: Expr<'a>) -> Expr<'a> {
-                let id = {
-                    let mut a = rhs.arena.borrow_mut();
-                    let lhs_id = a.constant($to_f64(self));
-                    sub_into(&mut a, lhs_id, rhs.id)
-                };
+                let id = rhs.arena.with_mut(|arena| {
+                    let lhs_id = arena.constant($to_f64(self));
+                    sub_into(arena, lhs_id, rhs.id)
+                });
                 Expr::new(id, rhs.arena)
             }
         }
@@ -100,11 +101,10 @@ macro_rules! impl_scalar_ops {
         impl<'a> Mul<$scalar> for Expr<'a> {
             type Output = Self;
             fn mul(self, rhs: $scalar) -> Self {
-                let id = {
-                    let mut a = self.arena.borrow_mut();
-                    let rhs_id = a.constant($to_f64(rhs));
-                    mul_into(&mut a, self.id, rhs_id)
-                };
+                let id = self.arena.with_mut(|arena| {
+                    let rhs_id = arena.constant($to_f64(rhs));
+                    mul_into(arena, self.id, rhs_id)
+                });
                 Self::new(id, self.arena)
             }
         }
@@ -119,11 +119,10 @@ macro_rules! impl_scalar_ops {
         impl<'a> Div<$scalar> for Expr<'a> {
             type Output = Self;
             fn div(self, rhs: $scalar) -> Self {
-                let id = {
-                    let mut a = self.arena.borrow_mut();
-                    let rhs_id = a.constant($to_f64(rhs));
-                    div_into(&mut a, self.id, rhs_id)
-                };
+                let id = self.arena.with_mut(|arena| {
+                    let rhs_id = arena.constant($to_f64(rhs));
+                    div_into(arena, self.id, rhs_id)
+                });
                 Self::new(id, self.arena)
             }
         }
@@ -131,11 +130,10 @@ macro_rules! impl_scalar_ops {
         impl<'a> Div<Expr<'a>> for $scalar {
             type Output = Expr<'a>;
             fn div(self, rhs: Expr<'a>) -> Expr<'a> {
-                let id = {
-                    let mut a = rhs.arena.borrow_mut();
-                    let lhs_id = a.constant($to_f64(self));
-                    div_into(&mut a, lhs_id, rhs.id)
-                };
+                let id = rhs.arena.with_mut(|arena| {
+                    let lhs_id = arena.constant($to_f64(self));
+                    div_into(arena, lhs_id, rhs.id)
+                });
                 Expr::new(id, rhs.arena)
             }
         }
@@ -155,8 +153,11 @@ impl<'a> std::iter::Sum for Expr<'a> {
         let first = iter.next().expect("Expr::sum on empty iterator");
         let mut ids = Vec::with_capacity(iter.size_hint().0.saturating_add(1));
         ids.push(first.id);
-        ids.extend(iter.map(|expr| expr.id));
-        let id = add_n(&mut first.arena.borrow_mut(), &ids);
+        ids.extend(iter.map(|expr| {
+            first.assert_same_arena(expr);
+            expr.id
+        }));
+        let id = first.arena.with_mut(|arena| add_n(arena, &ids));
         Self::new(id, first.arena)
     }
 }

--- a/crates/oximo-expr/tests/arithmetic.rs
+++ b/crates/oximo-expr/tests/arithmetic.rs
@@ -1,18 +1,17 @@
 #![expect(clippy::float_cmp)]
 
-use std::cell::RefCell;
-
 use oximo_expr::{
-    Expr, ExprArena, ExprClass, ExprNode, VarId, classify, dot, evaluate, extract_linear,
+    Expr, ExprArena, ExprArenaCell, ExprClass, ExprNode, VarId, classify, dot, evaluate,
+    extract_linear,
 };
 
-fn make_var(arena: &RefCell<ExprArena>, idx: u32) -> Expr<'_> {
+fn make_var(arena: &ExprArenaCell, idx: u32) -> Expr<'_> {
     Expr::from_var(arena, VarId(idx))
 }
 
 #[test]
 fn linear_fast_path_collapses_add() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let y = make_var(&arena, 1);
 
@@ -33,7 +32,7 @@ fn linear_fast_path_collapses_add() {
 
 #[test]
 fn linear_fast_path_handles_subtraction() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let y = make_var(&arena, 1);
 
@@ -48,7 +47,7 @@ fn linear_fast_path_handles_subtraction() {
 
 #[test]
 fn nonlinear_pow_is_not_linear() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let combo = x.powi(2) + x;
     assert!(extract_linear(&arena.borrow(), combo.id).is_none());
@@ -56,7 +55,7 @@ fn nonlinear_pow_is_not_linear() {
 
 #[test]
 fn evaluate_recovers_value() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let y = make_var(&arena, 1);
     let combo = 2.0 * x + 3.0 * y + 5.0;
@@ -68,7 +67,7 @@ fn evaluate_recovers_value() {
 
 #[test]
 fn negation_flips_coefficients() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let y = make_var(&arena, 1);
     let combo = -(2.0 * x + 3.0 * y + 5.0);
@@ -82,7 +81,7 @@ fn negation_flips_coefficients() {
 
 #[test]
 fn dot_computes_weighted_sum() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let xs: Vec<_> = (0..3).map(|i| make_var(&arena, i)).collect();
     let weights = [2.0, 3.0, 5.0];
     let result = dot(&xs, &weights);
@@ -96,7 +95,7 @@ fn dot_computes_weighted_sum() {
 #[test]
 #[should_panic(expected = "dot: length mismatch")]
 fn dot_panics_on_length_mismatch() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let xs: Vec<_> = (0..3).map(|i| make_var(&arena, i)).collect();
     let weights = [2.0, 3.0];
     let _ = dot(&xs, &weights);
@@ -112,7 +111,7 @@ fn dot_panics_on_empty() {
 
 #[test]
 fn div_by_constant_stays_linear() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let combo = x / 2.0;
 
@@ -129,7 +128,7 @@ fn div_by_constant_stays_linear() {
 
 #[test]
 fn div_two_vars_is_nonlinear() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let a = make_var(&arena, 0);
     let b = make_var(&arena, 1);
     let q = a / b;
@@ -141,7 +140,7 @@ fn div_two_vars_is_nonlinear() {
 
 #[test]
 fn scalar_over_var_is_nonlinear() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let recip = 1.0 / x;
     assert!(matches!(arena.borrow().get(recip.id), ExprNode::Div(_, _)));
@@ -150,7 +149,7 @@ fn scalar_over_var_is_nonlinear() {
 
 #[test]
 fn evaluate_division() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let a = make_var(&arena, 0);
     let b = make_var(&arena, 1);
     let q = a / b;
@@ -161,7 +160,7 @@ fn evaluate_division() {
 
 #[test]
 fn evaluate_division_by_zero_is_infinite() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let a = make_var(&arena, 0);
     let b = make_var(&arena, 1);
     let q = a / b;
@@ -172,7 +171,7 @@ fn evaluate_division_by_zero_is_infinite() {
 
 #[test]
 fn evaluate_abs() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let e = x.abs();
     let arena_ref = arena.borrow();
@@ -184,7 +183,7 @@ fn evaluate_abs() {
 
 #[test]
 fn abs_is_nonlinear() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let e = x.abs();
     assert!(matches!(arena.borrow().get(e.id), ExprNode::Abs(_)));
@@ -194,7 +193,7 @@ fn abs_is_nonlinear() {
 
 #[test]
 fn large_sum_extracts_correctly() {
-    let arena = RefCell::new(ExprArena::new());
+    let arena = ExprArenaCell::new(ExprArena::new());
     let vars: Vec<_> = (0..100).map(|i| make_var(&arena, i)).collect();
     let total: Expr = vars.iter().copied().sum();
     let arena_ref = arena.borrow();

--- a/crates/oximo/benches/preprocessing/model.rs
+++ b/crates/oximo/benches/preprocessing/model.rs
@@ -1,5 +1,5 @@
-use criterion::Criterion;
-use oximo_core::model::benchmark_support;
+use criterion::{BenchmarkId, Criterion, Throughput};
+use oximo_core::model::benchmark_support::{self, IndexedBuildCase};
 
 use super::common::{LARGE, crossover_sizes, pair, sizes};
 
@@ -27,4 +27,39 @@ pub fn bench(criterion: &mut Criterion) {
         pair(&mut group, &format!("socp/crossover/{rows}"), rows, &model, benchmark_support::infer);
     }
     group.finish();
+
+    let mut build = criterion.benchmark_group("preprocessing/indexed_build");
+    for rows in [256, 512, 1_024, 2_048, 8_192] {
+        for (name, case) in [
+            ("variables", IndexedBuildCase::Variables),
+            ("parameters", IndexedBuildCase::Parameters),
+            ("algebraic", IndexedBuildCase::Algebraic),
+            ("range", IndexedBuildCase::Range),
+            ("soc", IndexedBuildCase::Soc),
+            ("sos", IndexedBuildCase::Sos),
+        ] {
+            build.throughput(Throughput::Elements(rows as u64));
+            build.bench_with_input(BenchmarkId::new(name, rows), &rows, |bencher, &rows| {
+                bencher.iter(|| {
+                    std::hint::black_box(benchmark_support::indexed_build(rows, case, false))
+                });
+            });
+            let parallel = format!("{name}_parallel_{}t", super::common::threads());
+            build.bench_with_input(BenchmarkId::new(parallel, rows), &rows, |bencher, &rows| {
+                bencher.iter(|| {
+                    std::hint::black_box(benchmark_support::indexed_build(rows, case, true))
+                });
+            });
+        }
+    }
+    build.finish();
+
+    let mut scalar = criterion.benchmark_group("preprocessing/scalar_build");
+    for rows in [32, 1_024] {
+        scalar.throughput(Throughput::Elements(rows as u64));
+        scalar.bench_with_input(BenchmarkId::from_parameter(rows), &rows, |bencher, &rows| {
+            bencher.iter(|| std::hint::black_box(benchmark_support::scalar_build(rows)));
+        });
+    }
+    scalar.finish();
 }


### PR DESCRIPTION
## Description

This PR adds synchronized expression-arena snapshots and parallelizes large indexed model construction while keeping scalar and small indexed builds serial.

This is a breaking change since indexed callbacks now require `Fn + Send + Sync` and `Model::arena()` now returns a snapshot.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [ ] `cargo test --features gams` passes (requires GAMS)
- [ ] `cargo test --features gurobi` passes (requires Gurobi)
- [ ] `cargo test --features mosek` passes (requires MOSEK)
- [ ] `cargo test --features baron` passes (requires BARON)