### PR TITLE
oximo-io: add IoError for missing objective instead of unwrap()

### DIFF
--- a/crates/oximo-io/src/lp.rs
+++ b/crates/oximo-io/src/lp.rs
@@ -631,9 +631,6 @@ fn parse_lp<R: BufRead>(mut input: R, model_name: &str) -> Result<Model, IoError
             "constraint is missing a comparison and right-hand side",
         ));
     }
-    if p.sense.is_none() {
-        return Err(invalid_lp(1, 1, "missing Minimize or Maximize section"));
-    }
     build_model(p, objective_lines, model_name)
 }
 
@@ -643,6 +640,9 @@ fn build_model(
     objective_lines: Vec<String>,
     model_name: &str,
 ) -> Result<Model, IoError> {
+    let Some(objective_sense) = p.sense else {
+        return Err(invalid_lp(1, 1, "missing Minimize or Maximize section"));
+    };
     let obj_text = objective_lines.join(" ");
     let obj_text = obj_text.split_once(':').map_or(obj_text.as_str(), |(_, x)| x);
     let obj_toks = lex(obj_text, 1)?;
@@ -766,7 +766,7 @@ fn build_model(
         m.add_sos_constraint(name, sos_type, members);
     }
     let e = lower(&m, &vars, obj)?;
-    match p.sense.unwrap() {
+    match objective_sense {
         ObjectiveSense::Minimize => m.__minimize(e),
         ObjectiveSense::Maximize => m.__maximize(e),
     }

--- a/crates/oximo-io/tests/lp_reader.rs
+++ b/crates/oximo-io/tests/lp_reader.rs
@@ -279,3 +279,17 @@ fn higher_degree_expression_is_invalid_lp_syntax() {
     let err = read_lp("Minimize\n obj: x^3\nEnd\n".as_bytes()).unwrap_err();
     assert!(matches!(err, IoError::InvalidLp { .. }));
 }
+
+#[test]
+fn missing_objective_section_is_reported_with_position() {
+    let text = "Subject To\n c: x <= 5\nEnd\n";
+    let err = read_lp(text.as_bytes()).unwrap_err();
+    match err {
+        IoError::InvalidLp { line, column, message } => {
+            assert_eq!(line, 1);
+            assert_eq!(column, 1);
+            assert_eq!(message, "missing Minimize or Maximize section");
+        }
+        other => panic!("expected InvalidLp, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Description

This makes `lp.rs` report an `IoError` (with line/col) instead of unwrapping when the Minimize/Maximize section is missing, and includes a test for that path. 

 ## Checklist

- [ ] I have updated the documentation accordingly _**-> NA**_
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`) _**-> scoped (`cargo test -p oximo-io`)**_

- [ ] `cargo test --features gams` passes (requires GAMS)
- [ ] `cargo test --features gurobi` passes (requires Gurobi)
- [ ] `cargo test --features mosek` passes (requires MOSEK)
- [ ] `cargo test --features baron` passes (requires BARON)

## Changes Made

- in case of missing objective, `lp.rs` now returns `IoError::InvalidLp` at the beginning of `build_model` instead of panicking on `p.sense.unwrap()` at the end of the function

- `is_none` check in `parse_lp` removed (chose to throw `IoError` in `build_model` not in `parse_lp` because similar errors were being thrown from inside `build_model`)

- test added: `missing_objective_section_is_reported_with_position`, similar in style to existing tests, also checks if line/col present in error message

## Related Issues
Fixes #61 
