### PR TITLE
Return handles for indexed and range constraints

### DIFF
--- a/crates/oximo-core/Cargo.toml
+++ b/crates/oximo-core/Cargo.toml
@@ -28,3 +28,7 @@ oximo-expr.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "indexed_ranges"
+harness = false

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -190,6 +190,34 @@ constraint!(m, flow[i in 0..n, j in 0..m], x[i, j] >= 0.0);
 constraint!(m, diag[(i, j) in rc if i == j], x[i, j] <= 1.0);
 ```
 
+Capture the macro result to query rows without reconstructing their names:
+
+```rust
+use oximo_core::prelude::*;
+
+let m = Model::new("constraint_handles");
+variable!(m, x[i in 0..4] >= 0.0);
+let capacity: ConstraintId = constraint!(m, capacity, x[0] <= 10.0);
+let cover: IndexedConstraint<usize> =
+    constraint!(m, cover[i in 0..4 if i % 2 == 0], x[i] >= 1.0);
+assert!(cover.get(1).is_none()); // filtered out
+for (i, cid) in cover.iter() {
+    assert_eq!(cover.get(i), Some(cid));
+}
+
+let bands: IndexedRangeConstraint<usize> =
+    constraint!(m, bands[i in 0..4], 1.0 <= x[i] <= 4.0);
+let RangeConstraintIds::Interval(cid) = bands.get(0).unwrap() else {
+    panic!("constant bounds and a linear body produce an interval row");
+};
+```
+
+`get(key)` returns copied IDs; `iter()` yields typed `(K, ID)` pairs in domain
+order for dense, sparse, string, tuple, and filtered domains.
+
+Two-sided ranges return `RangeConstraintIds::Interval(cid)` or
+`RangeConstraintIds::Split { lower, upper }`.
+
 ### Summation
 
 `sum!(body for k in domain)` reads as `sum_{k in domain} body`. Nest with extra

--- a/crates/oximo-core/benches/indexed_ranges.rs
+++ b/crates/oximo-core/benches/indexed_ranges.rs
@@ -1,0 +1,69 @@
+//! Focused range-registration benchmark.
+//! Usage: cargo bench -p oximo-core --bench indexed_ranges -- interval 100000 6 20
+//! Cases: interval, split (quadratic body), mixed (alternating), symbolic.
+//! Arguments: case, domain size, Rayon threads, measured samples (after 2 warmups).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use oximo_core::prelude::*;
+
+fn sample(case: &str, size: usize) -> u128 {
+    let model = Model::new("range_bench");
+    let keys = Set::range(0..size);
+    let x = model.__indexed_var("x", &keys).build();
+    let lo = model.__param("lo", 0.0);
+    let start = Instant::now();
+    let family = if case == "symbolic" {
+        model.__add_range_constraints_over("r", &keys, |i| (x[i] + 1.0, lo, 10.0))
+    } else {
+        model.__add_range_constraints_over("r", &keys, |i| {
+            let body = if case == "split" || (case == "mixed" && i % 2 != 0) {
+                x[i].powi(2)
+            } else {
+                x[i] + 1.0
+            };
+            (body, 0.0, 10.0)
+        })
+    };
+    black_box(&family);
+    let elapsed = start.elapsed().as_nanos();
+    assert_eq!(family.len(), size);
+    let expected_rows = match case {
+        "interval" => size,
+        "mixed" => size + size / 2,
+        _ => 2 * size,
+    };
+    assert_eq!(model.num_constraints(), expected_rows);
+    for key in [0, size - 1] {
+        match family.get(key).unwrap() {
+            RangeConstraintIds::Interval(id) => {
+                assert_eq!(model.constraint_id(&format!("r[{key}]")), Some(id));
+            }
+            RangeConstraintIds::Split { lower, upper } => {
+                assert_eq!(model.constraint_id(&format!("r[{key}]_lo")), Some(lower));
+                assert_eq!(model.constraint_id(&format!("r[{key}]_hi")), Some(upper));
+            }
+        }
+    }
+    elapsed
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().skip(1).filter(|arg| arg != "--bench").collect();
+    let case = args.first().map_or("mixed", String::as_str);
+    assert!(["interval", "split", "mixed", "symbolic"].contains(&case));
+    let size = args.get(1).map_or(100_000, |arg| arg.parse::<usize>().unwrap());
+    let threads = args.get(2).map_or(6, |arg| arg.parse::<usize>().unwrap());
+    let samples = args.get(3).map_or(20, |arg| arg.parse::<usize>().unwrap());
+    assert!(size > 0 && threads > 0 && samples > 0);
+    rayon::ThreadPoolBuilder::new().num_threads(threads).build().unwrap().install(|| {
+        for _ in 0..2 {
+            black_box(sample(case, size));
+        }
+        println!("case,size,threads,sample,nanoseconds");
+        for index in 0..samples {
+            println!("{case},{size},{threads},{index},{}", sample(case, size));
+        }
+    });
+}

--- a/crates/oximo-core/src/constraint.rs
+++ b/crates/oximo-core/src/constraint.rs
@@ -24,6 +24,16 @@ impl fmt::Display for Sense {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ConstraintId(pub u32);
 
+/// Model row IDs produced by a two-sided range declaration.
+///
+/// Constant bounds with a linear body produce one interval row. Other ranges
+/// produce separate lower and upper rows. You can query each row's dual individually.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RangeConstraintIds {
+    Interval(ConstraintId),
+    Split { lower: ConstraintId, upper: ConstraintId },
+}
+
 impl ConstraintId {
     #[inline]
     pub fn index(self) -> usize {

--- a/crates/oximo-core/src/indexed.rs
+++ b/crates/oximo-core/src/indexed.rs
@@ -4,7 +4,109 @@ use std::ops::Index;
 use oximo_expr::Expr;
 use rustc_hash::FxHashMap;
 
+use crate::constraint::{ConstraintId, RangeConstraintIds};
 use crate::set::{Axis, FromIndexKey, IndexKey};
+
+/// Owned, ordered IDs with a domain-specific lookup index.
+#[derive(Clone, Debug)]
+struct ConstraintFamilyStorage<T> {
+    entries: Vec<(IndexKey, T)>,
+    lookup: ConstraintFamilyLookup,
+}
+
+#[derive(Clone, Debug)]
+enum ConstraintFamilyLookup {
+    Dense(Box<[Axis]>),
+    Sparse(FxHashMap<IndexKey, usize>),
+}
+
+impl<T: Copy> ConstraintFamilyStorage<T> {
+    fn new(keys: Vec<IndexKey>, axes: Option<&[Axis]>, values: Vec<T>) -> Self {
+        assert_eq!(keys.len(), values.len(), "constraint family key/value length mismatch");
+        let lookup = axes.map_or_else(
+            || {
+                ConstraintFamilyLookup::Sparse(
+                    keys.iter().cloned().enumerate().map(|(i, key)| (key, i)).collect(),
+                )
+            },
+            |axes| ConstraintFamilyLookup::Dense(axes.into()),
+        );
+        Self { entries: keys.into_iter().zip(values).collect(), lookup }
+    }
+
+    fn get(&self, key: &IndexKey) -> Option<T> {
+        let position = match &self.lookup {
+            ConstraintFamilyLookup::Dense(axes) => grid_offset(axes, key)?,
+            ConstraintFamilyLookup::Sparse(positions) => *positions.get(key)?,
+        };
+        self.entries.get(position).map(|(_, value)| *value)
+    }
+}
+
+macro_rules! constraint_family {
+    ($(#[$doc:meta])* $name:ident, $value:ty) => {
+        $(#[$doc])*
+        pub struct $name<K = IndexKey> {
+            storage: ConstraintFamilyStorage<$value>,
+            _marker: PhantomData<fn() -> K>,
+        }
+
+        impl<K> Clone for $name<K> {
+            fn clone(&self) -> Self {
+                Self { storage: self.storage.clone(), _marker: PhantomData }
+            }
+        }
+
+        impl<K> std::fmt::Debug for $name<K> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(stringify!($name)).field("entries", &self.storage.entries).finish()
+            }
+        }
+
+        impl<K> $name<K> {
+            pub(crate) fn new(keys: Vec<IndexKey>, axes: Option<&[Axis]>, values: Vec<$value>) -> Self {
+                Self { storage: ConstraintFamilyStorage::new(keys, axes, values), _marker: PhantomData }
+            }
+
+            /// Number of domain entries (not the number of lowered rows).
+            pub fn len(&self) -> usize {
+                self.storage.entries.len()
+            }
+
+            pub fn is_empty(&self) -> bool {
+                self.storage.entries.is_empty()
+            }
+
+            /// Look up an entry, returning `None` for missing or filtered-out keys.
+            pub fn get<Q: Into<IndexKey>>(&self, key: Q) -> Option<$value> {
+                self.storage.get(&key.into())
+            }
+        }
+
+        impl<K: FromIndexKey> $name<K> {
+            /// Iterate typed keys and copied IDs in the original domain order.
+            pub fn iter(&self) -> impl Iterator<Item = (K, $value)> + '_ {
+                self.storage.entries.iter().map(|(key, value)| (K::from_index_key(key), *value))
+            }
+        }
+    };
+}
+
+constraint_family!(
+    /// Owned handle returned by an indexed single-relation `constraint!` declaration.
+    ///
+    /// IDs refer to rows of the originating model.
+    /// `get` supports integer, string, and tuple keys, including sparse domains.
+    IndexedConstraint, ConstraintId
+);
+
+constraint_family!(
+    /// Owned handle returned by an indexed two-sided range `constraint!` declaration.
+    ///
+    /// Each key maps to one interval ID or separate lower/upper IDs. Entries can
+    /// have different lowering forms within the same family.
+    IndexedRangeConstraint, RangeConstraintIds
+);
 
 /// Backing storage for an [`IndexedFamily`].
 ///

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -22,11 +22,13 @@ pub mod sos;
 pub mod sum;
 pub mod var;
 
-pub use constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
+pub use constraint::{
+    Constraint, ConstraintExpr, ConstraintId, IntoRhs, RangeConstraintIds, Relate, Sense,
+};
 pub use display::{ConstraintDisplay, ExprDisplay, ObjectiveDisplay, SocDisplay, SosDisplay};
 pub use domain::Domain;
 pub use error::{Error, Result};
-pub use indexed::{IndexedParam, IndexedVar};
+pub use indexed::{IndexedConstraint, IndexedParam, IndexedRangeConstraint, IndexedVar};
 pub use model::{
     ConstraintRef, IndexedVarBuilder, Model, ModelConstraints, ModelKind, display_index_key,
 };

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -10,10 +10,15 @@ use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use smol_str::SmolStr;
 
-use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
+use crate::constraint::{
+    Constraint, ConstraintExpr, ConstraintId, IntoRhs, RangeConstraintIds, Relate, Sense,
+};
 use crate::domain::Domain;
 use crate::error::{Error, Result};
-use crate::indexed::{IndexedFamily, IndexedParam, IndexedVar, build_storage};
+use crate::indexed::{
+    IndexedConstraint, IndexedFamily, IndexedParam, IndexedRangeConstraint, IndexedVar,
+    build_storage,
+};
 use crate::objective::{Objective, ObjectiveSense};
 use crate::param::Parameter;
 use crate::reformulation::SosReformulationArtifacts;
@@ -102,12 +107,18 @@ impl PendingConstraint {
     }
 }
 
+#[derive(Debug)]
+struct PendingRangeBatch {
+    rows: Vec<PendingConstraint>,
+    row_counts: Vec<u8>,
+}
+
 fn prepare_range<'a, B1: IntoRhs<'a>, B2: IntoRhs<'a>>(
     name: String,
     mid: Expr<'a>,
     lo: B1,
     hi: B2,
-) -> Vec<PendingConstraint> {
+) -> (PendingConstraint, Option<PendingConstraint>) {
     if let (Some(lower), Some(upper)) = (lo.const_bound(), hi.const_bound())
         && mid.__class() == ExprClass::Linear
     {
@@ -115,12 +126,12 @@ fn prepare_range<'a, B1: IntoRhs<'a>, B2: IntoRhs<'a>>(
             !lower.is_nan() && !upper.is_nan(),
             "constraint {name:?} has NaN bound (lower={lower}, upper={upper})"
         );
-        vec![PendingConstraint { name: name.into(), lhs: mid.id, lower, upper }]
+        (PendingConstraint { name: name.into(), lhs: mid.id, lower, upper }, None)
     } else {
-        vec![
+        (
             PendingConstraint::from_expr(format!("{name}_lo").into(), mid.ge(lo)),
-            PendingConstraint::from_expr(format!("{name}_hi").into(), mid.le(hi)),
-        ]
+            Some(PendingConstraint::from_expr(format!("{name}_hi").into(), mid.le(hi))),
+        )
     }
 }
 
@@ -899,7 +910,7 @@ impl Model {
         id
     }
 
-    fn register_constraints_batch(&self, items: Vec<PendingConstraint>) {
+    fn register_constraints_batch(&self, items: Vec<PendingConstraint>) -> Vec<ConstraintId> {
         let mut names = self.constraint_names.borrow_mut();
         validate_batch_names(&names, items.iter().map(|item| item.name.clone()), "constraint");
         let mut constraints = self.constraints.borrow_mut();
@@ -910,6 +921,7 @@ impl Model {
         }
         constraints.reserve(items.len());
         names.reserve(items.len());
+        let mut ids = Vec::with_capacity(items.len());
         for item in items {
             let id =
                 ConstraintId(u32::try_from(constraints.len()).expect("constraint count overflow"));
@@ -921,8 +933,10 @@ impl Model {
                 active: true,
             });
             names.insert(item.name, id);
+            ids.push(id);
         }
         self.cached_kind.set(None);
+        ids
     }
 
     /// A fresh unique auto-name `_c{n}`, skipping any a user already took.
@@ -974,12 +988,17 @@ impl Model {
     /// (any [`FromIndexKey`]: `i64`, `i32`, `usize`, `String`, raw `IndexKey`, or
     /// tuples up to arity 4). Not part of the stable public API.
     #[doc(hidden)]
-    pub fn __add_constraints_over<'a, K, F>(&'a self, name_prefix: &str, set: &Set<K>, rule: F)
+    pub fn __add_constraints_over<'a, K, F>(
+        &'a self,
+        name_prefix: &str,
+        set: &Set<K>,
+        rule: F,
+    ) -> IndexedConstraint<K>
     where
         K: FromIndexKey,
         F: Fn(K) -> ConstraintExpr<'a> + Send + Sync,
     {
-        self.add_constraints_over_with(name_prefix, set, &rule, None);
+        self.add_constraints_over_with(name_prefix, set, &rule, None)
     }
 
     fn add_constraints_over_with<'a, K, F>(
@@ -988,19 +1007,21 @@ impl Model {
         set: &Set<K>,
         rule: &F,
         forced_parallel: Option<bool>,
-    ) where
+    ) -> IndexedConstraint<K>
+    where
         K: FromIndexKey,
         F: Fn(K) -> ConstraintExpr<'a> + Send + Sync,
     {
         let keys: Vec<IndexKey> = set.iter().collect();
         if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_ALGEBRAIC_THRESHOLD) {
+            let mut ids = Vec::with_capacity(keys.len());
             for key in &keys {
                 let constraint = rule(K::from_index_key(key));
                 self.assert_expr_belongs(constraint.lhs);
                 let name: SmolStr = format_index_name(name_prefix, key).into();
-                self.__add_constraint(name, constraint);
+                ids.push(self.__add_constraint(name, constraint));
             }
-            return;
+            return IndexedConstraint::new(keys, set.axes(), ids);
         }
 
         let arena = &self.arena;
@@ -1042,7 +1063,8 @@ impl Model {
             pending.extend(fork.value);
         }
         drop(batch);
-        self.register_constraints_batch(pending);
+        let ids = self.register_constraints_batch(pending);
+        IndexedConstraint::new(keys, set.axes(), ids)
     }
 
     /// Macro-facing entry point for a two-sided range `lo <= mid <= hi`.
@@ -1051,33 +1073,56 @@ impl Model {
     /// bounds are pure constants and the body is linear (the condition under which
     /// one two-sided row is representable).
     #[doc(hidden)]
-    pub fn __add_range<'a, B1, B2>(&'a self, name: &str, mid: Expr<'a>, lo: B1, hi: B2)
+    pub fn __add_range<'a, B1, B2>(
+        &'a self,
+        name: &str,
+        mid: Expr<'a>,
+        lo: B1,
+        hi: B2,
+    ) -> RangeConstraintIds
     where
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
     {
         self.assert_expr_belongs(mid);
         if let Some((lower, upper)) = self.collapse_bounds(mid.id, &lo, &hi) {
-            self.register_constraint(name.into(), mid.id, lower, upper);
+            RangeConstraintIds::Interval(self.register_constraint(
+                name.into(),
+                mid.id,
+                lower,
+                upper,
+            ))
         } else {
-            self.__add_constraint(format!("{name}_lo"), mid.ge(lo));
-            self.__add_constraint(format!("{name}_hi"), mid.le(hi));
+            let lower = self.__add_constraint(format!("{name}_lo"), mid.ge(lo));
+            let upper = self.__add_constraint(format!("{name}_hi"), mid.le(hi));
+            RangeConstraintIds::Split { lower, upper }
         }
     }
 
     /// Anonymous form of [`Self::__add_range`] (auto-named rows).
     #[doc(hidden)]
-    pub fn __add_range_auto<'a, B1, B2>(&'a self, mid: Expr<'a>, lo: B1, hi: B2)
+    pub fn __add_range_auto<'a, B1, B2>(
+        &'a self,
+        mid: Expr<'a>,
+        lo: B1,
+        hi: B2,
+    ) -> RangeConstraintIds
     where
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
     {
         self.assert_expr_belongs(mid);
         if let Some((lower, upper)) = self.collapse_bounds(mid.id, &lo, &hi) {
-            self.register_constraint(self.next_auto_name(), mid.id, lower, upper);
+            RangeConstraintIds::Interval(self.register_constraint(
+                self.next_auto_name(),
+                mid.id,
+                lower,
+                upper,
+            ))
         } else {
-            self.__add_constraint_auto(mid.ge(lo));
-            self.__add_constraint_auto(mid.le(hi));
+            let lower = self.__add_constraint_auto(mid.ge(lo));
+            let upper = self.__add_constraint_auto(mid.le(hi));
+            RangeConstraintIds::Split { lower, upper }
         }
     }
 
@@ -1095,22 +1140,22 @@ impl Model {
         (classify(&self.arena.borrow(), mid) == ExprClass::Linear).then_some((lower, upper))
     }
 
-    /// Macro-facing entry point for a two-sided range family. One row per key,
-    /// each collapsing to a single interval constraint when both bounds are
-    /// constant (see [`Self::__add_range`]).
+    /// Macro-facing entry point for a two-sided range family. Each key maps to
+    /// one interval row or separate lower/upper rows (see [`Self::__add_range`]).
     #[doc(hidden)]
     pub fn __add_range_constraints_over<'a, K, B1, B2, F>(
         &'a self,
         name: &str,
         set: &Set<K>,
         rule: F,
-    ) where
+    ) -> IndexedRangeConstraint<K>
+    where
         K: FromIndexKey,
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
         F: Fn(K) -> (Expr<'a>, B1, B2) + Send + Sync,
     {
-        self.add_range_constraints_over_with(name, set, &rule, None);
+        self.add_range_constraints_over_with(name, set, &rule, None)
     }
 
     fn add_range_constraints_over_with<'a, K, B1, B2, F>(
@@ -1119,7 +1164,8 @@ impl Model {
         set: &Set<K>,
         rule: &F,
         forced_parallel: Option<bool>,
-    ) where
+    ) -> IndexedRangeConstraint<K>
+    where
         K: FromIndexKey,
         B1: IntoRhs<'a>,
         B2: IntoRhs<'a>,
@@ -1127,12 +1173,13 @@ impl Model {
     {
         let keys: Vec<IndexKey> = set.iter().collect();
         if !indexed_parallel(keys.len(), forced_parallel, PAR_INDEXED_RANGE_THRESHOLD) {
+            let mut ids = Vec::with_capacity(keys.len());
             for key in &keys {
                 let (mid, lo, hi) = rule(K::from_index_key(key));
                 self.assert_expr_belongs(mid);
-                self.__add_range(&format_index_name(name, key), mid, lo, hi);
+                ids.push(self.__add_range(&format_index_name(name, key), mid, lo, hi));
             }
-            return;
+            return IndexedRangeConstraint::new(keys, set.axes(), ids);
         }
 
         let arena = &self.arena;
@@ -1144,14 +1191,20 @@ impl Model {
             .par_chunks(chunk_size)
             .map(|chunk| {
                 arena.__with_fork(snapshot.clone(), || {
-                    chunk
-                        .iter()
-                        .flat_map(|key| {
-                            let (mid, lo, hi) = rule(K::from_index_key(key));
-                            assert_expr_arena(mid, expected_arena);
-                            prepare_range(format_index_name(name, key), mid, lo, hi)
-                        })
-                        .collect::<Vec<_>>()
+                    let mut prepared = PendingRangeBatch {
+                        rows: Vec::with_capacity(chunk.len()),
+                        row_counts: Vec::with_capacity(chunk.len()),
+                    };
+                    for key in chunk {
+                        let (mid, lo, hi) = rule(K::from_index_key(key));
+                        assert_expr_arena(mid, expected_arena);
+                        let (first, upper) =
+                            prepare_range(format_index_name(name, key), mid, lo, hi);
+                        prepared.row_counts.push(if upper.is_some() { 2 } else { 1 });
+                        prepared.rows.push(first);
+                        prepared.rows.extend(upper);
+                    }
+                    prepared
                 })
             })
             .collect();
@@ -1160,20 +1213,38 @@ impl Model {
             let existing = self.constraint_names.borrow();
             validate_batch_names(
                 &existing,
-                forks.iter().flat_map(|fork| fork.value.iter().map(|item| item.name.clone())),
+                forks.iter().flat_map(|fork| fork.value.rows.iter().map(|item| item.name.clone())),
                 "constraint",
             );
         }
         let remaps = batch.merge(&mut forks);
-        let mut pending = Vec::with_capacity(keys.len().saturating_mul(2));
+        let row_count = forks.iter().map(|fork| fork.value.rows.len()).sum();
+        let mut pending = Vec::with_capacity(row_count);
+        let mut row_counts = Vec::with_capacity(keys.len());
         for (mut fork, remap) in forks.into_iter().zip(remaps) {
-            for item in &mut fork.value {
+            for item in &mut fork.value.rows {
                 item.remap(remap);
             }
-            pending.extend(fork.value);
+            row_counts.extend(fork.value.row_counts);
+            pending.extend(fork.value.rows);
         }
         drop(batch);
-        self.register_constraints_batch(pending);
+        let mut ids = self.register_constraints_batch(pending).into_iter();
+        let groups = row_counts
+            .into_iter()
+            .map(|count| {
+                let first = ids.next().expect("range row ID missing");
+                match count {
+                    1 => RangeConstraintIds::Interval(first),
+                    2 => RangeConstraintIds::Split {
+                        lower: first,
+                        upper: ids.next().expect("upper range row ID missing"),
+                    },
+                    _ => unreachable!("range must lower to one or two rows"),
+                }
+            })
+            .collect();
+        IndexedRangeConstraint::new(keys, set.axes(), groups)
     }
 
     /// Unified view of every algebraic, explicit SOC, and SOS constraint
@@ -2437,6 +2508,62 @@ mod tests {
     }
 
     #[test]
+    fn indexed_constraint_handles_match_in_serial_and_parallel() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Handles {
+            ordinary: Vec<(usize, ConstraintId)>,
+            ranges: Vec<(usize, RangeConstraintIds)>,
+        }
+
+        fn build(parallel: bool, keys: &Set<usize>) -> Handles {
+            let model = Model::new("family_id_parity");
+            let x = model.__var("x").build();
+            model.__add_constraint("prior", x.ge(0.0));
+            let ordinary =
+                model.add_constraints_over_with("c", keys, &|_| x.le(5.0), Some(parallel));
+            let ranges = model.add_range_constraints_over_with(
+                "r",
+                keys,
+                &|i| (if i % 2 == 0 { x + 1.0 } else { x.powi(2) }, 0.0, 10.0),
+                Some(parallel),
+            );
+            for (key, id) in ordinary.iter() {
+                assert_eq!(ordinary.get(key), Some(id));
+                assert_eq!(model.constraint_id(&format!("c[{key}]")), Some(id));
+            }
+            for (key, ids) in ranges.iter() {
+                assert_eq!(ranges.get(key), Some(ids));
+                match ids {
+                    RangeConstraintIds::Interval(id) => {
+                        assert_eq!(model.constraint_id(&format!("r[{key}]")), Some(id));
+                        let row = &model.constraints.borrow()[id.index()];
+                        assert_eq!((row.lower, row.upper), (0.0, 10.0));
+                        assert_eq!(classify(&model.arena(), row.lhs), ExprClass::Linear);
+                    }
+                    RangeConstraintIds::Split { lower, upper } => {
+                        assert_eq!(model.constraint_id(&format!("r[{key}]_lo")), Some(lower));
+                        assert_eq!(model.constraint_id(&format!("r[{key}]_hi")), Some(upper));
+                        let rows = model.constraints.borrow();
+                        assert_eq!(rows[lower.index()].lower.to_bits(), 0.0_f64.to_bits());
+                        assert_eq!(rows[upper.index()].upper.to_bits(), 10.0_f64.to_bits());
+                        assert_eq!(
+                            classify(&model.arena(), rows[lower.index()].lhs),
+                            ExprClass::Quadratic
+                        );
+                    }
+                }
+            }
+            Handles { ordinary: ordinary.iter().collect(), ranges: ranges.iter().collect() }
+        }
+
+        rayon::ThreadPoolBuilder::new().num_threads(4).build().unwrap().install(|| {
+            for keys in [Set::range(3..1030), Set::from_ints([8, 1, 6, 3, 4])] {
+                assert_eq!(build(false, &keys), build(true, &keys));
+            }
+        });
+    }
+
+    #[test]
     fn indexed_build_forced_parallel_matches_serial_for_every_family() {
         #[derive(Debug, PartialEq)]
         struct Digest {
@@ -2560,6 +2687,39 @@ mod tests {
 
         model.__add_constraint("after", x.le(2.0));
         assert_eq!(model.constraint_id("after"), Some(ConstraintId(0)));
+    }
+
+    #[test]
+    fn parallel_range_failure_does_not_mutate_model_or_arena() {
+        for duplicate_name in [false, true] {
+            let model = Model::new("range_batch_atomicity");
+            let x = model.__var("x").build();
+            let prior = model.__add_constraint("r[17]_hi", x.le(2.0));
+            let arena_len = model.arena().len();
+            let keys = Set::range(0..128usize);
+            let rule = |i: usize| {
+                let body = if i.is_multiple_of(2) { x + 1.0 } else { x.powi(2) };
+                assert!(duplicate_name || i != 17, "deliberate range callback panic");
+                (body, 0.0, 10.0)
+            };
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                model.add_range_constraints_over_with("r", &keys, &rule, Some(true));
+            }));
+            assert!(result.is_err());
+            assert_eq!(model.num_constraints(), 1);
+            assert_eq!(model.constraint_id("r[17]_hi"), Some(prior));
+            assert_eq!(model.arena().len(), arena_len);
+
+            // The failed batch must also release the arena for subsequent builds.
+            let family = model.add_range_constraints_over_with(
+                "after",
+                &keys,
+                &|_| (x, 0.0, 1.0),
+                Some(true),
+            );
+            assert_eq!(family.get(0), Some(RangeConstraintIds::Interval(ConstraintId(1))));
+            assert_eq!(model.num_constraints(), 129);
+        }
     }
 
     #[test]

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -1,7 +1,9 @@
-pub use crate::constraint::{Constraint, ConstraintExpr, ConstraintId, IntoRhs, Relate, Sense};
+pub use crate::constraint::{
+    Constraint, ConstraintExpr, ConstraintId, IntoRhs, RangeConstraintIds, Relate, Sense,
+};
 pub use crate::domain::Domain;
 pub use crate::error::Error;
-pub use crate::indexed::{IndexedParam, IndexedVar};
+pub use crate::indexed::{IndexedConstraint, IndexedParam, IndexedRangeConstraint, IndexedVar};
 pub use crate::model::{
     ConstraintRef, IndexedVarBuilder, Model, ModelConstraints, ModelKind, display_index_key,
 };

--- a/crates/oximo-core/tests/indexed_constraint.rs
+++ b/crates/oximo-core/tests/indexed_constraint.rs
@@ -1,0 +1,240 @@
+#![deny(unused_variables)]
+
+use oximo_core::prelude::*;
+
+#[test]
+fn scalar_relations_still_return_ids() {
+    let m = Model::new("scalar_ids");
+    variable!(m, x);
+    let named: ConstraintId = constraint!(m, capacity, x <= 10.0);
+    let anonymous: ConstraintId = constraint!(m, x >= 0.0);
+    let computed: ConstraintId = constraint!(m, name = format!("fixed_{}", 2), x == 2.0);
+    assert_eq!(m.constraint_id("capacity"), Some(named));
+    assert_eq!(m.constraint_id("_c0"), Some(anonymous));
+    assert_eq!(m.constraint_id("fixed_2"), Some(computed));
+}
+
+#[test]
+fn dense_family_returns_actual_ids_and_owns_its_entries() {
+    let cover = {
+        let m = Model::new("dense_ids");
+        variable!(m, x);
+        constraint!(m, prior, x >= 0.0);
+        let cover: IndexedConstraint<usize> = constraint!(m, cover[_i in 3..6], x <= 10.0);
+        assert_eq!(cover.len(), 3);
+        assert!(!cover.is_empty());
+        for (i, cid) in cover.iter() {
+            assert_eq!(m.constraint_id(&format!("cover[{i}]")), Some(cid));
+            assert_eq!(cover.get(i), Some(cid));
+        }
+        cover
+    };
+    assert_eq!(
+        cover.iter().collect::<Vec<_>>(),
+        vec![(3, ConstraintId(1)), (4, ConstraintId(2)), (5, ConstraintId(3)),]
+    );
+    assert_eq!(cover.get(2), None);
+    assert_eq!(cover.get(-1), None);
+    assert_eq!(cover.get(6), None);
+    assert_eq!(cover.get((3, 0)), None);
+    assert_eq!(cover.get("3"), None);
+    assert_eq!(cover.clone().iter().collect::<Vec<_>>(), cover.iter().collect::<Vec<_>>());
+    assert!(format!("{cover:?}").contains("IndexedConstraint"));
+}
+
+#[test]
+fn dense_tuple_lookup_uses_each_axis_offset() {
+    let m = Model::new("grid_ids");
+    variable!(m, x);
+    let grid: IndexedConstraint<(usize, usize)> =
+        constraint!(m, grid[_i in 2..4, _j in 5..8], x <= 1.0);
+    let expected = [(2, 5), (2, 6), (2, 7), (3, 5), (3, 6), (3, 7)];
+    assert_eq!(grid.iter().map(|(key, _)| key).collect::<Vec<_>>(), expected);
+    for (key, cid) in grid.iter() {
+        assert_eq!(grid.get(key), Some(cid));
+        assert_eq!(m.constraint_id(&format!("grid[{},{}]", key.0, key.1)), Some(cid));
+    }
+    assert_eq!(grid.get((2, 8)), None);
+    assert_eq!(grid.get((1, 5)), None);
+    assert_eq!(grid.get(2), None);
+}
+
+#[test]
+fn sparse_and_filtered_domains_preserve_order() {
+    let m = Model::new("sparse_ids");
+    variable!(m, x);
+    let indices = Set::from_ints([7, 3, 20]);
+    let sparse: IndexedConstraint<usize> = constraint!(m, sparse[_i in indices], x <= 5.0);
+    assert_eq!(sparse.iter().map(|(i, _)| i).collect::<Vec<_>>(), [7, 3, 20]);
+    for (i, cid) in sparse.iter() {
+        assert_eq!(sparse.get(i), Some(cid));
+        assert_eq!(m.constraint_id(&format!("sparse[{i}]")), Some(cid));
+    }
+    assert_eq!(sparse.get(0), None);
+    let filtered = constraint!(m, filtered[i in 0..6 if i % 2 == 0], x >= 0.0);
+    assert_eq!(filtered.iter().map(|(i, _)| i).collect::<Vec<_>>(), [0, 2, 4]);
+    assert_eq!(filtered.get(1), None);
+    assert_eq!(filtered.get(4), m.constraint_id("filtered[4]"));
+}
+
+#[test]
+fn string_and_filtered_tuple_domains_support_lookup() {
+    let m = Model::new("string_ids");
+    variable!(m, x);
+    let plants = Set::strings(["west", "skip", "east"]);
+    let supply: IndexedConstraint<String> =
+        constraint!(m, supply[p in plants if p != "skip"], x <= 5.0);
+    assert_eq!(supply.iter().map(|(p, _)| p).collect::<Vec<_>>(), ["west", "east"]);
+    assert_eq!(supply.get("skip"), None);
+    assert_eq!(supply.get("east"), m.constraint_id("supply[east]"));
+    let grid: IndexedConstraint<(String, usize)> =
+        constraint!(m, grid[p in plants, i in 1..3 if p != "skip" && i == 2], x >= 0.0);
+    assert_eq!(grid.len(), 2);
+    for ((p, i), cid) in grid.iter() {
+        assert_eq!(grid.get((p.as_str(), i)), Some(cid));
+        assert_eq!(m.constraint_id(&format!("grid[{p},{i}]")), Some(cid));
+    }
+    assert_eq!(grid.get(("west", 1)), None);
+}
+
+#[test]
+fn empty_domains_return_empty_handles() {
+    let m = Model::new("empty_ids");
+    variable!(m, x);
+    let empty = constraint!(m, empty[_i in 0..0], x <= 1.0);
+    let filtered = constraint!(m, filtered[i in 0..3 if i > 5], x <= 1.0);
+    for family in [empty, filtered] {
+        assert!(family.is_empty());
+        assert_eq!(family.len(), 0);
+        assert_eq!(family.iter().count(), 0);
+        assert_eq!(family.get(0), None);
+    }
+    let ranges: IndexedRangeConstraint<usize> = constraint!(m, ranges[_i in 0..0], 0.0 <= x <= 1.0);
+    assert!(ranges.is_empty());
+    assert_eq!(ranges.iter().count(), 0);
+    assert_eq!(ranges.get(0), None);
+    assert_eq!(m.num_constraints(), 0);
+}
+
+#[test]
+fn scalar_ranges_return_named_and_anonymous_groups() {
+    let m = Model::new("range_ids");
+    variable!(m, x);
+    param!(m, lo = 0.0);
+    let band: RangeConstraintIds = constraint!(m, band, 0.0 <= x <= 4.0);
+    assert_eq!(band, RangeConstraintIds::Interval(m.constraint_id("band").unwrap()));
+    let reversed = constraint!(m, name = format!("band_{}", 2), 4.0 >= x >= 0.0);
+    assert_eq!(reversed, RangeConstraintIds::Interval(m.constraint_id("band_2").unwrap()));
+    let auto = constraint!(m, 0.0 <= x <= 4.0);
+    assert_eq!(auto, RangeConstraintIds::Interval(m.constraint_id("_c0").unwrap()));
+    let split = constraint!(m, symbolic, lo <= x <= 4.0);
+    assert_eq!(
+        split,
+        RangeConstraintIds::Split {
+            lower: m.constraint_id("symbolic_lo").unwrap(),
+            upper: m.constraint_id("symbolic_hi").unwrap(),
+        }
+    );
+    let nonlinear = constraint!(m, name = "nonlinear".to_owned(), 4.0 >= x.powi(2) >= 0.0);
+    assert_eq!(
+        nonlinear,
+        RangeConstraintIds::Split {
+            lower: m.constraint_id("nonlinear_lo").unwrap(),
+            upper: m.constraint_id("nonlinear_hi").unwrap(),
+        }
+    );
+    let auto_split = constraint!(m, lo <= x <= 4.0);
+    assert_eq!(
+        auto_split,
+        RangeConstraintIds::Split {
+            lower: m.constraint_id("_c1").unwrap(),
+            upper: m.constraint_id("_c2").unwrap(),
+        }
+    );
+}
+
+#[test]
+fn range_family_can_mix_interval_and_split_entries() {
+    let m = Model::new("mixed_range_ids");
+    variable!(m, x);
+    constraint!(m, prior, x >= 0.0);
+    let bodies = [x, x.powi(2), x + 1.0];
+    let ranges: IndexedRangeConstraint<usize> =
+        constraint!(m, ranges[i in 0..3], 4.0 >= bodies[i] >= 0.0);
+    assert_eq!(ranges.len(), 3);
+    assert_eq!(m.num_constraints(), 5);
+    assert_eq!(
+        ranges.iter().collect::<Vec<_>>(),
+        vec![
+            (0, RangeConstraintIds::Interval(ConstraintId(1))),
+            (1, RangeConstraintIds::Split { lower: ConstraintId(2), upper: ConstraintId(3) }),
+            (2, RangeConstraintIds::Interval(ConstraintId(4))),
+        ]
+    );
+    assert_eq!(ranges.get(3), None);
+    for (i, ids) in ranges.iter() {
+        assert_eq!(ranges.get(i), Some(ids));
+    }
+    assert_eq!(ranges.clone().iter().collect::<Vec<_>>(), ranges.iter().collect::<Vec<_>>());
+    assert!(format!("{ranges:?}").contains("IndexedRangeConstraint"));
+
+    let keys = Set::strings(["last", "skip", "first"]);
+    let sparse = constraint!(m, sparse[k in keys if k != "skip"], 0.0 <= x <= 4.0);
+    assert_eq!(sparse.iter().map(|(k, _)| k).collect::<Vec<_>>(), ["last", "first"]);
+    assert_eq!(sparse.get("skip"), None);
+    assert_eq!(
+        sparse.get("first"),
+        Some(RangeConstraintIds::Interval(m.constraint_id("sparse[first]").unwrap()))
+    );
+}
+
+#[test]
+fn index_used_only_in_format_string_still_binds() {
+    let m = Model::new("fmt_ids");
+    variable!(m, x);
+    let f: IndexedConstraint<usize> =
+        constraint!(m, f[i in 0..2], x <= format!("{i}").parse::<f64>().unwrap());
+    assert_eq!(f.len(), 2);
+    let g: IndexedConstraint<usize> =
+        constraint!(m, g[i in 0..4 if !format!("{i}").is_empty()], x <= 1.0);
+    assert_eq!(g.len(), 4);
+}
+
+#[test]
+fn tuple_bindings_can_move_string_keys_after_generated_borrow() {
+    let m = Model::new("moved_keys");
+    variable!(m, x);
+    let keys = Set::strings(["2", "3"]);
+    let domain = &keys * &Set::range(0..2);
+    // `key` is unused in the filter, `guard` is unused in the rule, and
+    // into_bytes consumes the String after the generated acknowledgement.
+    let moved = constraint!(m, moved[(key, guard) in domain if guard == 1],
+        x <= f64::from(key.into_bytes()[0] - b'0'));
+    assert_eq!(moved.len(), 2);
+    let rows = m.constraints();
+    for (key, expected) in [("2", 2.0), ("3", 3.0)] {
+        let id = moved.get((key, 1)).unwrap();
+        assert!((rows.algebraic()[id.index()].upper - expected).abs() < f64::EPSILON);
+    }
+}
+
+#[test]
+fn sums_acknowledge_unused_bindings_and_allow_moves() {
+    let m = Model::new("sum_bindings");
+    variable!(m, x);
+    let keys = Set::strings(["2", "3"]);
+    let domain = &keys * &Set::range(0..2);
+    // Deliberately use a non-underscore name for the unused index: denying
+    // unused_variables makes this fail if generated acknowledgements regress.
+    let unfiltered = sum!(f64::from(key.into_bytes()[0] - b'0') * x for (key, unused) in domain);
+    let filtered =
+        sum!(f64::from(key.into_bytes()[0] - b'0') * x for (key, unused) in domain if true);
+    let nested =
+        sum!(f64::from(key.into_bytes()[0] - b'0') * x for unused in 0..2, key in keys if true);
+    let arena = m.arena();
+    for total in [unfiltered, filtered, nested] {
+        let linear = oximo_expr::extract_linear(&arena, total.id).unwrap();
+        assert_eq!(linear.coeffs.len(), 1);
+        assert!((linear.coeffs[0].1 - 10.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/oximo-macros/src/bind.rs
+++ b/crates/oximo-macros/src/bind.rs
@@ -108,61 +108,13 @@ pub(crate) fn filtered_set(
         None => set,
         Some(cond) => {
             let param = family_closure_param(binds);
-            quote!( #root::__macro_support::filter_keys_owned((#set), |#param| #cond) )
+            let used = mark_bindings_used(binds);
+            quote!( #root::__macro_support::filter_keys_owned((#set), |#param| { #used #cond }) )
         }
     }
 }
 
-/// Closure parameter for a per-key expression (a `.lb_by`/`.ub_by` bound or an
-/// indexed `param!` value): each index the expression does not reference is
-/// replaced with `_`, so the generated closure never has an unused parameter.
-/// The family's key type pins the parameter, so it is left bare for inference
-/// unless the user annotated every binding.
-pub(crate) fn masked_closure_param(binds: &[IndexBind], expr: &TokenStream2) -> TokenStream2 {
-    let masked = binds.iter().map(|b| mask_pat(&b.pat, expr));
-    let pattern = if binds.len() == 1 {
-        let p = mask_pat(&binds[0].pat, expr);
-        quote!(#p)
-    } else {
-        quote!( (#(#masked),*) )
-    };
-
-    let tys: Option<Vec<&Type>> = binds.iter().map(|b| b.ty.as_ref()).collect();
-    match tys {
-        Some(tys) if binds.len() == 1 => {
-            let ty = tys[0];
-            quote!(#pattern: #ty)
-        }
-        Some(tys) => quote!( #pattern: (#(#tys),*) ),
-        None => pattern,
-    }
-}
-
-/// Replace each bare-ident sub-pattern that `expr` does not reference with `_`,
-/// recursing into tuple patterns.
-fn mask_pat(pat: &Pat, expr: &TokenStream2) -> TokenStream2 {
-    match pat {
-        Pat::Tuple(t) => {
-            let elems = t.elems.iter().map(|e| mask_pat(e, expr));
-            quote!( (#(#elems),*) )
-        }
-        Pat::Ident(pi) if pi.subpat.is_none() && pi.by_ref.is_none() => {
-            if references_any(expr, &[pi.ident.to_string()]) { quote!(#pat) } else { quote!(_) }
-        }
-        _ => quote!(#pat),
-    }
-}
-
-/// Whether a token stream references any of the given identifiers.
-pub(crate) fn references_any(ts: &TokenStream2, idents: &[String]) -> bool {
-    ts.clone().into_iter().any(|tt| match tt {
-        TokenTree::Ident(id) => idents.contains(&id.to_string()),
-        TokenTree::Group(g) => references_any(&g.stream(), idents),
-        _ => false,
-    })
-}
-
-/// Build the closure parameter for an index family decoded as a whole key.
+/// Closure parameter for an index family decoded as a whole key.
 /// The `Set<K>` passed to `__add_constraints_over` pins `K`, so the
 /// pattern is left bare unless the user annotated every binding.
 pub(crate) fn family_closure_param(binds: &[IndexBind]) -> TokenStream2 {
@@ -183,4 +135,50 @@ pub(crate) fn family_closure_param(binds: &[IndexBind]) -> TokenStream2 {
         Some(tys) => quote!( #pattern: (#(#tys),*) ),
         None => pattern,
     }
+}
+
+/// Statements (`let _ = &ident;` per bound name) that mark every index binding
+/// as used inside a generated closure or loop. A family expands to two closures over
+/// the same names (filter + rule), each of which may ignore a subset
+/// (guard-only keys).
+pub(crate) fn mark_bindings_used(binds: &[IndexBind]) -> TokenStream2 {
+    let mut idents = Vec::new();
+    for b in binds {
+        collect_pat_idents(&b.pat, &mut idents);
+    }
+    let stmts = idents.iter().map(|id| quote!(let _ = &#id;));
+    quote!(#(#stmts)*)
+}
+
+/// Collect the identifiers actually bound by a pattern.
+fn collect_pat_idents(pat: &Pat, out: &mut Vec<syn::Ident>) {
+    match pat {
+        Pat::Ident(pi) => {
+            let name = pi.ident.to_string();
+            if name != "_" && !name.starts_with('_') {
+                out.push(pi.ident.clone());
+            }
+            if let Some((_, sub)) = &pi.subpat {
+                collect_pat_idents(sub, out);
+            }
+        }
+        Pat::Tuple(t) => t.elems.iter().for_each(|e| collect_pat_idents(e, out)),
+        Pat::TupleStruct(ts) => ts.elems.iter().for_each(|e| collect_pat_idents(e, out)),
+        Pat::Struct(s) => s.fields.iter().for_each(|f| collect_pat_idents(&f.pat, out)),
+        Pat::Slice(s) => s.elems.iter().for_each(|e| collect_pat_idents(e, out)),
+        Pat::Reference(r) => collect_pat_idents(&r.pat, out),
+        Pat::Paren(p) => collect_pat_idents(&p.pat, out),
+        Pat::Type(t) => collect_pat_idents(&t.pat, out),
+        Pat::Or(o) => o.cases.iter().for_each(|c| collect_pat_idents(c, out)),
+        _ => {}
+    }
+}
+
+/// Whether a token stream references any of the given identifiers.
+pub(crate) fn references_any(ts: &TokenStream2, idents: &[String]) -> bool {
+    ts.clone().into_iter().any(|tt| match tt {
+        TokenTree::Ident(id) => idents.contains(&id.to_string()),
+        TokenTree::Group(g) => references_any(&g.stream(), idents),
+        _ => false,
+    })
 }

--- a/crates/oximo-macros/src/constraint.rs
+++ b/crates/oximo-macros/src/constraint.rs
@@ -8,7 +8,7 @@ use proc_macro2::{Spacing, Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::Expr;
 
-use crate::bind::{family_closure_param, filtered_set};
+use crate::bind::{IndexBind, family_closure_param, filtered_set, mark_bindings_used};
 use crate::{
     Named, RelOp, build_set, next_seg, oximo_root, parse_named, split_relops, split_top_commas,
 };
@@ -46,10 +46,9 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
             match binds {
                 None => Ok(register_named(&model, &name_str, rel)),
                 Some(binds) => {
-                    let param = family_closure_param(&binds);
                     let set = build_set(&binds, &root)?;
                     let set = filtered_set(set, &binds, cond.as_ref(), &root);
-                    Ok(register_family(&model, &name_str, &set, &param, rel))
+                    Ok(register_family(&model, &name_str, &set, &binds, rel))
                 }
             }
         }
@@ -153,15 +152,17 @@ fn register_family(
     model: &Expr,
     name_str: &str,
     set: &TokenStream2,
-    param: &TokenStream2,
+    binds: &[IndexBind],
     rel: Relations,
 ) -> TokenStream2 {
+    let param = family_closure_param(binds);
+    let used = mark_bindings_used(binds);
     match rel {
         Relations::Single(r) => quote! {
-            (#model).__add_constraints_over(#name_str, &(#set), |#param| #r);
+            (#model).__add_constraints_over(#name_str, &(#set), |#param| { #used #r })
         },
         Relations::Range { mid, lo, hi } => quote! {
-            (#model).__add_range_constraints_over(#name_str, &(#set), |#param| (#mid, #lo, #hi));
+            (#model).__add_range_constraints_over(#name_str, &(#set), |#param| { #used (#mid, #lo, #hi) })
         },
     }
 }

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -51,6 +51,11 @@ pub fn variable(input: TokenStream) -> TokenStream {
 
 /// `constraint!(model, [name|name[idx]], lhs <op> rhs)`, register a constraint,
 /// an auto-named anonymous constraint, or an indexed family of constraints.
+///
+/// Single relations return `ConstraintId` for scalars and `IndexedConstraint<K>`
+/// for families. Two-sided ranges return `RangeConstraintIds` for scalars and
+/// `IndexedRangeConstraint<K>` for families. Bind a result explicitly with
+/// `let handle = constraint!(...)` to query the registered rows.
 #[proc_macro]
 pub fn constraint(input: TokenStream) -> TokenStream {
     constraint::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()

--- a/crates/oximo-macros/src/param.rs
+++ b/crates/oximo-macros/src/param.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::Expr;
 
-use crate::bind::{filtered_set, masked_closure_param};
+use crate::bind::{family_closure_param, filtered_set, mark_bindings_used};
 use crate::{Named, build_set, oximo_root, parse_named, split_top_commas};
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
@@ -37,13 +37,14 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         Some(binds) => {
             let root = oximo_root();
             let value = crate::index::rewrite_index_subscripts(value_ts);
-            let param = masked_closure_param(&binds, &value);
+            let param = family_closure_param(&binds);
+            let used = mark_bindings_used(&binds);
             let set = build_set(&binds, &root)?;
             let set = filtered_set(set, &binds, cond.as_ref(), &root);
             Ok(quote! {
                 let #name = {
                     let __set = #set;
-                    (#model).__indexed_param(#name_str, &__set, move |#param| f64::from(#value))
+                    (#model).__indexed_param(#name_str, &__set, move |#param| { #used f64::from(#value) })
                 };
             })
         }

--- a/crates/oximo-macros/src/soc.rs
+++ b/crates/oximo-macros/src/soc.rs
@@ -7,7 +7,7 @@ use proc_macro2::{Delimiter, Span, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::Expr;
 
-use crate::bind::{family_closure_param, filtered_set};
+use crate::bind::{family_closure_param, filtered_set, mark_bindings_used};
 use crate::constraint::computed_name;
 use crate::{
     Named, RelOp, build_set, next_seg, oximo_root, parse_named, split_relops, split_top_commas,
@@ -57,13 +57,14 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
                 )),
                 Some(binds) => {
                     let param = family_closure_param(&binds);
+                    let used = mark_bindings_used(&binds);
                     let set = build_set(&binds, &root)?;
                     let set = filtered_set(set, &binds, cond.as_ref(), &root);
                     Ok(quote! {
                         (#model).__add_soc_constraints_over(
                             #name_str,
                             &(#set),
-                            |#param| ([#(#terms),*], #bound),
+                            |#param| { #used ([#(#terms),*], #bound) },
                         );
                     })
                 }

--- a/crates/oximo-macros/src/sos.rs
+++ b/crates/oximo-macros/src/sos.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 use quote::{ToTokens, quote};
 use syn::Expr;
 
-use crate::bind::{family_closure_param, filtered_set};
+use crate::bind::{family_closure_param, filtered_set, mark_bindings_used};
 use crate::constraint::computed_name;
 use crate::{Named, build_set, oximo_root, parse_named, split_top_commas};
 
@@ -62,6 +62,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         }),
         Some(binds) => {
             let param = family_closure_param(&binds);
+            let used = mark_bindings_used(&binds);
             let set = build_set(&binds, &root)?;
             let set = filtered_set(set, &binds, cond.as_ref(), &root);
             Ok(match &members {
@@ -70,7 +71,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
                         #name_str,
                         &(#set),
                         #sos_type,
-                        |#param| [#(#members),*],
+                        |#param| { #used [#(#members),*] },
                     );
                 },
                 Members::Auto(members) => quote! {
@@ -78,7 +79,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
                         #name_str,
                         &(#set),
                         #sos_type,
-                        |#param| [#(#members),*],
+                        |#param| { #used [#(#members),*] },
                     );
                 },
             })

--- a/crates/oximo-macros/src/sum.rs
+++ b/crates/oximo-macros/src/sum.rs
@@ -43,8 +43,9 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         let mut expr = quote!(#body);
         for b in binds.iter().rev() {
             let param = b.closure_param();
+            let used = crate::bind::mark_bindings_used(std::slice::from_ref(b));
             let domain = &b.domain;
-            expr = quote!( #root::__macro_support::sum_over(&(#domain), |#param| #expr) );
+            expr = quote!( #root::__macro_support::sum_over(&(#domain), |#param| { #used #expr }) );
         }
         return Ok(expr);
     };
@@ -58,6 +59,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     };
     for b in binds.iter().rev() {
         let pat = &b.pat;
+        let used = crate::bind::mark_bindings_used(std::slice::from_ref(b));
         let domain = &b.domain;
         let keys = if let Some(ty) = b.keys_of_type() {
             quote!( #root::__macro_support::keys_of::<#ty, _>(&(#domain)) )
@@ -66,6 +68,7 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
         };
         inner = quote! {
             for #pat in #keys {
+                #used
                 #inner
             }
         };

--- a/crates/oximo-macros/src/variable.rs
+++ b/crates/oximo-macros/src/variable.rs
@@ -15,7 +15,7 @@
 use proc_macro2::{Spacing, TokenStream as TokenStream2, TokenTree};
 use quote::{ToTokens, quote};
 
-use crate::bind::{filtered_set, masked_closure_param, references_any};
+use crate::bind::{family_closure_param, filtered_set, mark_bindings_used, references_any};
 use crate::{Named, RelOp, build_set, oximo_root, parse_named, split_relops, split_top_commas};
 
 pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
@@ -99,10 +99,11 @@ pub(crate) fn expand(input: TokenStream2) -> syn::Result<TokenStream2> {
     let bound_method = |val: &TokenStream2, kind: BoundKind| -> TokenStream2 {
         match binds_slice {
             Some(bs) if references_any(val, &idents) => {
-                let param = masked_closure_param(bs, val);
+                let param = family_closure_param(bs);
+                let used = mark_bindings_used(bs);
                 match kind {
-                    BoundKind::Lb => quote!(.lb_by(move |#param| f64::from(#val))),
-                    BoundKind::Ub => quote!(.ub_by(move |#param| f64::from(#val))),
+                    BoundKind::Lb => quote!(.lb_by(move |#param| { #used f64::from(#val) })),
+                    BoundKind::Ub => quote!(.ub_by(move |#param| { #used f64::from(#val) })),
                 }
             }
             _ => match kind {

--- a/crates/oximo/tests/solve.rs
+++ b/crates/oximo/tests/solve.rs
@@ -41,6 +41,51 @@ fn highs_multi_optima_returns_single_best() {
 }
 
 #[test]
+fn indexed_constraint_handles_query_known_duals() {
+    let m = Model::new("indexed_duals");
+    variable!(m, x[i in 0..5] >= 0.0);
+    constraint!(m, prior, x[1] <= 10.0);
+    let costs = [2.0, 1.0, 3.0, 1.0, 5.0];
+    let demand = [1.0, 0.0, 2.0, 0.0, 3.0];
+    let cover: IndexedConstraint<usize> =
+        constraint!(m, cover[i in 0..5 if i % 2 == 0], x[i] >= demand[i]);
+    objective!(m, Min, sum!(costs[i] * x[i] for i in 0..5));
+    let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert_eq!(cover.get(1), None);
+    for (i, cid) in cover.iter() {
+        assert_eq!(cover.get(i), Some(cid));
+        let dual = result.dual_of(cid).expect("cover dual missing");
+        assert!((dual - costs[i]).abs() < 1e-6, "cover[{i}]: {dual}");
+    }
+}
+
+#[test]
+fn range_family_handles_query_interval_and_split_duals() {
+    let m = Model::new("range_family_duals");
+    variable!(m, x[i in 0..2]);
+    variable!(m, y[i in 0..2]);
+    param!(m, lo = 1.0);
+    let bands: IndexedRangeConstraint<usize> = constraint!(m, bands[i in 0..2], 1.0 <= x[i] <= 4.0);
+    let split = constraint!(m, split[i in 0..2], lo <= y[i] <= 4.0);
+    objective!(m, Min, 2.0 * x[0] - 3.0 * x[1] + 5.0 * y[0] - 7.0 * y[1]);
+    let result = Highs.solve(&m, &HighsOptions::default()).unwrap();
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    for (i, group) in bands.iter() {
+        let RangeConstraintIds::Interval(cid) = group else { panic!("expected interval") };
+        let expected = [2.0, -3.0][i];
+        assert!((result.dual_of(cid).expect("interval dual missing") - expected).abs() < 1e-6);
+    }
+    for (i, group) in split.iter() {
+        let RangeConstraintIds::Split { lower, upper } = group else { panic!("expected split") };
+        let expected_lower = [5.0, 0.0][i];
+        let expected_upper = [0.0, -7.0][i];
+        assert!((result.dual_of(lower).expect("lower dual missing") - expected_lower).abs() < 1e-6);
+        assert!((result.dual_of(upper).expect("upper dual missing") - expected_upper).abs() < 1e-6);
+    }
+}
+
+#[test]
 fn range_constraint_solves_as_single_row() {
     // max x  s.t.  1 <= x <= 4.
     let m = Model::new("range");


### PR DESCRIPTION
## Description

This PR adds return handles for indexed and range constraints. It also preserves index bindings without suppressing warnings.
Codex created all the tests inside `indexed_constraint`.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [ ] `cargo test --features gams` passes (requires GAMS)
- [ ] `cargo test --features gurobi` passes (requires Gurobi)
- [ ] `cargo test --features mosek` passes (requires MOSEK)
- [ ] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/82