### PR TITLE
oximo-baron(bugfix): correct write_equations for free constraint rows

### DIFF
--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -1290,11 +1290,8 @@ pub mod benchmark_support {
         let mut names = Vec::with_capacity(constraints.len() + 2 * socs.len());
         for (i, c) in constraints.iter().enumerate() {
             let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
-            if c.is_range() {
-                names.extend([format!("c{i}_lo"), format!("c{i}_hi")]);
-                emit_map.extend([id, id]);
-            } else {
-                names.push(format!("c{i}"));
+            for (suffix, _, _) in equation_rows(c).into_iter().flatten() {
+                names.push(format!("c{i}{suffix}"));
                 emit_map.push(id);
             }
         }
@@ -1327,19 +1324,9 @@ pub mod benchmark_support {
             )));
         }
         let mut out = String::new();
-        if let Some((sense, rhs)) = c.as_single() {
-            let op = match sense {
-                Sense::Le => "<=",
-                Sense::Ge => ">=",
-                Sense::Eq => "==",
-            };
-            write!(out, "c{index}: ").unwrap();
+        for (suffix, op, rhs) in equation_rows(c).into_iter().flatten() {
+            write!(out, "c{index}{suffix}: ").unwrap();
             write_constraint_body(&mut out, arena, c.lhs, op, rhs)?;
-        } else {
-            write!(out, "c{index}_lo: ").unwrap();
-            write_constraint_body(&mut out, arena, c.lhs, ">=", c.lower)?;
-            write!(out, "c{index}_hi: ").unwrap();
-            write_constraint_body(&mut out, arena, c.lhs, "<=", c.upper)?;
         }
         Ok(out)
     }
@@ -1856,6 +1843,23 @@ The best solution found is:
         assert!(bar.contains("EQUATIONS c1;"), "{bar}");
         assert!(!bar.contains("c0"), "free row must emit nothing: {bar}");
         assert_eq!(con_order, vec![ConstraintId(1)], "{con_order:?}");
+    }
+
+    #[cfg(feature = "benchmark-support")]
+    #[test]
+    fn benchmark_render_uses_equation_rows_for_ranges() {
+        let m = Model::new("benchmark-range");
+        let x = m.__var("x").lb(-5.0).ub(5.0).build();
+        m.__add_constraint_interval("free", x, f64::NEG_INFINITY, f64::INFINITY);
+        m.__add_constraint_interval("range", x, 1.0, 3.0);
+
+        let parallel = super::benchmark_support::render_equations(&m, true).unwrap();
+        let serial = super::benchmark_support::render_equations(&m, false).unwrap();
+
+        assert_eq!(parallel, serial, "benchmark rendering must preserve BARON output");
+        assert!(parallel.contains("EQUATIONS c1_lo, c1_hi;"), "{parallel}");
+        assert!(parallel.contains("c1_lo:") && parallel.contains("c1_hi:"), "{parallel}");
+        assert!(!parallel.contains("c0"), "unconstrained row must emit nothing: {parallel}");
     }
 
     #[test]

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -347,6 +347,18 @@ fn upper_bound_to_emit(v: &Variable) -> Option<f64> {
     }
 }
 
+type EquationRow = (&'static str, &'static str, f64);
+
+fn equation_rows(c: &Constraint) -> [Option<EquationRow>; 2] {
+    match c.as_single() {
+        Some((Sense::Le, rhs)) => [Some(("", "<=", rhs)), None],
+        Some((Sense::Ge, rhs)) => [Some(("", ">=", rhs)), None],
+        Some((Sense::Eq, rhs)) => [Some(("", "==", rhs)), None],
+        None if c.is_range() => [Some(("_lo", ">=", c.lower)), Some(("_hi", "<=", c.upper))],
+        None => [None, None],
+    }
+}
+
 /// Write the `EQUATIONS` block, returning the emit-order map.
 /// The `ConstraintId` behind each emitted equation, in BARON's 1-based
 /// "Constraint no." order. BARON has no two-sided equation,
@@ -360,30 +372,15 @@ fn write_equations(
     socs: &[SocConstraint],
 ) -> Result<Vec<ConstraintId>, SolverError> {
     let mut emit_map: Vec<ConstraintId> = Vec::with_capacity(constraints.len());
-    if constraints.is_empty() && socs.is_empty() {
-        return Ok(emit_map);
-    }
-
     let mut names: Vec<String> = Vec::with_capacity(constraints.len() + 2 * socs.len());
-    for (i, c) in constraints.iter().enumerate() {
-        let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
-        if c.is_range() {
-            names.push(format!("c{i}_lo"));
-            names.push(format!("c{i}_hi"));
-            emit_map.push(id);
-            emit_map.push(id);
-        } else {
-            names.push(format!("c{i}"));
-            emit_map.push(id);
-        }
-    }
-    for i in 0..socs.len() {
-        names.push(format!("soc{i}"));
-        names.push(format!("soc{i}_sign"));
-    }
-    writeln!(bar, "EQUATIONS {};", names.join(", ")).unwrap();
+    let mut bodies = String::new();
 
     for (i, c) in constraints.iter().enumerate() {
+        let rows = equation_rows(c);
+        if rows.iter().all(Option::is_none) {
+            // Free `[-inf, +inf]` row
+            continue;
+        }
         // BARON rejects a constraint whose expression evaluates to a constant,
         // so surface a clear error instead of emitting an invalid `.bar`.
         if !expr_has_var(arena, c.lhs) {
@@ -393,22 +390,24 @@ fn write_equations(
                 c.name
             )));
         }
-        if let Some((sense, rhs)) = c.as_single() {
-            let op = match sense {
-                Sense::Le => "<=",
-                Sense::Ge => ">=",
-                Sense::Eq => "==",
-            };
-            write!(bar, "c{i}: ").unwrap();
-            write_constraint_body(bar, arena, c.lhs, op, rhs)?;
-        } else {
-            // Two-sided range -> `_lo` (>= lower) and `_hi` (<= upper).
-            write!(bar, "c{i}_lo: ").unwrap();
-            write_constraint_body(bar, arena, c.lhs, ">=", c.lower)?;
-            write!(bar, "c{i}_hi: ").unwrap();
-            write_constraint_body(bar, arena, c.lhs, "<=", c.upper)?;
+        let id = ConstraintId(u32::try_from(i).expect("constraint count overflow"));
+        for (suffix, op, rhs) in rows.into_iter().flatten() {
+            names.push(format!("c{i}{suffix}"));
+            emit_map.push(id);
+            write!(bodies, "c{i}{suffix}: ").unwrap();
+            write_constraint_body(&mut bodies, arena, c.lhs, op, rhs)?;
         }
     }
+    for i in 0..socs.len() {
+        names.push(format!("soc{i}"));
+        names.push(format!("soc{i}_sign"));
+    }
+    if names.is_empty() {
+        return Ok(emit_map);
+    }
+
+    writeln!(bar, "EQUATIONS {};", names.join(", ")).unwrap();
+    bar.push_str(&bodies);
     write_soc_rows(bar, arena, socs);
     writeln!(bar).unwrap();
     Ok(emit_map)
@@ -1841,6 +1840,22 @@ The best solution found is:
         assert_eq!(dual.len(), 1);
         assert_eq!(soc.get(&0), Some(&-0.75));
         assert_eq!(soc.len(), 1);
+    }
+
+    #[test]
+    fn free_row_from_infinite_bound_emits_no_equation() {
+        let capacity = [f64::INFINITY, 10.0];
+        let m = Model::new("freerow");
+        variable!(m, 0.0 <= x[i in 0..2] <= 10.0);
+        constraint!(m, cap[i in 0..2], x[i] <= capacity[i]);
+        objective!(m, Max, x[0] + x[1]);
+
+        let (bar, _vars, con_order, _soc) =
+            build_bar(&m, &BaronOptions::default()).expect("build_bar");
+
+        assert!(bar.contains("EQUATIONS c1;"), "{bar}");
+        assert!(!bar.contains("c0"), "free row must emit nothing: {bar}");
+        assert_eq!(con_order, vec![ConstraintId(1)], "{con_order:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Description : 

- Add new `equation_rows` function to provide a single source of truth of how many BARON rows and map entries should be written per constraint. Fix free rows being treated as range constraint when writing the EQUATIONS section.


Before : 

free row => 2 BARON rows, 1 map entries
single row => 1 BARON row, 1 map entry
range row => 2 BARON rows, 2 map entries

After : 

free row => 0 BARON rows, 0 map entries
single row => 1 BARON row, 1 map entry
range row => 2 BARON rows, 2 map entries


## Checklist

- [x ] I have added tests that cover my changes
- [x ] I have run `cargo fmt` and `cargo clippy` to ensure code quality



## Related Issues

Closes #86 