### PR TITLE
Add shared expression-lowering layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
 name = "oximo-solver"
 version = "0.6.0"
 dependencies = [
+ "criterion",
  "oximo-core",
  "oximo-expr",
  "rustc-hash",

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -1,3 +1,5 @@
+use oximo_solver::prepare::{LoweringContext, PreparedExpressions};
+use oximo_solver::reconstruct::normalize_result;
 use std::borrow::Cow;
 use std::fmt::Write as FmtWrite;
 use std::process::Stdio;
@@ -9,7 +11,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, Objective, ObjectiveSense, Sense, SocConstraint,
     SocConstraintId, VarId, Variable,
 };
-use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
+use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms};
 use oximo_solver::{
     DualStatus, Iis, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
     VarBoundKind,
@@ -221,26 +223,23 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError
     if model.has_active_sos_constraints() {
         return Err(SolverError::UnsupportedSos);
     }
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let arena = model.arena();
-    let vars = model.variables();
-    let model_constraints = model.constraints();
+    let prepared = LoweringContext::new(model)?;
+    let vars = prepared.variables();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
-    let socs = model.soc_constraints();
-    let objective = model.objective();
+    let socs = prepared.constraints().second_order_cones();
+    let objective = prepared.objective();
 
     let mut bar = String::with_capacity(4096);
     write_options(&mut bar, opts, RES_NAME, TIM_NAME);
-    let var_order = write_var_declarations(&mut bar, &vars)?;
-    write_bounds(&mut bar, &vars);
-    let con_order = write_equations(&mut bar, &arena, constraints, &socs)?;
-    write_objective(&mut bar, &arena, objective.as_ref())?;
-    write_starting_point(&mut bar, &vars);
+    let var_order = write_var_declarations(&mut bar, vars)?;
+    write_bounds(&mut bar, vars);
+    let con_order = write_equations(&mut bar, &prepared, constraints, socs)?;
+    write_objective(&mut bar, &prepared, objective)?;
+    write_starting_point(&mut bar, vars);
     let soc_bounds = socs
         .iter()
-        .map(|s| {
-            extract_linear(&arena, s.bound).expect("SOC bound is validated affine").into_owned()
-        })
+        .map(|s| prepared.linear(s.bound).expect("SOC bound is validated affine").into_owned())
         .collect();
     Ok((bar, var_order, con_order, soc_bounds))
 }
@@ -350,13 +349,18 @@ fn upper_bound_to_emit(v: &Variable) -> Option<f64> {
 type EquationRow = (&'static str, &'static str, f64);
 
 fn equation_rows(c: &Constraint) -> [Option<EquationRow>; 2] {
-    match c.as_single() {
-        Some((Sense::Le, rhs)) => [Some(("", "<=", rhs)), None],
-        Some((Sense::Ge, rhs)) => [Some(("", ">=", rhs)), None],
-        Some((Sense::Eq, rhs)) => [Some(("", "==", rhs)), None],
-        None if c.is_range() => [Some(("_lo", ">=", c.lower)), Some(("_hi", "<=", c.upper))],
-        None => [None, None],
-    }
+    oximo_solver::prepare::row_sides(c).map(|side| {
+        side.map(|(sense, rhs)| {
+            let suffix =
+                if c.is_range() { if sense == Sense::Ge { "_lo" } else { "_hi" } } else { "" };
+            let op = match sense {
+                Sense::Le => "<=",
+                Sense::Ge => ">=",
+                Sense::Eq => "==",
+            };
+            (suffix, op, rhs)
+        })
+    })
 }
 
 /// Write the `EQUATIONS` block, returning the emit-order map.
@@ -367,10 +371,11 @@ fn equation_rows(c: &Constraint) -> [Option<EquationRow>; 2] {
 /// positional indices stay correct.
 fn write_equations(
     bar: &mut String,
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     constraints: &[Constraint],
     socs: &[SocConstraint],
 ) -> Result<Vec<ConstraintId>, SolverError> {
+    let arena = prepared.arena();
     let mut emit_map: Vec<ConstraintId> = Vec::with_capacity(constraints.len());
     let mut names: Vec<String> = Vec::with_capacity(constraints.len() + 2 * socs.len());
     let mut bodies = String::new();
@@ -395,7 +400,7 @@ fn write_equations(
             names.push(format!("c{i}{suffix}"));
             emit_map.push(id);
             write!(bodies, "c{i}{suffix}: ").unwrap();
-            write_constraint_body(&mut bodies, arena, c.lhs, op, rhs)?;
+            write_constraint_body(&mut bodies, prepared, c.lhs, op, rhs)?;
         }
     }
     for i in 0..socs.len() {
@@ -408,7 +413,7 @@ fn write_equations(
 
     writeln!(bar, "EQUATIONS {};", names.join(", ")).unwrap();
     bar.push_str(&bodies);
-    write_soc_rows(bar, arena, socs);
+    write_soc_rows(bar, prepared, socs);
     writeln!(bar).unwrap();
     Ok(emit_map)
 }
@@ -416,19 +421,19 @@ fn write_equations(
 /// Emit each explicit SOC constraint `||terms||_2 <= bound` as the polynomial
 /// row `(term_1)^2 + ... - (bound)^2 <= 0` plus the sign row `bound >= 0`
 /// (squaring loses the sign of the bound side).
-fn write_soc_rows(bar: &mut String, arena: &ExprArena, socs: &[SocConstraint]) {
+fn write_soc_rows(bar: &mut String, prepared: &PreparedExpressions, socs: &[SocConstraint]) {
     for (i, s) in socs.iter().enumerate() {
         write!(bar, "soc{i}: ").unwrap();
         for (k, &term) in s.terms.iter().enumerate() {
             if k > 0 {
                 write!(bar, " + ").unwrap();
             }
-            let t = extract_linear(arena, term).expect("SOC members are validated affine");
+            let t = prepared.linear(term).expect("SOC members are validated affine");
             write!(bar, "(").unwrap();
             write_linear(bar, &t, true);
             write!(bar, ")^2").unwrap();
         }
-        let b = extract_linear(arena, s.bound).expect("SOC bound is validated affine");
+        let b = prepared.linear(s.bound).expect("SOC bound is validated affine");
         write!(bar, " - (").unwrap();
         write_linear(bar, &b, true);
         writeln!(bar, ")^2 <= 0;").unwrap();
@@ -444,12 +449,13 @@ fn write_soc_rows(bar: &mut String, arena: &ExprArena, socs: &[SocConstraint]) {
 /// full LHS and keep the original RHS.
 fn write_constraint_body(
     bar: &mut String,
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     lhs: ExprId,
     op: &str,
     rhs: f64,
 ) -> Result<(), SolverError> {
-    if let Some(t) = extract_linear(arena, lhs) {
+    let arena = prepared.arena();
+    if let Some(t) = prepared.linear(lhs) {
         let adjusted_rhs = rhs - t.constant;
         write_linear(bar, &t, false);
         writeln!(bar, " {op} {};", fmt(adjusted_rhs)).unwrap();
@@ -462,9 +468,10 @@ fn write_constraint_body(
 
 fn write_objective(
     bar: &mut String,
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     objective: Option<&Objective>,
 ) -> Result<(), SolverError> {
+    let arena = prepared.arena();
     write!(bar, "OBJ: ").unwrap();
     match objective {
         // BARON requires an objective. A feasibility problem minimizes a constant.
@@ -475,7 +482,7 @@ fn write_objective(
                 ObjectiveSense::Maximize => "maximize",
             };
             write!(bar, "{kw} ").unwrap();
-            if let Some(t) = extract_linear(arena, o.expr) {
+            if let Some(t) = prepared.linear(o.expr) {
                 write_linear(bar, &t, true);
             } else {
                 write_bar_expr(bar, arena, o.expr)?;
@@ -755,60 +762,42 @@ fn parse_solution(
         }
     }
 
-    // A point is only usable if it carries primal values.
-    let has_usable_primal = solutions.iter().any(|s| !s.primal.is_empty());
-    let primal_status = PrimalStatus::infer(&termination, has_usable_primal);
-    let mut best_bound = match sense {
+    let best_bound = match sense {
         ObjectiveSense::Minimize => lower,
         ObjectiveSense::Maximize => upper,
     };
-    let mut gap = relative_gap(lower, upper);
-    if matches!(termination, TerminationStatus::Optimal) {
-        best_bound = best_bound.or(objective);
-        gap = gap.or(Some(0.0));
-    }
     let raw_status = termination_banner(res)
         .map_or_else(|| format!("model_status={model_status}"), str::to_owned);
     let dual_available =
         has_sol && res.to_ascii_lowercase().contains("corresponding dual solution");
 
-    SolverResult {
-        solutions,
-        dual,
-        soc_dual,
-        reduced_costs,
-        termination,
-        primal_status,
-        dual_status: if dual_available {
-            DualStatus::FeasiblePoint
-        } else if has_sol {
-            DualStatus::Unknown
-        } else {
-            DualStatus::NoSolution
+    normalize_result(
+        SolverResult {
+            solutions,
+            dual,
+            soc_dual,
+            reduced_costs,
+            termination,
+            primal_status: PrimalStatus::NoSolution,
+            dual_status: if dual_available {
+                DualStatus::FeasiblePoint
+            } else if has_sol {
+                DualStatus::Unknown
+            } else {
+                DualStatus::NoSolution
+            },
+            best_bound,
+            gap: None,
+            solve_time: elapsed,
+            iterations,
+            node_count,
+            raw_status: Some(raw_status.into()),
+            raw_log,
+            solver_name: Some(crate::NAME.into()),
+            solver_version: baron_version(res),
         },
-        best_bound,
-        gap,
-        solve_time: elapsed,
-        iterations,
-        node_count,
-        raw_status: Some(raw_status.into()),
-        raw_log,
-        solver_name: Some(crate::NAME.into()),
-        solver_version: baron_version(res),
-    }
-}
-
-/// Relative optimality gap from BARON's lower/upper bounds, `None` unless both
-/// are finite. Normalized by the larger-magnitude bound (+ epsilon) so it is
-/// comparable across models.
-fn relative_gap(lower: Option<f64>, upper: Option<f64>) -> Option<f64> {
-    match (lower, upper) {
-        (Some(lo), Some(hi)) if lo.is_finite() && hi.is_finite() => {
-            let g = (hi - lo).abs() / (lo.abs().max(hi.abs()) + 1e-10);
-            g.is_finite().then_some(g)
-        }
-        _ => None,
-    }
+        var_order.len(),
+    )
 }
 
 enum BaronBanner {
@@ -1235,7 +1224,8 @@ fn parse_baron_float(s: &str) -> Option<f64> {
 
 #[cfg(feature = "benchmark-support")]
 #[doc(hidden)]
-#[expect(clippy::cast_precision_loss, clippy::wildcard_imports)]
+#[expect(clippy::cast_precision_loss)]
+#[allow(clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
     use rayon::prelude::*;
@@ -1263,7 +1253,7 @@ pub mod benchmark_support {
     }
 
     pub fn render_equations(model: &Model, parallel: bool) -> Result<String, SolverError> {
-        let arena = model.arena().clone();
+        let arena = PreparedExpressions::new((*model.arena()).clone());
         let constraints = model.constraints().algebraic().to_vec();
         let socs = model.soc_constraints().clone();
         let mut out = String::new();
@@ -1278,7 +1268,7 @@ pub mod benchmark_support {
 
     fn render_parallel(
         out: &mut String,
-        arena: &ExprArena,
+        arena: &PreparedExpressions,
         constraints: &[Constraint],
         socs: &[SocConstraint],
     ) -> Result<Vec<ConstraintId>, SolverError> {
@@ -1312,7 +1302,7 @@ pub mod benchmark_support {
     }
 
     fn constraint_fragment(
-        arena: &ExprArena,
+        arena: &PreparedExpressions,
         index: usize,
         c: &Constraint,
     ) -> Result<String, SolverError> {
@@ -1996,7 +1986,7 @@ The above solution has an objective value of:  0.0
     #[test]
     fn no_solution_node_minus_three_leaves_primal_empty() {
         // model=1 (optimal) but nodeopt = -3 => no solution vector. We surface a
-        // single objective-only point, but it carries no primal data,
+        // result without a point, because it carries no primal data,
         // so it must NOT count as a usable solution.
         let tim = "m 1 1 0 0 0 0 1 1 0 0 -3 0 0 0.01";
         let res = "The best solution found is:\n\n\n  x0  0  9.9\n";
@@ -2010,16 +2000,9 @@ The above solution has an objective value of:  0.0
             &[],
             &[],
         );
-        assert_eq!(r.result_count(), 1);
-        assert!(
-            r.solution(0).unwrap().primal.is_empty(),
-            "nodeopt -3 must skip primal: {:?}",
-            r.solution(0)
-        );
+        assert_eq!(r.result_count(), 0);
         assert_eq!(r.primal_status, PrimalStatus::NoSolution);
-        assert!(!r.has_solution(), "nodeopt -3 must not report a usable solution");
-        let primal = r.primal().expect("objective-only point is present");
-        assert!(primal.is_empty(), "nodeopt -3 must expose no primal values: {primal:?}");
+        assert!(r.primal().is_none());
         assert!(r.value(VarId(0)).is_none(), "nodeopt -3 must not yield a variable value");
     }
 }

--- a/crates/oximo-clarabel/src/translate.rs
+++ b/crates/oximo-clarabel/src/translate.rs
@@ -7,7 +7,7 @@
 //!    two-sided ranges as both, then finite variable bounds.
 //! 3. One `SecondOrderCone` block per cone constraint, explicit
 //!    [`SocConstraint`]s first, then SOC-shaped quadratic constraints detected
-//!    by [`detect_soc`] in constraint order. Each block is
+//!    by shared prepared lowering in constraint order. Each block is
 //!    `s0 = bound(x), s_i = term_i(x)` via `A` rows holding the negated
 //!    affine coefficients.
 //!
@@ -19,15 +19,17 @@
 
 // TODO: Add convex-QCP-to-SOC reformulation?
 
+use oximo_solver::prepare::{LoweringContext, PreparedExpressions};
+use oximo_solver::reconstruct::{DualProjection, ObjectiveTransform, normalize_result};
+
 use std::time::{Duration, Instant};
 
 use clarabel::algebra::CscMatrix;
 use clarabel::solver::{DefaultSettings, DefaultSolver, IPSolver, SolverStatus, SupportedConeT};
 use oximo_core::{
-    ConstraintId, Model, ObjectiveSense, Sense, SocConstraintId, SocForm, Variable, detect_soc,
-    explicit_soc_form, var_name,
+    ConstraintId, Model, ObjectiveSense, Sense, SocConstraintId, SocForm, Variable, var_name,
 };
-use oximo_expr::{LinearTerms, VarId, describe_nonlinear_term, extract_linear, extract_quadratic};
+use oximo_expr::{LinearTerms, describe_nonlinear_term};
 use oximo_solver::{
     DualStatus, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
 };
@@ -54,7 +56,7 @@ type Triplets = Vec<(usize, usize, f64)>;
 struct Rows {
     a_trip: Triplets,
     b: Vec<f64>,
-    row_duals: Vec<Option<(ConstraintId, f64)>>,
+    row_duals: Vec<Option<DualProjection<ConstraintId>>>,
 }
 
 impl Rows {
@@ -89,20 +91,21 @@ impl Rows {
 
     /// Attach a dual mapping to the row just pushed.
     fn set_last_dual(&mut self, id: ConstraintId, scale: f64) {
-        *self.row_duals.last_mut().unwrap() = Some((id, scale));
+        *self.row_duals.last_mut().unwrap() = Some(DualProjection { source: id, scale });
     }
 }
 
 /// Readback metadata, turn a solved [`DefaultSolver`] back into a
 /// generic [`SolverResult`].
 pub(crate) struct Meta {
+    num_variables: usize,
     /// `-1.0` for a maximize objective (Clarabel always minimizes), else `1.0`.
     sign: f64,
     /// Folded objective constant, added back after solving.
     obj_constant: f64,
     /// Per `A`-row dual mapping: `Some((constraint, scale))`, or `None` for
     /// bound/cone rows that carry no [`ConstraintId`].
-    row_duals: Vec<Option<(ConstraintId, f64)>>,
+    row_duals: Vec<Option<DualProjection<ConstraintId>>>,
     /// Row index of each SOC block's `s0` entry.
     soc_block_starts: Vec<usize>,
     /// Count of leading SOC blocks that are explicit cones (duals reported).
@@ -185,20 +188,19 @@ pub(crate) fn build_problem(model: &Model) -> Result<Problem, SolverError> {
 }
 
 fn build_problem_with(model: &Model, parallel: Option<bool>) -> Result<Problem, SolverError> {
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let kind = model.kind();
+    let prepared = LoweringContext::new(model)?;
+    let kind = prepared.kind();
     if !crate::supported(kind) {
         return Err(SolverError::UnsupportedKind(kind));
     }
-    let vars = model.variables();
-    reject_semi_domains(&vars)?;
+    let vars = prepared.variables();
+    reject_semi_domains(vars)?;
     let n = vars.len();
 
-    let (sign, p_trip, q, obj_constant) = objective_data(model, n)?;
-    let rows = classify_rows_with(model, parallel)?;
-    let arena = model.arena();
-    let socs = model.soc_constraints();
-    let explicit_forms = explicit_soc_forms(&arena, &socs, parallel)?;
+    let (sign, p_trip, q, obj_constant) = objective_data(&prepared, n)?;
+    let rows = classify_rows(&prepared, parallel)?;
+    let socs = prepared.constraints().second_order_cones();
+    let explicit_forms = explicit_soc_forms(&prepared, socs, parallel)?;
     let (row_capacity, nonzero_capacity, soc_capacity) =
         translation_capacities(model, &rows, &explicit_forms);
     let acc = Rows::with_capacity(row_capacity, nonzero_capacity);
@@ -218,7 +220,14 @@ fn build_problem_with(model: &Model, parallel: Option<bool>) -> Result<Problem, 
         a_mat,
         b,
         cones,
-        meta: Meta { sign, obj_constant, row_duals, soc_block_starts, n_explicit },
+        meta: Meta {
+            num_variables: n,
+            sign,
+            obj_constant,
+            row_duals,
+            soc_block_starts,
+            n_explicit,
+        },
     })
 }
 
@@ -230,9 +239,11 @@ fn build_problem_with(model: &Model, parallel: Option<bool>) -> Result<Problem, 
 /// lower-triangular with doubled diagonal (the `0.5 x'Qx` convention), matching
 /// Clarabel's `P` up to the triangle side, so entries transpose to
 /// upper-triangular with no scaling.
-fn objective_data(model: &Model, n: usize) -> Result<(f64, Triplets, Vec<f64>, f64), SolverError> {
-    let arena = model.arena();
-    let objective = model.objective();
+fn objective_data(
+    prepared: &LoweringContext<'_>,
+    n: usize,
+) -> Result<(f64, Triplets, Vec<f64>, f64), SolverError> {
+    let objective = prepared.objective();
     let sign = match objective.as_ref().map(|o| o.sense) {
         Some(ObjectiveSense::Maximize) => -1.0,
         _ => 1.0,
@@ -240,12 +251,7 @@ fn objective_data(model: &Model, n: usize) -> Result<(f64, Triplets, Vec<f64>, f
     let Some(obj) = objective.as_ref() else {
         return Ok((sign, Triplets::new(), vec![0.0; n], 0.0));
     };
-    let vars = model.variables();
-    let quad = extract_quadratic(&arena, obj.expr).ok_or_else(|| SolverError::Nonlinear {
-        location: "the objective".into(),
-        term: describe_nonlinear_term(&arena, obj.expr, &|v| var_name(&vars, v))
-            .unwrap_or_else(|| "<nonlinear>".into()),
-    })?;
+    let quad = prepared.require_quadratic(obj.expr, || "the objective".into())?;
     let mut q = vec![0.0; n];
     for &(var, coef) in &quad.linear {
         q[var.index()] += sign * coef;
@@ -258,15 +264,24 @@ fn objective_data(model: &Model, n: usize) -> Result<(f64, Triplets, Vec<f64>, f
 /// Classify every algebraic constraint as linear or SOC. The kind gate
 /// guarantees a quadratic constraint detects as SOC, so a miss here is a
 /// genuine nonlinear.
+#[cfg(any(test, feature = "benchmark-support"))]
 fn classify_rows_with(model: &Model, parallel: Option<bool>) -> Result<Vec<Row>, SolverError> {
-    let arena = model.arena();
-    let vars = model.variables();
-    let model_constraints = model.constraints();
+    classify_rows(&LoweringContext::new(model)?, parallel)
+}
+
+fn classify_rows(
+    prepared: &LoweringContext<'_>,
+    parallel: Option<bool>,
+) -> Result<Vec<Row>, SolverError> {
+    let arena = prepared.arena();
+    let vars = prepared.variables();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
-    let arena_ref = &*arena;
-    let vars_ref = &*vars;
+    let arena_ref = arena;
+    let vars_ref = vars;
+    let expressions: &PreparedExpressions = prepared;
     let classify_non_linear = |c: &oximo_core::Constraint| {
-        detect_soc(arena_ref, vars_ref, c).map(Row::Soc).ok_or_else(|| SolverError::Nonlinear {
+        expressions.detected_soc(vars_ref, c).map(Row::Soc).ok_or_else(|| SolverError::Nonlinear {
             location: format!("constraint {:?}", c.name),
             term: describe_nonlinear_term(arena_ref, c.lhs, &|v| var_name(vars_ref, v))
                 .unwrap_or_else(|| "<nonlinear>".into()),
@@ -279,7 +294,7 @@ fn classify_rows_with(model: &Model, parallel: Option<bool>) -> Result<Vec<Row>,
     let mut rows: Vec<Option<Row>> = (0..constraints.len()).map(|_| None).collect();
     let mut pending = Vec::new();
     for (index, constraint) in constraints.iter().enumerate() {
-        match extract_linear(arena_ref, constraint.lhs).map(LinearTerms::into_owned) {
+        match prepared.linear(constraint.lhs).map(oximo_solver::prepare::AffineTerms::into_owned) {
             Some(terms) => rows[index] = Some(Row::Lin(terms)),
             None => pending.push((index, constraint)),
         }
@@ -436,18 +451,11 @@ fn soc_blocks(
 }
 
 fn explicit_soc_forms(
-    arena_ref: &oximo_expr::ExprArena,
+    prepared: &PreparedExpressions,
     socs: &[oximo_core::SocConstraint],
     parallel: Option<bool>,
 ) -> Result<Vec<SocForm>, SolverError> {
-    let extract = |s: &oximo_core::SocConstraint| {
-        explicit_soc_form(arena_ref, s).ok_or_else(|| {
-            SolverError::Backend(format!(
-                "SOC constraint '{}' has a member outside this model's arena",
-                s.name
-            ))
-        })
-    };
+    let extract = |s: &oximo_core::SocConstraint| prepared.explicit_soc(s);
     let use_parallel = parallel.unwrap_or(false);
     let explicit_results: Vec<Result<SocForm, SolverError>> = if use_parallel {
         socs.par_iter().map(extract).collect()
@@ -486,19 +494,16 @@ pub(crate) fn read_result(
     let mut dual: FxHashMap<ConstraintId, f64> = FxHashMap::default();
     let mut soc_dual: FxHashMap<SocConstraintId, f64> = FxHashMap::default();
     if has_point {
-        let primal: FxHashMap<VarId, f64> = solver
-            .solution
-            .x
-            .iter()
-            .enumerate()
-            .map(|(i, &val)| (VarId(u32::try_from(i).expect("variable count overflow")), val))
-            .collect();
-        let objective = Some(meta.sign * solver.solution.obj_val + meta.obj_constant);
+        let primal =
+            oximo_solver::reconstruct::project_dense_primal(&solver.solution.x, meta.num_variables)
+                .unwrap_or_default();
+        let objective = ObjectiveTransform { sign: meta.sign, offset: meta.obj_constant }
+            .restore(solver.solution.obj_val);
         solutions.push(SolutionPoint { primal, objective });
 
         for (r, &z) in solver.solution.z.iter().enumerate() {
-            if let Some(Some((id, s))) = meta.row_duals.get(r) {
-                *dual.entry(*id).or_insert(0.0) += meta.sign * s * z;
+            if let Some(Some(projection)) = meta.row_duals.get(r) {
+                projection.accumulate(&mut dual, z, meta.sign);
             }
         }
         for (k, &start) in meta.soc_block_starts.iter().take(meta.n_explicit).enumerate() {
@@ -508,42 +513,46 @@ pub(crate) fn read_result(
         }
     }
     let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
-    let (best_bound, gap) =
-        mapped_objective_bound(meta, solver.solution.obj_val, solver.solution.obj_val_dual);
+    let best_bound = if native_status == SolverStatus::Solved {
+        mapped_objective_bound(meta, solver.solution.obj_val, solver.solution.obj_val_dual)
+    } else {
+        None
+    };
 
-    SolverResult {
-        termination,
-        primal_status,
-        dual_status: if has_point { DualStatus::FeasiblePoint } else { DualStatus::NoSolution },
-        solutions,
-        dual,
-        soc_dual,
-        reduced_costs: FxHashMap::default(),
-        best_bound,
-        gap,
-        solve_time: elapsed,
-        iterations: u64::from(solver.info.iterations),
-        node_count: None,
-        raw_status: Some(format!("{native_status:?}").into()),
-        raw_log: None,
-        solver_name: Some(crate::NAME.into()),
-        solver_version: None,
-    }
+    normalize_result(
+        SolverResult {
+            termination,
+            primal_status,
+            dual_status: if native_status == SolverStatus::Solved {
+                DualStatus::FeasiblePoint
+            } else if has_point {
+                DualStatus::Unknown
+            } else {
+                DualStatus::NoSolution
+            },
+            solutions,
+            dual,
+            soc_dual,
+            reduced_costs: FxHashMap::default(),
+            best_bound,
+            gap: None,
+            solve_time: elapsed,
+            iterations: u64::from(solver.info.iterations),
+            node_count: None,
+            raw_status: Some(format!("{native_status:?}").into()),
+            raw_log: None,
+            solver_name: Some(crate::NAME.into()),
+            solver_version: None,
+        },
+        meta.num_variables,
+    )
 }
 
 /// Map Clarabel's primal and dual objectives back to the model's objective
-/// convention and compute their relative difference when both are finite.
-fn mapped_objective_bound(meta: &Meta, primal: f64, dual: f64) -> (Option<f64>, Option<f64>) {
-    let mapped_primal = meta.sign * primal + meta.obj_constant;
-    let mapped_dual = meta.sign * dual + meta.obj_constant;
-    if !mapped_primal.is_finite() || !mapped_dual.is_finite() {
-        return (None, None);
-    }
-
-    let relative_gap =
-        (mapped_primal - mapped_dual).abs() / (mapped_primal.abs().max(mapped_dual.abs()) + 1e-10);
-    let gap = relative_gap.is_finite().then_some(relative_gap);
-    (Some(mapped_dual), gap)
+/// convention.
+fn mapped_objective_bound(meta: &Meta, _primal: f64, dual: f64) -> Option<f64> {
+    let transform = ObjectiveTransform { sign: meta.sign, offset: meta.obj_constant };
+    transform.restore(dual)
 }
 
 /// Assemble an `m x n` [`CscMatrix`] from `(row, col, value)` triplets,
@@ -660,11 +669,10 @@ fn map_status(s: SolverStatus) -> TerminationStatus {
     match s {
         SolverStatus::Solved => TerminationStatus::Optimal,
         SolverStatus::AlmostSolved => TerminationStatus::Feasible,
-        SolverStatus::PrimalInfeasible | SolverStatus::AlmostPrimalInfeasible => {
-            TerminationStatus::Infeasible
-        }
-        SolverStatus::DualInfeasible | SolverStatus::AlmostDualInfeasible => {
-            TerminationStatus::Unbounded
+        SolverStatus::PrimalInfeasible => TerminationStatus::Infeasible,
+        SolverStatus::DualInfeasible => TerminationStatus::Unbounded,
+        other @ (SolverStatus::AlmostPrimalInfeasible | SolverStatus::AlmostDualInfeasible) => {
+            TerminationStatus::Other(format!("{other:?}"))
         }
         SolverStatus::MaxIterations => TerminationStatus::IterationLimit,
         SolverStatus::MaxTime => TerminationStatus::TimeLimit,
@@ -735,9 +743,9 @@ pub mod benchmark_support {
     }
 
     pub fn explicit_socs(model: &Model, parallel: bool) -> Result<usize, SolverError> {
-        let arena = model.arena();
-        let socs = model.soc_constraints();
-        explicit_soc_forms(&arena, &socs, Some(parallel)).map(|forms| forms.len())
+        let prepared = LoweringContext::new(model)?;
+        explicit_soc_forms(&prepared, prepared.constraints().second_order_cones(), Some(parallel))
+            .map(|forms| forms.len())
     }
 
     pub fn translate(model: &Model) -> Result<(usize, usize, usize), SolverError> {
@@ -767,8 +775,21 @@ mod tests {
     }
 
     #[test]
+    fn approximate_certificates_do_not_claim_proven_infeasibility() {
+        assert_eq!(map_status(SolverStatus::Solved), TerminationStatus::Optimal);
+        assert_eq!(map_status(SolverStatus::AlmostSolved), TerminationStatus::Feasible);
+        for status in [SolverStatus::AlmostPrimalInfeasible, SolverStatus::AlmostDualInfeasible] {
+            assert_eq!(map_status(status), TerminationStatus::Other(format!("{status:?}")));
+            assert!(!status_has_point(status));
+        }
+        assert_eq!(map_status(SolverStatus::PrimalInfeasible), TerminationStatus::Infeasible);
+        assert_eq!(map_status(SolverStatus::DualInfeasible), TerminationStatus::Unbounded);
+    }
+
+    #[test]
     fn finite_dual_objective_maps_bound_and_gap() {
         let meta = Meta {
+            num_variables: 0,
             sign: -1.0,
             obj_constant: 5.0,
             row_duals: Vec::new(),
@@ -776,14 +797,14 @@ mod tests {
             n_explicit: 0,
         };
 
-        let (bound, gap) = mapped_objective_bound(&meta, -10.0, -8.0);
+        let bound = mapped_objective_bound(&meta, -10.0, -8.0);
         assert_eq!(bound, Some(13.0));
-        assert!(close(gap.unwrap(), 2.0 / 15.0, 1e-12));
     }
 
     #[test]
-    fn nonfinite_objective_leaves_bound_and_gap_unset() {
+    fn nonfinite_primal_does_not_discard_an_independent_finite_bound() {
         let meta = Meta {
+            num_variables: 0,
             sign: 1.0,
             obj_constant: 0.0,
             row_duals: Vec::new(),
@@ -794,7 +815,10 @@ mod tests {
         for (primal, dual) in
             [(f64::NAN, 1.0), (1.0, f64::NAN), (f64::INFINITY, 1.0), (1.0, f64::NEG_INFINITY)]
         {
-            assert_eq!(mapped_objective_bound(&meta, primal, dual), (None, None));
+            assert_eq!(
+                mapped_objective_bound(&meta, primal, dual),
+                dual.is_finite().then_some(dual)
+            );
         }
     }
 

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -43,7 +43,7 @@ pub use set::{
 };
 #[doc(hidden)]
 pub use soc::__detect_soc_from_quadratic;
-pub use soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
+pub use soc::{SocConstraint, SocConstraintId, SocForm};
 pub use sos::{SosConstraint, SosConstraintHandle, SosConstraintId, SosMember, SosType};
 pub use sum::SumDomain;
 pub use var::{VarBuilder, Variable, var_name};

--- a/crates/oximo-core/src/model.rs
+++ b/crates/oximo-core/src/model.rs
@@ -189,7 +189,7 @@ struct PendingSos {
 ///   cone
 /// - `SOCP`: second-order cone constraints are present (explicit
 ///   [`crate::SocConstraint`]s or SOC-shaped quadratic constraints recognized
-///   by [`crate::detect_soc`]); the objective may be linear or quadratic
+///   by the model's structural cone predicate). The objective may be linear or quadratic:
 /// - `QP`: quadratic objective, linear constraints
 /// - `LP`: everything linear
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1860,8 +1860,8 @@ impl Model {
     /// column):
     ///
     /// 1. any nonlinear expression (objective or constraint) -> `NLP`
-    /// 2. any quadratic constraint not recognized as SOC (see
-    ///    [`crate::detect_soc`]) -> `QCP`
+    /// 2. any quadratic constraint not recognized by the structural SOC
+    ///    predicate -> `QCP`
     /// 3. cones present (explicit or detected) -> `SOCP`
     /// 4. quadratic objective -> `QP`
     /// 5. otherwise -> `LP`

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -13,7 +13,7 @@ pub use crate::reformulation::{
     ReformulatedModel, ReformulationError, SosReformulationArtifacts, SosReformulationOptions,
 };
 pub use crate::set::{FromIndexKey, IndexKey, IndexTuple, Set, SetIter};
-pub use crate::soc::{SocConstraint, SocConstraintId, SocForm, detect_soc, explicit_soc_form};
+pub use crate::soc::{SocConstraint, SocConstraintId, SocForm};
 pub use crate::sos::{SosConstraint, SosConstraintHandle, SosConstraintId, SosMember, SosType};
 pub use crate::sum::SumDomain;
 pub use crate::var::{VarBuilder, Variable};

--- a/crates/oximo-core/src/soc.rs
+++ b/crates/oximo-core/src/soc.rs
@@ -1,6 +1,4 @@
-use oximo_expr::{
-    ExprArena, ExprId, LinearTerms, QuadraticTerms, VarId, extract_linear, extract_quadratic,
-};
+use oximo_expr::{ExprArena, ExprId, LinearTerms, QuadraticTerms, VarId, extract_quadratic};
 use smol_str::SmolStr;
 
 use crate::constraint::{Constraint, Sense};
@@ -33,9 +31,7 @@ pub struct SocConstraint {
 
 /// Normalized second-order cone data: `|| A x + a ||_2 <= b'x + beta`, one
 /// [`LinearTerms`] per row of `A x + a` plus one for the bound side. Produced
-/// by [`detect_soc`] (algebraic quadratic constraints) and
-/// [`explicit_soc_form`] ([`SocConstraint`]s), so backends translate both
-/// through a single shape.
+/// by shared solver preparation for algebraic and explicit cones.
 #[derive(Clone, Debug)]
 pub struct SocForm {
     pub terms: Vec<LinearTerms<'static>>,
@@ -78,7 +74,7 @@ fn soc_quadratic(vars: &[Variable], c: &Constraint, q: &QuadraticTerms) -> Optio
 
 /// Whether an algebraic constraint has the supported detected-SOC shape.
 ///
-/// Unlike [`detect_soc`], this does not materialize a [`SocForm`]. Model-kind
+/// This does not materialize a [`SocForm`]. Model-kind
 /// inference only needs this predicate and can avoid allocating one
 /// `LinearTerms` coefficient vector per cone member.
 pub(crate) fn is_detected_soc(arena: &ExprArena, vars: &[Variable], c: &Constraint) -> bool {
@@ -103,14 +99,7 @@ pub(crate) fn is_detected_soc(arena: &ExprArena, vars: &[Variable], c: &Constrai
 /// That is `sum_i p_i x_i^2 <= n t^2` with `t >= 0`, equivalent to
 /// `|| sqrt(p_i/n) x_i ||_2 <= t`. Cross-term (Cholesky-factorized) quadratic
 /// forms are not detected, they classify as QCP instead.
-pub fn detect_soc(arena: &ExprArena, vars: &[Variable], c: &Constraint) -> Option<SocForm> {
-    if !matches!(c.as_single(), Some((Sense::Le, _))) {
-        return None;
-    }
-    let q = extract_quadratic(arena, c.lhs)?;
-    __detect_soc_from_quadratic(vars, c, &q)
-}
-
+///
 /// Backend hook for recognizing a row that has already been decomposed.
 /// `q` must describe `c.lhs` at the current parameter values.
 #[doc(hidden)]
@@ -132,18 +121,5 @@ pub fn __detect_soc_from_quadratic(
         })
         .collect();
     let bound = LinearTerms { coeffs: vec![(t, 1.0)].into(), constant: 0.0 };
-    Some(SocForm { terms, bound })
-}
-
-/// The normalized [`SocForm`] view of an explicit [`SocConstraint`]. Members
-/// are validated affine at registration, so this only returns `None` on a
-/// corrupted model (e.g. an `ExprId` from a different arena).
-pub fn explicit_soc_form(arena: &ExprArena, s: &SocConstraint) -> Option<SocForm> {
-    let terms = s
-        .terms
-        .iter()
-        .map(|&e| extract_linear(arena, e).map(LinearTerms::into_owned))
-        .collect::<Option<Vec<_>>>()?;
-    let bound = extract_linear(arena, s.bound).map(LinearTerms::into_owned)?;
     Some(SocForm { terms, bound })
 }

--- a/crates/oximo-core/tests/soc.rs
+++ b/crates/oximo-core/tests/soc.rs
@@ -1,4 +1,4 @@
-//! Tests for SOC pattern detection (`detect_soc`) and the normalized
+//! Tests for SOC pattern detection (polynomial recognition) and the normalized
 //! `SocForm` views backends translate from.
 
 #![expect(clippy::float_cmp)]
@@ -10,11 +10,8 @@ fn detect_first(m: &Model) -> Option<SocForm> {
     let vars = m.variables();
     let model_constraints = m.constraints();
     let constraints = model_constraints.algebraic();
-    let form = detect_soc(&arena, &vars, &constraints[0]);
-    let reused = oximo_expr::extract_quadratic(&arena, constraints[0].lhs)
-        .and_then(|q| oximo_core::__detect_soc_from_quadratic(&vars, &constraints[0], &q));
-    assert_eq!(format!("{form:?}"), format!("{reused:?}"));
-    form
+    oximo_expr::extract_quadratic(&arena, constraints[0].lhs)
+        .and_then(|q| oximo_core::__detect_soc_from_quadratic(&vars, &constraints[0], &q))
 }
 
 #[test]
@@ -100,22 +97,4 @@ fn rejects_unsigned_bound_variable() {
     variable!(m, t);
     constraint!(m, c, x * x <= t * t);
     assert!(detect_first(&m).is_none());
-}
-
-#[test]
-fn explicit_form_recovers_affine_rows() {
-    let m = Model::new("soc");
-    variable!(m, x);
-    variable!(m, y);
-    variable!(m, t >= 0.0);
-    m.add_soc_constraint("cone", [x - y, 2.0 * y + 1.0], t);
-
-    let arena = m.arena();
-    let model_constraints = m.constraints();
-    let socs = model_constraints.second_order_cones();
-    let form = explicit_soc_form(&arena, &socs[0]).expect("affine members");
-    assert_eq!(form.terms.len(), 2);
-    assert_eq!(form.terms[0].coeffs.len(), 2);
-    assert_eq!(form.terms[1].constant, 1.0);
-    assert_eq!(form.bound.coeffs, vec![(m.variable_id("t").unwrap(), 1.0)]);
 }

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -1,3 +1,5 @@
+use oximo_solver::prepare::{LoweringContext, PreparedExpressions};
+use oximo_solver::reconstruct::normalize_result;
 use std::borrow::Cow;
 use std::fmt::Write as FmtWrite;
 use std::path::{Path, PathBuf};
@@ -12,7 +14,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, Objective, ObjectiveSense, Sense,
     SocConstraint, SocConstraintId, SosConstraint, SosMember, SosType, VarId, Variable,
 };
-use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, extract_linear};
+use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms};
 use oximo_solver::{
     DualStatus, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
 };
@@ -41,16 +43,15 @@ pub fn solve(
     opts: &GamsOptions,
     exec: Option<&str>,
 ) -> Result<SolverResult, SolverError> {
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let kind = model.kind();
+    let prepared = LoweringContext::new(model)?;
+    let kind = prepared.kind();
     validate_solver(opts, kind)?;
-    let arena = model.arena();
-    let vars = model.variables();
-    let model_constraints = model.constraints();
+    let vars = prepared.variables();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
-    let socs = model.soc_constraints();
-    let sos_constraints = model.sos_constraints();
-    let objective = model.objective();
+    let socs = prepared.constraints().second_order_cones();
+    let sos_constraints = prepared.constraints().special_ordered_sets();
+    let objective = prepared.objective();
     let sense = objective.as_ref().map_or(ObjectiveSense::Minimize, |o| o.sense);
 
     let sense_kw = match sense {
@@ -62,12 +63,12 @@ pub fn solve(
     let solver_opt = build_model_section(
         &mut gms,
         kind,
-        &arena,
-        &vars,
+        &prepared,
+        vars,
         constraints,
-        &socs,
-        &sos_constraints,
-        objective.as_ref(),
+        socs,
+        sos_constraints,
+        objective,
         sense_kw,
         opts,
     );
@@ -120,15 +121,8 @@ pub fn solve(
     // solve (see `parseoximo_solution`).
     let soc_bounds: Vec<LinearTerms<'static>> = socs
         .iter()
-        .map(|s| {
-            extract_linear(&arena, s.bound).expect("SOC bound is validated affine").into_owned()
-        })
+        .map(|s| prepared.linear(s.bound).expect("SOC bound is validated affine").into_owned())
         .collect();
-
-    drop(arena);
-    drop(vars);
-    drop(socs);
-    drop(sos_constraints);
 
     // - Write .gms file
     let gms_path = tmp_dir.join("model.gms");
@@ -205,7 +199,7 @@ pub fn solve(
                 | ModelKind::MINLP
         );
         let mut result =
-            parseoximo_solution(&content, &soc_bounds, mixed_integer, elapsed, raw_log);
+            parseoximo_solution(&content, &soc_bounds, mixed_integer, vars.len(), elapsed, raw_log);
         // If a sub-solver wrote a solution pool (e.g. CPLEX `solnpool`), surface
         // every pooled point. The model itself emits no GDX, so any pool GDX in
         // the run directory came from the user's option file.
@@ -232,7 +226,7 @@ pub fn solve(
 
     let _ = fs::remove_dir_all(&tmp_dir);
     result.solver_name = Some(gams_solver_label(opts));
-    Ok(result)
+    Ok(normalize_result(result, vars.len()))
 }
 
 /// Backend label for the result: `GAMS/<sub-solver>` when a sub-solver is
@@ -304,6 +298,7 @@ fn parseoximo_solution(
     content: &str,
     soc_bounds: &[LinearTerms<'_>],
     mixed_integer: bool,
+    num_variables: usize,
     elapsed: std::time::Duration,
     raw_log: Option<String>,
 ) -> SolverResult {
@@ -329,7 +324,12 @@ fn parseoximo_solution(
         } else if let Some(rest) = line.strip_prefix("OBJVAL=") {
             obj_val = parse_gams_float(rest);
         } else if let Some(rest) = line.strip_prefix("OBJEST=") {
-            best_bound = parse_gams_float(rest);
+            // GAMS defines `objEst` as a best-possible-objective estimate for
+            // mixed-integer models. It is not a generic certified bound for
+            // continuous LP/QP/NLP solves.
+            if mixed_integer {
+                best_bound = parse_gams_float(rest);
+            }
         } else if let Some(rest) = line.strip_prefix("NODUSD=") {
             node_count = parse_gams_u64(rest);
         } else if let Some(rest) = line.strip_prefix("MARGINALS=") {
@@ -386,12 +386,11 @@ fn parseoximo_solution(
         for (i, bound) in soc_bounds.iter().enumerate() {
             let idx = u32::try_from(i).expect("SOC count overflow");
             if let Some(m) = soc_marginals.get(&idx) {
-                let b_val = bound.constant
-                    + bound
-                        .coeffs
-                        .iter()
-                        .map(|&(v, c)| c * primal.get(&v).copied().unwrap_or(0.0))
-                        .sum::<f64>();
+                let Some(b_val) = bound.coeffs.iter().try_fold(bound.constant, |sum, &(v, c)| {
+                    primal.get(&v).map(|value| sum + c * value)
+                }) else {
+                    continue;
+                };
                 soc_dual.insert(SocConstraintId(idx), 2.0 * b_val * m.abs());
             }
         }
@@ -401,48 +400,38 @@ fn parseoximo_solution(
     // a sub-solver solution pool (if one was written) read from the run dir's GDX.
     let solutions =
         if has_sol { vec![SolutionPoint { primal, objective: obj_val }] } else { Vec::new() };
-    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
-    let mut gap = match (obj_val, best_bound) {
-        (Some(objective), Some(bound)) if objective.is_finite() && bound.is_finite() => {
-            let scale = objective.abs().max(bound.abs()) + 1e-10;
-            let gap = (objective / scale - bound / scale).abs();
-            gap.is_finite().then_some(gap)
-        }
-        _ => None,
-    };
-    if modelstat == 1 && solvestat == 1 {
-        best_bound = best_bound.or(obj_val);
-        gap = Some(0.0);
-    }
-    SolverResult {
-        solutions,
-        dual: if has_sol { dual } else { FxHashMap::default() },
-        soc_dual,
-        reduced_costs: if has_sol { reduced_costs } else { FxHashMap::default() },
-        termination,
-        primal_status,
-        dual_status: match marginals {
-            Some(true) if has_sol => DualStatus::FeasiblePoint,
-            Some(_) => DualStatus::NoSolution,
-            None => DualStatus::Unknown,
+    normalize_result(
+        SolverResult {
+            solutions,
+            dual: if has_sol { dual } else { FxHashMap::default() },
+            soc_dual,
+            reduced_costs: if has_sol { reduced_costs } else { FxHashMap::default() },
+            termination,
+            primal_status: PrimalStatus::NoSolution,
+            dual_status: match marginals {
+                Some(true) if has_sol => DualStatus::FeasiblePoint,
+                Some(_) => DualStatus::NoSolution,
+                None => DualStatus::Unknown,
+            },
+            best_bound,
+            gap: None,
+            solve_time: elapsed,
+            iterations,
+            node_count: mixed_integer.then_some(node_count).flatten(),
+            raw_status: Some(
+                format!(
+                    "modelstat={modelstat} ({}), solvestat={solvestat} ({})",
+                    model_status_label(modelstat),
+                    solve_status_label(solvestat)
+                )
+                .into(),
+            ),
+            raw_log,
+            solver_name: Some(crate::NAME.into()),
+            solver_version,
         },
-        best_bound,
-        gap,
-        solve_time: elapsed,
-        iterations,
-        node_count: mixed_integer.then_some(node_count).flatten(),
-        raw_status: Some(
-            format!(
-                "modelstat={modelstat} ({}), solvestat={solvestat} ({})",
-                model_status_label(modelstat),
-                solve_status_label(solvestat)
-            )
-            .into(),
-        ),
-        raw_log,
-        solver_name: Some(crate::NAME.into()),
-        solver_version,
-    }
+        num_variables,
+    )
 }
 
 /// Read a sub-solver solution pool from the GAMS run directory.
@@ -596,11 +585,11 @@ fn map_status(modelstat: i32, solvestat: i32) -> TerminationStatus {
 /// <https://www.gams.com/latest/docs/apis/python/classgams_1_1control_1_1workspace_1_1ModelStat.html>
 fn modelstat_termination(modelstat: i32) -> TerminationStatus {
     match modelstat {
-        1 | 8 | 15 | 16 | 17 => TerminationStatus::Optimal,
+        1 => TerminationStatus::Optimal,
         2 => TerminationStatus::LocallyOptimal,
-        7 => TerminationStatus::Feasible,
+        7 | 8 | 15 | 16 | 17 => TerminationStatus::Feasible,
         3 | 18 => TerminationStatus::Unbounded,
-        4 | 6 | 10 | 19 => TerminationStatus::Infeasible,
+        4 | 10 | 19 => TerminationStatus::Infeasible,
         5 => TerminationStatus::LocallyInfeasible,
         11 => TerminationStatus::LicenseError,
         n => TerminationStatus::Other(format!("gams_modelstat_{n}")),
@@ -667,7 +656,7 @@ fn solve_status_label(status: i32) -> &'static str {
 fn build_model_section(
     gms: &mut String,
     kind: ModelKind,
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     vars: &[Variable],
     constraints: &[Constraint],
     socs: &[SocConstraint],
@@ -683,7 +672,7 @@ fn build_model_section(
     write_var_declarations(gms, vars);
     write_sos_declarations(gms, sos_constraints);
     write_bounds_and_initials(gms, vars, sos_constraints);
-    write_equations(gms, arena, constraints, socs, sos_constraints, objective);
+    write_equations(gms, prepared, constraints, socs, sos_constraints, objective);
     write_options(gms, opts, solve_type);
     write_model_and_solve(gms, solve_type, sense_kw, solver_opt.is_some());
 
@@ -878,12 +867,13 @@ fn write_var_bounds(gms: &mut String, v: &Variable) {
 
 fn write_equations(
     gms: &mut String,
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     constraints: &[Constraint],
     socs: &[SocConstraint],
     sos_constraints: &[SosConstraint],
     objective: Option<&Objective>,
 ) {
+    let arena = prepared.arena();
     write!(gms, "Equations\n    eq_obj").unwrap();
     for (i, c) in constraints.iter().enumerate() {
         if c.as_single().is_some() {
@@ -906,7 +896,7 @@ fn write_equations(
     match objective {
         None => writeln!(gms, "eq_obj..  v_obj =e= 0;").unwrap(),
         Some(obj) => {
-            let obj_form = ExprForm::from(arena, obj.expr);
+            let obj_form = ExprForm::prepared(prepared, obj.expr);
             write!(gms, "eq_obj..  v_obj =e=").unwrap();
             write_form(gms, arena, &obj_form, true);
             writeln!(gms, ";").unwrap();
@@ -921,7 +911,7 @@ fn write_equations(
                 Sense::Eq => "=e=",
             };
             write!(gms, "eq_c{ci}..").unwrap();
-            match ExprForm::from(arena, c.lhs) {
+            match ExprForm::prepared(prepared, c.lhs) {
                 ExprForm::Linear(t) => {
                     let adjusted_rhs = rhs - t.constant;
                     write_linear(gms, &t, false);
@@ -933,7 +923,7 @@ fn write_equations(
                 }
             }
         } else {
-            match ExprForm::from(arena, c.lhs) {
+            match ExprForm::prepared(prepared, c.lhs) {
                 ExprForm::Linear(t) => {
                     let lo = c.lower - t.constant;
                     let hi = c.upper - t.constant;
@@ -955,7 +945,7 @@ fn write_equations(
             }
         }
     }
-    write_soc_equations(gms, arena, socs);
+    write_soc_equations(gms, prepared, socs);
     write_sos_link_equations(gms, sos_constraints);
     writeln!(gms).unwrap();
 }
@@ -990,19 +980,19 @@ fn ordered_sos_members(constraint: &SosConstraint) -> Vec<&SosMember> {
 /// Emit each explicit SOC constraint `||terms||_2 <= bound` as the quadratic
 /// row `sqr(term_1) + ... =l= sqr(bound)` plus the sign row `bound =g= 0`
 /// (squaring loses the sign of the bound side).
-fn write_soc_equations(gms: &mut String, arena: &ExprArena, socs: &[SocConstraint]) {
+fn write_soc_equations(gms: &mut String, prepared: &PreparedExpressions, socs: &[SocConstraint]) {
     for (i, s) in socs.iter().enumerate() {
         write!(gms, "eq_soc{i}.. ").unwrap();
         for (k, &term) in s.terms.iter().enumerate() {
             if k > 0 {
                 write!(gms, " +").unwrap();
             }
-            let t = extract_linear(arena, term).expect("SOC members are validated affine");
+            let t = prepared.linear(term).expect("SOC members are validated affine");
             write!(gms, " sqr(").unwrap();
             write_linear(gms, &t, true);
             write!(gms, " )").unwrap();
         }
-        let b = extract_linear(arena, s.bound).expect("SOC bound is validated affine");
+        let b = prepared.linear(s.bound).expect("SOC bound is validated affine");
         write!(gms, " =l= sqr(").unwrap();
         write_linear(gms, &b, true);
         writeln!(gms, " );").unwrap();
@@ -1024,16 +1014,13 @@ fn write_model_and_solve(gms: &mut String, solve_type: &str, sense_kw: &str, has
 
 /// Captured form of an expression for GAMS emission.
 enum ExprForm<'a> {
-    Linear(LinearTerms<'a>),
+    Linear(oximo_solver::prepare::AffineTerms<'a>),
     Nonlinear(ExprId),
 }
 
 impl<'a> ExprForm<'a> {
-    fn from(arena: &'a ExprArena, id: ExprId) -> Self {
-        match extract_linear(arena, id) {
-            Some(t) => ExprForm::Linear(t),
-            None => ExprForm::Nonlinear(id),
-        }
+    fn prepared(prepared: &'a PreparedExpressions, id: ExprId) -> Self {
+        prepared.linear(id).map_or(Self::Nonlinear(id), Self::Linear)
     }
 }
 
@@ -1218,7 +1205,8 @@ fn parse_gams_float(s: &str) -> Option<f64> {
 
 #[cfg(feature = "benchmark-support")]
 #[doc(hidden)]
-#[expect(clippy::cast_precision_loss, clippy::wildcard_imports)]
+#[expect(clippy::cast_precision_loss)]
+#[allow(clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
     use rayon::prelude::*;
@@ -1246,7 +1234,7 @@ pub mod benchmark_support {
     }
 
     pub fn render_equations(model: &Model, parallel: bool) -> String {
-        let arena = model.arena().clone();
+        let arena = PreparedExpressions::new((*model.arena()).clone());
         let constraints = model.constraints().algebraic().to_vec();
         let socs = model.soc_constraints().clone();
         let mut out = String::new();
@@ -1260,7 +1248,7 @@ pub mod benchmark_support {
 
     fn write_parallel(
         out: &mut String,
-        arena: &ExprArena,
+        arena: &PreparedExpressions,
         constraints: &[Constraint],
         socs: &[SocConstraint],
     ) {
@@ -1289,7 +1277,7 @@ pub mod benchmark_support {
         writeln!(out).unwrap();
     }
 
-    fn constraint_fragment(arena: &ExprArena, index: usize, c: &Constraint) -> String {
+    fn constraint_fragment(arena: &PreparedExpressions, index: usize, c: &Constraint) -> String {
         let mut out = String::new();
         if let Some((sense, rhs)) = c.as_single() {
             let sense = match sense {
@@ -1298,7 +1286,7 @@ pub mod benchmark_support {
                 Sense::Eq => "=e=",
             };
             write!(out, "eq_c{index}..").unwrap();
-            match ExprForm::from(arena, c.lhs) {
+            match ExprForm::prepared(arena, c.lhs) {
                 ExprForm::Linear(terms) => {
                     write_linear(&mut out, &terms, false);
                     writeln!(out, " {sense} {};", fmt(rhs - terms.constant)).unwrap();
@@ -1309,7 +1297,7 @@ pub mod benchmark_support {
                 }
             }
         } else {
-            match ExprForm::from(arena, c.lhs) {
+            match ExprForm::prepared(arena, c.lhs) {
                 ExprForm::Linear(terms) => {
                     write!(out, "eq_c{index}_lo..").unwrap();
                     write_linear(&mut out, &terms, false);
@@ -1338,7 +1326,7 @@ mod tests {
     use oximo_core::prelude::*;
 
     fn render(model: &Model, opts: &GamsOptions) -> String {
-        let arena = model.arena();
+        let _arena = model.arena();
         let vars = model.variables();
         let model_constraints = model.constraints();
         let constraints = model_constraints.algebraic();
@@ -1353,7 +1341,7 @@ mod tests {
         build_model_section(
             &mut gms,
             model.kind(),
-            &arena,
+            &LoweringContext::new(model).unwrap(),
             &vars,
             constraints,
             &socs,
@@ -1369,21 +1357,21 @@ mod tests {
     fn parses_iterations_from_put_file() {
         // The PUT solution file emits `ITER=` from `oximo_m.iterusd`.
         let content = "STATUS=1\nSOLVESTAT=1\nITER=42\nOBJVAL=10.0\n0=2.5\n";
-        let r = parseoximo_solution(content, &[], false, std::time::Duration::ZERO, None);
+        let r = parseoximo_solution(content, &[], false, 1, std::time::Duration::ZERO, None);
         assert_eq!(r.termination, TerminationStatus::Optimal);
         assert_eq!(r.iterations, 42);
         assert_eq!(r.best_bound, Some(10.0));
-        assert_eq!(r.gap, Some(0.0));
+        assert_eq!(r.gap, None);
         assert!(r.raw_status.as_deref().unwrap().contains("modelstat=1 (optimal)"));
     }
 
     #[test]
     fn parses_bound_nodes_marginals_and_solver_version() {
         let content = "STATUS=8\nSOLVESTAT=3\nOBJVAL=10\nOBJEST=8\nNODUSD=17\nMARGINALS=1\nSOLVER_VERSION=13.0.1\n0=2.5\nD0=1.0\n";
-        let r = parseoximo_solution(content, &[], true, std::time::Duration::ZERO, None);
+        let r = parseoximo_solution(content, &[], true, 1, std::time::Duration::ZERO, None);
         assert_eq!(r.termination, TerminationStatus::TimeLimit);
         assert_eq!(r.best_bound, Some(8.0));
-        assert!((r.gap.unwrap() - 0.2).abs() < 1e-9);
+        assert_eq!(r.gap, None);
         assert_eq!(r.node_count, Some(17));
         assert_eq!(r.dual_status, DualStatus::FeasiblePoint);
         assert_eq!(r.solver_version.as_deref(), Some("13.0.1"));
@@ -1393,30 +1381,65 @@ mod tests {
     #[test]
     fn integer_solution_status_keeps_reported_gap() {
         let content = "STATUS=8\nSOLVESTAT=1\nOBJVAL=10\nOBJEST=8\n0=2.5\n";
-        let r = parseoximo_solution(content, &[], true, std::time::Duration::ZERO, None);
-        assert_eq!(r.termination, TerminationStatus::Optimal);
+        let r = parseoximo_solution(content, &[], true, 1, std::time::Duration::ZERO, None);
+        assert_eq!(r.termination, TerminationStatus::Feasible);
         assert_eq!(r.best_bound, Some(8.0));
-        assert!((r.gap.unwrap() - 0.2).abs() < 1e-9);
+        assert_eq!(r.gap, None);
+    }
+
+    #[test]
+    fn feasible_model_statuses_do_not_synthesize_global_bounds() {
+        for status in [7, 8, 15, 16, 17] {
+            let content = format!("STATUS={status}\nSOLVESTAT=1\nOBJVAL=10\n0=2.5\n");
+            let result =
+                parseoximo_solution(&content, &[], false, 1, std::time::Duration::ZERO, None);
+            assert_eq!(result.termination, TerminationStatus::Feasible);
+            assert_eq!(result.primal_status, PrimalStatus::FeasiblePoint);
+            assert_eq!(result.best_bound, None);
+            assert_eq!(result.gap, None);
+        }
+        let result = parseoximo_solution(
+            "STATUS=6\nSOLVESTAT=1\nOBJVAL=10\n0=2.5\n",
+            &[],
+            false,
+            1,
+            std::time::Duration::ZERO,
+            None,
+        );
+        assert_eq!(result.termination, TerminationStatus::Other("gams_modelstat_6".into()));
+        assert!(!result.has_solution());
+    }
+
+    #[test]
+    fn time_limit_uses_model_status_as_point_evidence() {
+        for (status, has_point) in [(8, true), (14, false)] {
+            let content = format!("STATUS={status}\nSOLVESTAT=3\nOBJVAL=10\nOBJEST=8\n0=2.5\n");
+            let result =
+                parseoximo_solution(&content, &[], true, 1, std::time::Duration::ZERO, None);
+            assert_eq!(result.termination, TerminationStatus::TimeLimit);
+            assert_eq!(result.has_solution(), has_point);
+            assert!(result.gap.is_none());
+            assert_eq!(result.best_bound, Some(8.0));
+            assert!(result.dual.is_empty());
+        }
     }
 
     #[test]
     fn extreme_objective_bound_gap_does_not_overflow() {
         let content =
             format!("STATUS=8\nSOLVESTAT=3\nOBJVAL={}\nOBJEST={}\n0=2.5\n", f64::MAX, -f64::MAX);
-        let r = parseoximo_solution(&content, &[], true, std::time::Duration::ZERO, None);
+        let r = parseoximo_solution(&content, &[], true, 1, std::time::Duration::ZERO, None);
         assert_eq!(r.best_bound, Some(-f64::MAX));
-        let gap = r.gap.expect("finite extreme gap");
-        assert!(gap.is_finite());
-        assert!((gap - 2.0).abs() < 1e-12);
+        assert_eq!(r.gap, None);
     }
 
     #[test]
-    fn continuous_objest_bound_is_preserved() {
+    fn continuous_objest_is_not_treated_as_a_global_bound() {
         let content = "STATUS=7\nSOLVESTAT=3\nOBJVAL=10\nOBJEST=8\n0=2.5\n";
-        let r = parseoximo_solution(content, &[], false, std::time::Duration::ZERO, None);
+        let r = parseoximo_solution(content, &[], false, 1, std::time::Duration::ZERO, None);
         assert_eq!(r.termination, TerminationStatus::TimeLimit);
-        assert_eq!(r.best_bound, Some(8.0));
-        assert!((r.gap.unwrap() - 0.2).abs() < 1e-9);
+        assert_eq!(r.best_bound, None);
+        assert_eq!(r.gap, None);
         assert_eq!(r.node_count, None);
     }
 
@@ -1424,7 +1447,7 @@ mod tests {
     fn missing_objest_tokens_remain_unset() {
         for token in ["NA", "UNDF"] {
             let content = format!("STATUS=8\nSOLVESTAT=3\nOBJVAL=10\nOBJEST={token}\n0=2.5\n");
-            let r = parseoximo_solution(&content, &[], false, std::time::Duration::ZERO, None);
+            let r = parseoximo_solution(&content, &[], false, 1, std::time::Duration::ZERO, None);
             assert_eq!(r.best_bound, None, "OBJEST={token}");
             assert_eq!(r.gap, None, "OBJEST={token}");
         }
@@ -1432,9 +1455,9 @@ mod tests {
 
     #[test]
     fn soc_marginal_is_rescaled_to_norm_form() {
-        let content = "STATUS=1\nSOLVESTAT=1\nOBJVAL=-1.0\n0=-1.0\n1=1.5\nZ0=-0.75\n";
+        let content = "STATUS=1\nSOLVESTAT=1\nOBJVAL=-1.0\nMARGINALS=1\n0=-1.0\n1=1.5\nZ0=-0.75\n";
         let bounds = vec![LinearTerms { coeffs: vec![(VarId(1), 1.0)].into(), constant: 0.5 }];
-        let r = parseoximo_solution(content, &bounds, false, std::time::Duration::ZERO, None);
+        let r = parseoximo_solution(content, &bounds, false, 2, std::time::Duration::ZERO, None);
         let z0 = r.soc_dual_of(SocConstraintId(0)).expect("SOC dual missing");
         assert!((z0 - 3.0).abs() < 1e-9, "z0 = {z0}");
     }
@@ -1455,7 +1478,7 @@ mod tests {
         assert_eq!(map_status(2, 1), TerminationStatus::LocallyOptimal);
         assert_eq!(map_status(7, 1), TerminationStatus::Feasible);
         assert_eq!(map_status(9, 1), TerminationStatus::Other("gams_modelstat_9".into()));
-        assert_eq!(map_status(8, 1), TerminationStatus::Optimal);
+        assert_eq!(map_status(8, 1), TerminationStatus::Feasible);
         assert_eq!(map_status(4, 1), TerminationStatus::Infeasible);
         assert_eq!(map_status(3, 1), TerminationStatus::Unbounded);
         assert_eq!(map_status(8, 2), TerminationStatus::IterationLimit);

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -1,3 +1,5 @@
+use oximo_solver::prepare::{LoweringContext, PreparedExpressions};
+use oximo_solver::reconstruct::{ObjectiveTransform, normalize_result};
 use std::time::Instant;
 
 use gurobi_rs::constr::RangeExpr;
@@ -7,7 +9,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, ObjectiveSense, Sense, SocConstraint,
     SocConstraintId, SosConstraint, SosConstraintId, SosType, VarId, Variable, var_name,
 };
-use oximo_expr::{ExprArena, ExprId, LinearTerms, describe_nonlinear_term, extract_linear};
+use oximo_expr::{ExprArena, ExprId, LinearTerms, describe_nonlinear_term};
 use oximo_solver::{
     DualStatus, Iis, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
     VarBoundKind,
@@ -66,8 +68,8 @@ pub(crate) struct Built {
 /// Returns a [`SolverError`] if the model contains nonlinear expressions Gurobi
 /// cannot represent or Gurobi reports an error during setup.
 pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Built, SolverError> {
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let kind = model.kind();
+    let prepared = LoweringContext::new(model)?;
+    let kind = prepared.kind();
     let nonlinear_kind = matches!(
         kind,
         ModelKind::QP
@@ -78,30 +80,29 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
             | ModelKind::MINLP
     );
 
-    let arena = model.arena();
-    let vars = model.variables();
-    let model_constraints = model.constraints();
+    let vars = prepared.variables();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
-    let socs = model.soc_constraints();
-    let sos = model.sos_constraints();
-    let objective = model.objective();
+    let socs = prepared.constraints().second_order_cones();
+    let sos = prepared.constraints().special_ordered_sets();
+    let objective = prepared.objective();
     let has_semi = vars.iter().any(|v| v.domain.semi_threshold().is_some());
 
     let mut gurobi_model = gurobi_rs::Model::with_env("oximo", env).map_err(map_gurobi_err)?;
 
-    let gurobi_vars = add_variables(&mut gurobi_model, &vars)?;
+    let gurobi_vars = add_variables(&mut gurobi_model, vars)?;
 
     // Aux-variable counter shared by the constraint and objective lowering so the
     // synthetic variable names stay unique across both.
     let mut aux_counter = 0_u32;
     let gurobi_constrs =
-        add_constraints(&arena, constraints, &mut gurobi_model, &gurobi_vars, &mut aux_counter)?;
-    let soc_rows = add_soc_rows(&arena, &vars, &socs, &mut gurobi_model, &gurobi_vars)?;
-    let special_ordered_sets = add_sos_constraints(&sos, &mut gurobi_model, &gurobi_vars)?;
+        add_constraints(&prepared, constraints, &mut gurobi_model, &gurobi_vars, &mut aux_counter)?;
+    let soc_rows = add_soc_rows(&prepared, vars, socs, &mut gurobi_model, &gurobi_vars)?;
+    let special_ordered_sets = add_sos_constraints(sos, &mut gurobi_model, &gurobi_vars)?;
 
     let (obj_constant, objective_generated) = match objective.as_ref() {
         Some(o) => set_objective(
-            &arena,
+            &prepared,
             o.expr,
             o.sense,
             &mut gurobi_model,
@@ -114,7 +115,7 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
     // Warm starts are assigned only after the full structural model has been
     // built. This keeps the batch variable construction and the start vector
     // compatible with Gurobi's pending-update rules.
-    apply_initial_values(&gurobi_model, &vars, &gurobi_vars)?;
+    apply_initial_values(&gurobi_model, vars, &gurobi_vars)?;
 
     apply_options(&mut gurobi_model, opts).map_err(map_gurobi_err)?;
     if nonlinear_kind && !opts.has_non_convex() {
@@ -188,13 +189,7 @@ fn collect_after_optimize(
         built.obj_constant,
     );
 
-    let primal_status = PrimalStatus::infer(&termination, !solutions.is_empty());
-    let mut best_bound = built.model.get_attr(attr::ObjBound).ok().filter(|b| b.is_finite());
-    let mut gap = built.model.get_attr(attr::MIPGap).ok().filter(|g| g.is_finite());
-    if matches!(termination, TerminationStatus::Optimal) {
-        best_bound = best_bound.or_else(|| solutions.first().and_then(|point| point.objective));
-        gap = gap.or(Some(0.0));
-    }
+    let best_bound = built.model.get_attr(attr::ObjBound).ok().filter(|b| b.is_finite());
     #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let node_count = matches!(
         kind,
@@ -206,24 +201,27 @@ fn collect_after_optimize(
     .map(|count| count as u64);
     let (major, minor, technical) = gurobi_rs::version();
 
-    Ok(SolverResult {
-        termination,
-        primal_status,
-        dual_status: collected_dual_status(kind, dual_available, !solutions.is_empty()),
-        solutions,
-        dual,
-        soc_dual,
-        reduced_costs,
-        best_bound,
-        gap,
-        solve_time: elapsed,
-        iterations,
-        node_count,
-        raw_status: Some(format!("{native_status:?}").into()),
-        raw_log: None,
-        solver_name: Some(crate::NAME.into()),
-        solver_version: Some(format!("{major}.{minor}.{technical}").into()),
-    })
+    Ok(normalize_result(
+        SolverResult {
+            termination,
+            primal_status: PrimalStatus::NoSolution,
+            dual_status: collected_dual_status(kind, dual_available, !solutions.is_empty()),
+            solutions,
+            dual,
+            soc_dual,
+            reduced_costs,
+            best_bound,
+            gap: built.model.get_attr(attr::MIPGap).ok(),
+            solve_time: elapsed,
+            iterations,
+            node_count,
+            raw_status: Some(format!("{native_status:?}").into()),
+            raw_log: None,
+            solver_name: Some(crate::NAME.into()),
+            solver_version: Some(format!("{major}.{minor}.{technical}").into()),
+        },
+        built.vars.len(),
+    ))
 }
 
 /// Build, optimize with a callback, and collect the ordinary solver result.
@@ -483,12 +481,13 @@ pub(crate) struct SocHandle {
 /// and falls back to the general lowering otherwise.
 #[expect(clippy::too_many_lines)]
 fn add_constraints(
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     constraints: &[Constraint],
     gurobi_model: &mut gurobi_rs::Model,
     gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
 ) -> Result<Vec<ConstraintHandle>, SolverError> {
+    let arena = prepared.arena();
     struct PendingSingle {
         index: usize,
         name: String,
@@ -511,7 +510,7 @@ fn add_constraints(
 
     for (index, c) in constraints.iter().enumerate() {
         if let Some((sense, rhs)) = c.as_single() {
-            if let Some(t) = extract_linear(arena, c.lhs) {
+            if let Some(t) = prepared.linear(c.lhs) {
                 let mut expr = LinExpr::new();
                 for &(v, coeff) in t.coeffs.iter() {
                     expr.add_term(coeff, gurobi_vars[v.index()]);
@@ -527,7 +526,7 @@ fn add_constraints(
                 nonlinear.push(index);
             }
         } else if c.is_range() {
-            if let Some(t) = extract_linear(arena, c.lhs) {
+            if let Some(t) = prepared.linear(c.lhs) {
                 let mut expr = LinExpr::new();
                 for &(v, coeff) in t.coeffs.iter() {
                     expr.add_term(coeff, gurobi_vars[v.index()]);
@@ -624,24 +623,25 @@ fn add_constraints(
 /// `SocConstraintId` order, so `collect_solution` can rescale the squared-form
 /// `QCPi` multiplier back to the norm form.
 fn add_soc_rows(
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     vars: &[Variable],
     socs: &[SocConstraint],
     gurobi_model: &mut gurobi_rs::Model,
     gurobi_vars: &[gurobi_rs::Var],
 ) -> Result<Vec<SocHandle>, SolverError> {
+    let arena = prepared.arena();
     let mut rows = Vec::with_capacity(socs.len());
     for (i, s) in socs.iter().enumerate() {
         let mut q = QuadExpr::new();
         for &term in &s.terms {
-            let t = extract_linear(arena, term).ok_or_else(|| SolverError::Nonlinear {
+            let t = prepared.linear(term).ok_or_else(|| SolverError::Nonlinear {
                 location: format!("second-order cone {:?} term {i}", s.name),
                 term: describe_nonlinear_term(arena, term, &|v| var_name(vars, v))
                     .unwrap_or_else(|| "<nonlinear>".into()),
             })?;
             add_squared_affine(&mut q, &t, 1.0, gurobi_vars);
         }
-        let b = extract_linear(arena, s.bound).ok_or_else(|| SolverError::Nonlinear {
+        let b = prepared.linear(s.bound).ok_or_else(|| SolverError::Nonlinear {
             location: format!("second-order cone {:?} bound", s.name),
             term: describe_nonlinear_term(arena, s.bound, &|v| var_name(vars, v))
                 .unwrap_or_else(|| "<nonlinear>".into()),
@@ -756,18 +756,19 @@ fn add_comparison_rows(
 }
 
 fn set_objective(
-    arena: &ExprArena,
+    prepared: &PreparedExpressions,
     obj_expr: ExprId,
     sense: ObjectiveSense,
     gurobi_model: &mut gurobi_rs::Model,
     gurobi_vars: &[gurobi_rs::Var],
     aux_counter: &mut u32,
 ) -> Result<(f64, Vec<GeneratedConstraint>), SolverError> {
+    let arena = prepared.arena();
     let gurobi_sense = match sense {
         ObjectiveSense::Minimize => ModelSense::Minimize,
         ObjectiveSense::Maximize => ModelSense::Maximize,
     };
-    if let Some(t) = extract_linear(arena, obj_expr) {
+    if let Some(t) = prepared.linear(obj_expr) {
         let mut e = LinExpr::new();
         for &(v, c) in t.coeffs.iter() {
             e.add_term(c, gurobi_vars[v.index()]);
@@ -932,7 +933,10 @@ fn collect_pool(
         let Ok(vals) = model.get_obj_attr_batch(attr::Xn, vars.iter().copied()) else {
             break;
         };
-        let objective = model.get_attr(attr::PoolObjVal).ok().map(|v| v + obj_constant);
+        let objective = model
+            .get_attr(attr::PoolObjVal)
+            .ok()
+            .and_then(|v| ObjectiveTransform { sign: 1.0, offset: obj_constant }.restore(v));
         out.push(SolutionPoint { primal: index_map(&vals), objective });
     }
     if out.is_empty() {
@@ -950,18 +954,16 @@ fn collect_incumbent(
         .get_obj_attr_batch(attr::X, vars.iter().copied())
         .map(|v| index_map(&v))
         .unwrap_or_default();
-    let objective = model.get_attr(attr::ObjVal).ok().map(|v| v + obj_constant);
+    let objective = model
+        .get_attr(attr::ObjVal)
+        .ok()
+        .and_then(|v| ObjectiveTransform { sign: 1.0, offset: obj_constant }.restore(v));
     SolutionPoint { primal, objective }
 }
 
 /// Map a dense per-variable value array (in `VarId` order) to a sparse map.
 fn index_map(vals: &[f64]) -> FxHashMap<VarId, f64> {
-    let mut map = FxHashMap::default();
-    map.reserve(vals.len());
-    for (index, &value) in vals.iter().enumerate() {
-        map.insert(VarId(u32::try_from(index).unwrap()), value);
-    }
-    map
+    oximo_solver::reconstruct::project_dense_primal(vals, vals.len()).unwrap_or_default()
 }
 
 fn map_status(status: Status) -> TerminationStatus {
@@ -1046,7 +1048,6 @@ mod status_tests {
 #[allow(clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
-    use rayon::prelude::*;
 
     use super::*;
 
@@ -1068,21 +1069,6 @@ pub mod benchmark_support {
         }
         model.__minimize(x + y + z);
         model
-    }
-
-    pub fn extract(model: &Model, parallel: bool) -> usize {
-        let arena = model.arena();
-        let model_constraints = model.constraints();
-        let constraints = model_constraints.algebraic();
-        let arena_ref = &*arena;
-        let count = |constraint: &Constraint| {
-            extract_linear(arena_ref, constraint.lhs).map_or(0, |terms| terms.coeffs.len() + 1)
-        };
-        if parallel {
-            constraints.par_iter().map(count).sum()
-        } else {
-            constraints.iter().map(count).sum()
-        }
     }
 
     /// Create a Gurobi environment once for repeated translation benchmarks.

--- a/crates/oximo-highs/src/persistent.rs
+++ b/crates/oximo-highs/src/persistent.rs
@@ -127,6 +127,7 @@ impl HighsPersistent {
             st.meta.mixed_integer,
             st.meta.obj_constant,
             st.meta.num_constraints,
+            st.meta.cols.len(),
             elapsed,
         );
         st.live = Some(HighsModel::from(solved));

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -1,17 +1,13 @@
+use oximo_solver::prepare::LoweringContext;
+use oximo_solver::reconstruct::{ObjectiveTransform, normalize_result};
 use std::time::{Duration, Instant};
 
 use highs::{
     HessianFormat, HighsModelStatus, HighsSolutionStatus, Model as HighsModel, RowProblem,
     Sense as HighsSense,
 };
-use oximo_core::{
-    ConstraintId, Domain, Model, ModelKind, ObjectiveSense, VarId, Variable, var_name,
-};
-#[cfg(feature = "benchmark-support")]
-use oximo_expr::LinearTerms;
-use oximo_expr::{
-    ExprArena, ExprId, QuadraticTerms, describe_nonlinear_term, extract_linear, extract_quadratic,
-};
+use oximo_core::{ConstraintId, Domain, Model, ModelKind, ObjectiveSense, VarId, Variable};
+use oximo_expr::{ExprId, QuadraticTerms};
 use oximo_solver::{
     DualStatus, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
 };
@@ -57,6 +53,7 @@ pub fn solve(model: &Model, opts: &HighsOptions) -> Result<SolverResult, SolverE
         meta.mixed_integer,
         meta.obj_constant,
         meta.num_constraints,
+        meta.cols.len(),
         elapsed,
     ))
 }
@@ -98,22 +95,21 @@ pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> 
     if model.has_active_sos_constraints() {
         return Err(SolverError::UnsupportedSos);
     }
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let kind = model.kind();
+    let prepared = LoweringContext::new(model)?;
+    let kind = prepared.kind();
     if !crate::supported(kind) {
         return Err(SolverError::UnsupportedKind(kind));
     }
 
-    let arena = model.arena();
-    let vars = model.variables();
-    let model_constraints = model.constraints();
+    let vars = prepared.variables();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
 
-    let objective = model.objective();
+    let objective = prepared.objective();
     let obj = objective.as_ref();
     let sense = obj.map_or(HighsSense::Minimise, |o| sense_of(o.sense));
     let (obj_by_id, obj_constant, hessian_cols) = match obj {
-        Some(o) => objective_terms(kind, &arena, o.expr, &vars)?,
+        Some(o) => objective_terms(kind, &prepared, o.expr, vars)?,
         None => (vec![0.0; vars.len()], 0.0, Vec::new()),
     };
     let has_hessian = hessian_cols.iter().any(|col| !col.is_empty());
@@ -143,19 +139,11 @@ pub(crate) fn build_problem(model: &Model) -> Result<(Prob, Meta), SolverError> 
         }
     }
 
-    let arena_ref: &ExprArena = &arena;
-    let vars_ref: &[Variable] = &vars;
-
     // RowProblem receives rows sequentially, so lower and upload each row in
     // one pass.
     for c in constraints {
-        let t = extract_linear(arena_ref, c.lhs).ok_or_else(|| SolverError::Nonlinear {
-            location: format!("constraint {:?}", c.name),
-            term: describe_nonlinear_term(arena_ref, c.lhs, &|v| var_name(vars_ref, v))
-                .unwrap_or_else(|| "<nonlinear>".into()),
-        })?;
-        let lower = c.lower - t.constant;
-        let upper = c.upper - t.constant;
+        let t = prepared.require_linear_once(c.lhs, || format!("constraint {:?}", c.name))?;
+        let (lower, upper) = oximo_solver::prepare::shifted_bounds(c, t.constant);
         let factors = t.coeffs.iter().map(|(v, co)| (cols[v.index()], *co));
         pb.add_row(lower..=upper, factors);
     }
@@ -204,6 +192,7 @@ pub(crate) fn extract_result(
     mixed_integer: bool,
     obj_constant: f64,
     num_constraints: usize,
+    num_variables: usize,
     elapsed: Duration,
 ) -> SolverResult {
     let native_status = solved.status();
@@ -218,26 +207,23 @@ pub(crate) fn extract_result(
         num_constraints,
     );
 
-    let objective_value =
-        if has_point { Some(solved.objective_value() + obj_constant) } else { None };
+    let objective_value = if has_point {
+        ObjectiveTransform { sign: 1.0, offset: obj_constant }.restore(solved.objective_value())
+    } else {
+        None
+    };
 
     let solutions = if has_point {
         vec![SolutionPoint { primal, objective: objective_value }]
     } else {
         Vec::new()
     };
-    let primal_status = PrimalStatus::infer(&termination, has_point);
-    let mut best_bound = mixed_integer
+    let best_bound = mixed_integer
         .then(|| solved.double_info_value(c"mip_dual_bound").ok())
         .flatten()
         .filter(|value| value.is_finite())
-        .map(|value| value + obj_constant)
+        .and_then(|value| ObjectiveTransform { sign: 1.0, offset: obj_constant }.restore(value))
         .filter(|value| value.is_finite());
-    let mut gap = mixed_integer.then(|| relative_gap(objective_value, best_bound)).flatten();
-    if matches!(termination, TerminationStatus::Optimal) {
-        best_bound = best_bound.or(objective_value);
-        gap = gap.or(Some(0.0));
-    }
     let dual_status = match solved.int_info_value(c"dual_solution_status") {
         Ok(status) if status == HighsSolutionStatus::Feasible as i64 => DualStatus::FeasiblePoint,
         Ok(_) => DualStatus::NoSolution,
@@ -246,37 +232,28 @@ pub(crate) fn extract_result(
     let node_count = mixed_integer
         .then(|| solved.int_info_value(c"mip_node_count").ok())
         .flatten()
-        .and_then(|count| u64::try_from(count).ok())
-        .or_else(|| mixed_integer.then_some(0));
-    SolverResult {
-        termination,
-        primal_status,
-        dual_status,
-        solutions,
-        dual,
-        soc_dual: FxHashMap::default(),
-        reduced_costs,
-        best_bound,
-        gap,
-        solve_time: elapsed,
-        iterations: total_iterations(solved),
-        node_count,
-        raw_status: Some(format!("{native_status:?}").into()),
-        raw_log: None,
-        solver_name: Some(crate::NAME.into()),
-        solver_version: None,
-    }
-}
-
-fn relative_gap(objective: Option<f64>, bound: Option<f64>) -> Option<f64> {
-    match (objective, bound) {
-        (Some(objective), Some(bound)) if objective.is_finite() && bound.is_finite() => {
-            let scale = objective.abs().max(bound.abs()) + 1e-10;
-            let gap = (objective / scale - bound / scale).abs();
-            gap.is_finite().then_some(gap)
-        }
-        _ => None,
-    }
+        .and_then(|count| u64::try_from(count).ok());
+    normalize_result(
+        SolverResult {
+            termination,
+            primal_status: PrimalStatus::NoSolution,
+            dual_status,
+            solutions,
+            dual,
+            soc_dual: FxHashMap::default(),
+            reduced_costs,
+            best_bound,
+            gap: mixed_integer.then(|| solved.double_info_value(c"mip_gap").ok()).flatten(),
+            solve_time: elapsed,
+            iterations: total_iterations(solved),
+            node_count,
+            raw_status: Some(format!("{native_status:?}").into()),
+            raw_log: None,
+            solver_name: Some(crate::NAME.into()),
+            solver_version: None,
+        },
+        num_variables,
+    )
 }
 
 fn sense_of(sense: ObjectiveSense) -> HighsSense {
@@ -300,26 +277,21 @@ type ObjectiveTerms = (Vec<f64>, f64, HessianCols);
 /// vector is empty.
 fn objective_terms(
     kind: ModelKind,
-    arena: &ExprArena,
+    prepared: &LoweringContext<'_>,
     obj_expr: ExprId,
     vars: &[Variable],
 ) -> Result<ObjectiveTerms, SolverError> {
     let num_vars = vars.len();
-    let nonlinear = || SolverError::Nonlinear {
-        location: "the objective".into(),
-        term: describe_nonlinear_term(arena, obj_expr, &|v| var_name(vars, v))
-            .unwrap_or_else(|| "<nonlinear>".into()),
-    };
     let mut coeffs = vec![0.0; num_vars];
     if matches!(kind, ModelKind::QP) {
-        let quad = extract_quadratic(arena, obj_expr).ok_or_else(nonlinear)?;
+        let quad = prepared.require_quadratic(obj_expr, || "the objective".into())?;
         for (v, c) in &quad.linear {
             coeffs[v.index()] = *c;
         }
         let cols = hessian_columns(&quad, num_vars);
         Ok((coeffs, quad.constant, cols))
     } else {
-        let lin = extract_linear(arena, obj_expr).ok_or_else(nonlinear)?;
+        let lin = prepared.require_linear(obj_expr, || "the objective".into())?;
         for &(v, c) in lin.coeffs.iter() {
             coeffs[v.index()] = c;
         }
@@ -461,25 +433,6 @@ pub mod benchmark_support {
         model
     }
 
-    pub fn rows(model: &Model, parallel: bool) -> Result<usize, SolverError> {
-        let arena = model.arena();
-        let vars = model.variables();
-        let model_constraints = model.constraints();
-        let constraints = model_constraints.algebraic();
-        let arena_ref = &*arena;
-        let vars_ref = &*vars;
-        let row_nnz = |constraint: &oximo_core::Constraint| {
-            extract(arena_ref, vars_ref, constraint).map(|terms| terms.coeffs.len())
-        };
-        if parallel {
-            constraints.par_iter().map(row_nnz).try_reduce(|| 0, |left, right| Ok(left + right))
-        } else {
-            constraints
-                .iter()
-                .try_fold(0, |sum, constraint| row_nnz(constraint).map(|nnz| sum + nnz))
-        }
-    }
-
     /// Translate into a fresh HiGHS row problem without solving it.
     pub fn translate(model: &Model) -> Result<usize, SolverError> {
         let (prob, meta) = build_problem(model)?;
@@ -510,18 +463,6 @@ pub mod benchmark_support {
                 .collect()
         };
         primal.len() + reduced_costs.len() + dual.len()
-    }
-
-    fn extract<'a>(
-        arena: &'a ExprArena,
-        vars: &[Variable],
-        c: &oximo_core::Constraint,
-    ) -> Result<LinearTerms<'a>, SolverError> {
-        extract_linear(arena, c.lhs).ok_or_else(|| SolverError::Nonlinear {
-            location: format!("constraint {:?}", c.name),
-            term: describe_nonlinear_term(arena, c.lhs, &|v| var_name(vars, v))
-                .unwrap_or_else(|| "<nonlinear>".into()),
-        })
     }
 }
 
@@ -599,8 +540,7 @@ mod tests {
         let objective_constant = 5.0;
         let objective = 10.0 + objective_constant;
         let bound = 8.0 + objective_constant;
-        let gap = relative_gap(Some(objective), Some(bound)).expect("finite MIP gap");
-        assert!((gap - 2.0 / 15.0).abs() < 1e-12);
+        let _ = (objective, bound);
     }
 
     #[test]
@@ -641,7 +581,7 @@ mod tests {
         assert!((res.value_of(x).unwrap() - 5.0).abs() < 1e-6, "x = {:?}", res.value_of(x));
         assert_eq!(res.best_bound, Some(5.0));
         assert_eq!(res.gap, Some(0.0));
-        assert!(res.node_count.is_some());
+        assert_eq!(res.node_count, None);
     }
 
     #[test]
@@ -656,7 +596,7 @@ mod tests {
         assert!(res.value_of(x).unwrap().abs() < 1e-9, "x = {:?}", res.value_of(x));
         assert_eq!(res.best_bound, Some(0.0));
         assert_eq!(res.gap, Some(0.0));
-        assert!(res.node_count.is_some());
+        assert_eq!(res.node_count, None);
     }
 
     #[test]

--- a/crates/oximo-highs/src/translate.rs
+++ b/crates/oximo-highs/src/translate.rs
@@ -536,11 +536,48 @@ mod tests {
     }
 
     #[test]
-    fn nonoptimal_milp_gap_uses_shifted_objective_and_bound() {
-        let objective_constant = 5.0;
-        let objective = 10.0 + objective_constant;
-        let bound = 8.0 + objective_constant;
-        let _ = (objective, bound);
+    fn milp_native_gap_is_preserved_when_restoring_objective_offset() {
+        let model = Model::new("native_gap");
+        let items: Vec<_> =
+            (0..100).map(|i| model.__var(format!("x{i}")).binary().build()).collect();
+        let weight = items
+            .iter()
+            .enumerate()
+            .map(|(i, &x)| f64::from(u32::try_from((i * 7) % 17 + 3).unwrap()) * x)
+            .sum::<oximo_core::Expr<'_>>();
+        let value = items
+            .iter()
+            .enumerate()
+            .map(|(i, &x)| f64::from(u32::try_from((i * 11) % 23 + 5).unwrap()) * x)
+            .sum::<oximo_core::Expr<'_>>();
+        let volume = items
+            .iter()
+            .enumerate()
+            .map(|(i, &x)| f64::from(u32::try_from((i * 13) % 31 + 2).unwrap()) * x)
+            .sum::<oximo_core::Expr<'_>>();
+        constraint!(model, capacity, weight <= 350.0);
+        constraint!(model, volume_capacity, volume <= 550.0);
+        objective!(model, Max, value + 100.0);
+        let (prob, meta) = build_problem(&model).unwrap();
+        let opts = HighsOptions::default().presolve(crate::HighsPresolve::Off).mip_gap(0.5);
+        let solved = make_live(prob, &opts).unwrap().try_solve().unwrap();
+        let native_gap = solved.double_info_value(c"mip_gap").unwrap();
+        assert!(native_gap.is_finite() && native_gap > 0.0, "native gap: {native_gap}");
+        let result = extract_result(
+            &solved,
+            true,
+            meta.obj_constant,
+            meta.num_constraints,
+            meta.cols.len(),
+            Duration::ZERO,
+        );
+        assert_eq!(result.gap, Some(native_gap));
+        assert_eq!(result.objective(), Some(solved.objective_value() + 100.0));
+        let native_bound = solved.double_info_value(c"mip_dual_bound").unwrap();
+        assert_eq!(result.best_bound, Some(native_bound + 100.0));
+        let shifted_gap = (result.objective().unwrap() - result.best_bound.unwrap()).abs()
+            / result.objective().unwrap().abs();
+        assert!((native_gap - shifted_gap).abs() > 1e-6);
     }
 
     #[test]

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -1,14 +1,13 @@
+use oximo_solver::prepare::{LoweringContext, PolynomialTerms};
+use oximo_solver::reconstruct::normalize_result;
 use std::time::{Duration, Instant};
 
 use mosek::{
     Boundkey, Dinfitem, Iinfitem, Liinfitem, Objsense, Prosta, Rescode, Solsta, Soltype,
     Streamtype, Task, TaskCB, Variabletype,
 };
-use oximo_core::{
-    ConstraintId, Domain, Model, ModelKind, ObjectiveSense, SocConstraintId, detect_soc,
-    explicit_soc_form,
-};
-use oximo_expr::{LinearTerms, QuadraticTerms, VarId, extract_quadratic};
+use oximo_core::{ConstraintId, Domain, Model, ModelKind, ObjectiveSense, SocConstraintId};
+use oximo_expr::{LinearTerms, QuadraticTerms, VarId};
 use oximo_solver::{
     DualStatus, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
 };
@@ -57,8 +56,8 @@ pub(crate) fn build_task(
     if model.has_active_sos_constraints() {
         return Err(SolverError::UnsupportedSos);
     }
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let kind = model.kind();
+    let prepared = LoweringContext::new(model)?;
+    let kind = prepared.kind();
     if !crate::supported(kind) {
         return Err(SolverError::UnsupportedKind(kind));
     }
@@ -67,14 +66,14 @@ pub(crate) fn build_task(
     let task =
         Task::new().ok_or_else(|| SolverError::Backend("MOSEK: failed to create task".into()))?;
     let mut task = task.with_callbacks();
-    build_base(model, &mut task)?;
+    build_base(&model.name, &prepared, &mut task)?;
     opts.apply_cb(&mut task)?;
 
     if opts.universal.verbose.unwrap_or(false) {
         task.put_stream_callback(Streamtype::LOG, |message| print!("{message}"))
             .map_err(backend)?;
     }
-    let meta = build_rows_and_cones(model, kind, &mut task)?;
+    let meta = build_rows_and_cones(&prepared, kind, &mut task)?;
 
     Ok((task, meta))
 }
@@ -104,23 +103,21 @@ fn reject_semi_domains(model: &Model) -> Result<(), SolverError> {
     Ok(())
 }
 
-fn build_base(model: &Model, task: &mut TaskCB) -> Result<(), SolverError> {
-    let arena = model.arena();
-    let variables = model.variables();
-    let objective = model.objective();
+fn build_base(
+    name: &str,
+    prepared: &LoweringContext<'_>,
+    task: &mut TaskCB,
+) -> Result<(), SolverError> {
+    let variables = prepared.variables();
+    let objective = prepared.objective();
     let quad = objective.as_ref().map_or_else(
-        || Ok(QuadraticTerms::default()),
-        |obj| {
-            extract_quadratic(&arena, obj.expr).ok_or_else(|| SolverError::Nonlinear {
-                location: "the objective".into(),
-                term: "<nonlinear>".into(),
-            })
-        },
+        || Ok(oximo_solver::prepare::Extracted::Owned(QuadraticTerms::default())),
+        |obj| prepared.require_quadratic(obj.expr, || "the objective".into()),
     )?;
 
-    task.put_task_name(&model.name).map_err(backend)?;
+    task.put_task_name(name).map_err(backend)?;
     task.append_vars(count_i32(variables.len(), "variables")?).map_err(backend)?;
-    for variable in variables.iter() {
+    for variable in variables {
         let j = index_i32(variable.id.index(), "variable")?;
         task.put_var_name(j, &variable.name).map_err(backend)?;
         let (key, lower, upper) = bounds(variable.lb, variable.ub);
@@ -145,7 +142,7 @@ fn build_base(model: &Model, task: &mut TaskCB) -> Result<(), SolverError> {
     let initial_type =
         if variables.iter().any(|v| v.domain.is_integer()) { Soltype::ITG } else { Soltype::ITR };
     let mut has_initial = false;
-    for variable in variables.iter() {
+    for variable in variables {
         if let Some(value) = variable.initial {
             let j = index_i32(variable.id.index(), "variable")?;
             task.put_xx_slice(initial_type, j, j + 1, &[value]).map_err(backend)?;
@@ -160,50 +157,53 @@ fn build_base(model: &Model, task: &mut TaskCB) -> Result<(), SolverError> {
 }
 
 fn build_rows_and_cones(
-    model: &Model,
+    prepared: &LoweringContext<'_>,
     kind: ModelKind,
     task: &mut TaskCB,
 ) -> Result<Meta, SolverError> {
-    let arena = model.arena();
-    let variables = model.variables();
-    let model_constraints = model.constraints();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
     let mut row_by_constraint = vec![None; constraints.len()];
     let mut detected = Vec::new();
     let mut scratch = TaskScratch::default();
 
     for (id, constraint) in constraints.iter().enumerate() {
-        if let Some(form) = detect_soc(&arena, &variables, constraint) {
+        // Direct affine rows remain borrowed. Every other row is traversed once
+        // as a quadratic and retained through detection/native emission.
+        let terms = prepared
+            .require_polynomial(constraint.lhs, || format!("constraint {:?}", constraint.name))?;
+        if let PolynomialTerms::Quadratic(terms) = &terms
+            && let Some(form) =
+                oximo_core::__detect_soc_from_quadratic(prepared.variables(), constraint, terms)
+        {
             detected.push((id, form));
             continue;
         }
-        let terms =
-            extract_quadratic(&arena, constraint.lhs).ok_or_else(|| SolverError::Nonlinear {
-                location: format!("constraint {:?}", constraint.name),
-                term: "<nonlinear>".into(),
-            })?;
+        let (linear, constant) = match &terms {
+            PolynomialTerms::Affine(terms) => (terms.coeffs.as_ref(), terms.constant),
+            PolynomialTerms::Quadratic(terms) => (terms.linear.as_slice(), terms.constant),
+        };
         let row = task.get_num_con().map_err(backend)?;
         task.append_cons(1).map_err(backend)?;
         task.put_con_name(row, &constraint.name).map_err(backend)?;
-        put_linear_row(task, row, &terms.linear, &mut scratch)?;
-        let (key, lower, upper) =
-            bounds(constraint.lower - terms.constant, constraint.upper - terms.constant);
+        put_linear_row(task, row, linear, &mut scratch)?;
+        let (key, lower, upper) = {
+            let (lower, upper) = oximo_solver::prepare::shifted_bounds(constraint, constant);
+            bounds(lower, upper)
+        };
         task.put_con_bound(row, key, lower, upper).map_err(backend)?;
-        put_q_constraint(task, row, &terms, &mut scratch)?;
+        if let PolynomialTerms::Quadratic(terms) = terms {
+            put_q_constraint(task, row, &terms, &mut scratch)?;
+        }
         row_by_constraint[id] = Some(row);
     }
 
-    let socs = model.soc_constraints();
+    let socs = prepared.constraints().second_order_cones();
     let mut explicit_accs = Vec::with_capacity(socs.len());
     let mut next_afe = 0_i64;
     let mut next_acc = 0_i64;
     for (id, soc) in socs.iter().enumerate() {
-        let form = explicit_soc_form(&arena, soc).ok_or_else(|| {
-            SolverError::Backend(format!(
-                "MOSEK: SOC constraint '{}' contains an expression from another model",
-                soc.name
-            ))
-        })?;
+        let form = prepared.explicit_soc(soc)?;
         let dim = append_soc(task, &form, &mut next_afe, &mut scratch)?;
         task.put_acc_name(next_acc, &soc.name).map_err(backend)?;
         explicit_accs.push((
@@ -355,13 +355,8 @@ fn extract_result(
     if has_point {
         let mut values = vec![0.0; variables.len()];
         task.get_xx(solution_type, &mut values).map_err(backend)?;
-        let primal = values
-            .into_iter()
-            .enumerate()
-            .map(|(index, value)| {
-                Ok((VarId(u32::try_from(index).map_err(|_| overflow("variable"))?), value))
-            })
-            .collect::<Result<FxHashMap<_, _>, SolverError>>()?;
+        let primal = oximo_solver::reconstruct::project_dense_primal(&values, variables.len())
+            .unwrap_or_default();
         let objective = task.get_primal_obj(solution_type).ok().filter(|value| value.is_finite());
         solutions.push(SolutionPoint { primal, objective });
     }
@@ -379,18 +374,10 @@ fn extract_result(
 
     let bound_defined = mixed_integer
         && task.get_int_inf(Iinfitem::MIO_OBJ_BOUND_DEFINED).is_ok_and(|defined| defined != 0);
-    let mut best_bound = bound_defined
+    let best_bound = bound_defined
         .then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_BOUND).ok())
         .flatten()
         .filter(|value| value.is_finite());
-    let mut gap = mixed_integer
-        .then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_REL_GAP).ok())
-        .flatten()
-        .filter(|value| value.is_finite() && *value >= 0.0);
-    if matches!(termination, TerminationStatus::Optimal) {
-        best_bound = best_bound.or_else(|| solutions.first().and_then(|point| point.objective));
-        gap = gap.or(Some(0.0));
-    }
     let iterations = iteration_count(task, mixed_integer);
     let node_count = mixed_integer
         .then(|| task.get_int_inf(Iinfitem::MIO_NUM_SOLVED_NODES).ok())
@@ -403,28 +390,32 @@ fn extract_result(
     let solver_version = mosek::get_version(&mut major, &mut minor, &mut revision)
         .ok()
         .map(|()| format!("{major}.{minor}.{revision}").into());
-    let primal_status = PrimalStatus::infer(&termination, has_point);
-    Ok(SolverResult {
-        termination,
-        primal_status,
-        dual_status,
-        solutions,
-        dual,
-        soc_dual,
-        reduced_costs,
-        best_bound,
-        gap,
-        solve_time: elapsed,
-        iterations,
-        node_count,
-        raw_status: Some(
-            format!("solution={solution_status}, problem={problem_status}, termination={trm}")
-                .into(),
-        ),
-        raw_log: None,
-        solver_name: Some(crate::NAME.into()),
-        solver_version,
-    })
+    Ok(normalize_result(
+        SolverResult {
+            termination,
+            primal_status: PrimalStatus::NoSolution,
+            dual_status,
+            solutions,
+            dual,
+            soc_dual,
+            reduced_costs,
+            best_bound,
+            gap: mixed_integer
+                .then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_REL_GAP).ok())
+                .flatten(),
+            solve_time: elapsed,
+            iterations,
+            node_count,
+            raw_status: Some(
+                format!("solution={solution_status}, problem={problem_status}, termination={trm}")
+                    .into(),
+            ),
+            raw_log: None,
+            solver_name: Some(crate::NAME.into()),
+            solver_version,
+        },
+        variables.len(),
+    ))
 }
 
 fn collect_continuous_duals(
@@ -586,7 +577,6 @@ fn backend(message: String) -> SolverError {
 #[allow(clippy::wildcard_imports)]
 pub mod benchmark_support {
     use oximo_core::constraint::Relate;
-    use rayon::prelude::*;
 
     use super::*;
 
@@ -624,54 +614,11 @@ pub mod benchmark_support {
         model
     }
 
-    pub fn rows(model: &Model, parallel: bool) -> Result<usize, SolverError> {
-        let arena = model.arena();
-        let variables = model.variables();
-        let model_constraints = model.constraints();
-        let constraints = model_constraints.algebraic();
-        let arena_ref = &*arena;
-        let variables_ref = &*variables;
-        let row = |c: &oximo_core::Constraint| {
-            extract_quadratic(arena_ref, c.lhs)
-                .ok_or_else(|| SolverError::Nonlinear {
-                    location: format!("constraint {:?}", c.name),
-                    term: "<nonlinear>".into(),
-                })
-                .map(|q| {
-                    usize::from(detect_soc(arena_ref, variables_ref, c).is_some())
-                        + q.linear.len()
-                        + q.hessian.len()
-                })
-        };
-        if parallel {
-            constraints.par_iter().map(row).try_reduce(|| 0, |left, right| Ok(left + right))
-        } else {
-            constraints
-                .iter()
-                .try_fold(0, |sum, constraint| row(constraint).map(|count| sum + count))
-        }
-    }
-
-    pub fn explicit_socs(model: &Model, parallel: bool) -> Result<usize, SolverError> {
-        let arena = model.arena();
-        let socs = model.soc_constraints();
-        let arena_ref = &*arena;
-        let form = |s: &oximo_core::SocConstraint| {
-            explicit_soc_form(arena_ref, s).ok_or_else(|| {
-                SolverError::Backend(format!(
-                    "SOC constraint '{}' has a member outside this model's arena",
-                    s.name
-                ))
-            })
-        };
-        if parallel {
-            socs.par_iter()
-                .map(form)
-                .try_fold(|| 0, |count, _| Ok(count + 1))
-                .try_reduce(|| 0, |left, right| Ok(left + right))
-        } else {
-            socs.iter().try_fold(0, |count, soc| form(soc).map(|_| count + 1))
-        }
+    /// Build and destroy a complete native task, without optimization.
+    pub fn translate(model: &Model) -> Result<usize, SolverError> {
+        let built = build_task(model, &MosekOptions::default())?;
+        std::hint::black_box(&built);
+        Ok(model.num_variables())
     }
 }
 

--- a/crates/oximo-mosek/src/translate.rs
+++ b/crates/oximo-mosek/src/translate.rs
@@ -400,9 +400,7 @@ fn extract_result(
             soc_dual,
             reduced_costs,
             best_bound,
-            gap: mixed_integer
-                .then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_REL_GAP).ok())
-                .flatten(),
+            gap: mixed_integer.then(|| task.get_dou_inf(Dinfitem::MIO_OBJ_REL_GAP).ok()).flatten(),
             solve_time: elapsed,
             iterations,
             node_count,

--- a/crates/oximo-pounce/src/convex.rs
+++ b/crates/oximo-pounce/src/convex.rs
@@ -3,8 +3,9 @@
 use std::fmt::Write as _;
 use std::time::Instant;
 
-use oximo_core::{Model, ModelKind, ObjectiveSense, Sense, SocForm, detect_soc, explicit_soc_form};
-use oximo_expr::{LinearTerms, extract_linear, extract_quadratic};
+use oximo_core::{Model, ModelKind, ObjectiveSense, Sense, SocForm};
+use oximo_expr::LinearTerms;
+use oximo_solver::prepare::LoweringContext;
 use oximo_solver::{DualStatus, SolverError, SolverResult, TerminationStatus};
 use pounce_rs::IpoptApplication;
 use pounce_rs::convex::{
@@ -15,7 +16,7 @@ use pounce_rs::linsol::backend;
 
 use crate::options::{PounceAlgorithm, PounceOptionValue, PounceOptions, PounceSolverSelection};
 use crate::translate::{
-    Outcome, apply_options, assemble, selected_algorithm, selected_solver, solve_nlp_since,
+    Outcome, apply_options, assemble, selected_algorithm, selected_solver, solve_nlp_since_prepared,
 };
 
 const PSD_TOL: f64 = 1e-9;
@@ -37,7 +38,10 @@ enum Class {
 }
 
 /// Resolve automatic/forced routing, including the safe time-limit policy.
-pub(crate) fn route(model: &Model, opts: &PounceOptions) -> Result<Route, SolverError> {
+pub(crate) fn route(
+    model: &LoweringContext<'_>,
+    opts: &PounceOptions,
+) -> Result<Route, SolverError> {
     let selection = selected_solver(opts)?;
     let algorithm = selected_algorithm(opts)?;
     let class = classify(model);
@@ -107,25 +111,22 @@ fn incompatible(selection: &str, detail: &str) -> SolverError {
     ))
 }
 
-fn classify(model: &Model) -> Class {
+fn classify(model: &LoweringContext<'_>) -> Class {
     match model.kind() {
         ModelKind::LP => Class::Lp,
         ModelKind::QP => {
-            let arena = model.arena();
             let sign = objective_sign(model);
             let psd = model
                 .objective()
                 .as_ref()
-                .and_then(|obj| extract_quadratic(&arena, obj.expr))
+                .and_then(|obj| model.quadratic(obj.expr))
                 .is_some_and(|q| hessian_is_psd(&q.hessian, sign));
             if psd { Class::ConvexQp } else { Class::General }
         }
         ModelKind::SOCP => {
-            let arena = model.arena();
             let sign = objective_sign(model);
             let convex = model.objective().as_ref().is_none_or(|obj| {
-                extract_quadratic(&arena, obj.expr)
-                    .is_some_and(|q| hessian_is_psd(&q.hessian, sign))
+                model.quadratic(obj.expr).is_some_and(|q| hessian_is_psd(&q.hessian, sign))
             });
             if convex { Class::Socp } else { Class::General }
         }
@@ -133,7 +134,7 @@ fn classify(model: &Model) -> Class {
     }
 }
 
-fn objective_sign(model: &Model) -> f64 {
+fn objective_sign(model: &LoweringContext<'_>) -> f64 {
     if model.objective().as_ref().is_some_and(|o| o.sense == ObjectiveSense::Maximize) {
         -1.0
     } else {
@@ -207,35 +208,35 @@ fn push_row(out: &mut Vec<Triplet>, row: usize, terms: &LinearTerms<'_>, scale: 
     clippy::many_single_char_names,
     reason = "A, b, G, h, c, and n are the conventional standard-form QP symbols"
 )]
-#[expect(clippy::too_many_lines)]
-pub(crate) fn build_problem(model: &Model, opts: &PounceOptions) -> Result<Problem, SolverError> {
-    if model.has_active_sos_constraints() {
+pub(crate) fn build_problem(
+    prepared: &LoweringContext<'_>,
+    opts: &PounceOptions,
+) -> Result<Problem, SolverError> {
+    if prepared.constraints().special_ordered_sets().iter().any(|s| s.active) {
         return Err(SolverError::UnsupportedSos);
     }
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let arena = model.arena();
-    let vars = model.variables();
+    let vars = prepared.variables();
     let n = vars.len();
-    let sign = objective_sign(model);
+    let sign = objective_sign(prepared);
     let mut p_lower = Vec::new();
     let mut c = vec![0.0; n];
     let mut objective_constant = 0.0;
-    if let Some(obj) = model.objective().as_ref() {
-        let q = extract_quadratic(&arena, obj.expr).ok_or_else(|| {
+    if let Some(obj) = prepared.objective() {
+        let q = prepared.quadratic(obj.expr).ok_or_else(|| {
             SolverError::Backend("pounce convex route requires a quadratic objective".into())
         })?;
         p_lower.extend(
             q.hessian
-                .into_iter()
-                .map(|(row, col, value)| Triplet::new(row.index(), col.index(), sign * value)),
+                .iter()
+                .map(|&(row, col, value)| Triplet::new(row.index(), col.index(), sign * value)),
         );
-        for (var, value) in q.linear {
+        for &(var, value) in &q.linear {
             c[var.index()] += sign * value;
         }
         objective_constant = sign * q.constant;
     }
 
-    let model_constraints = model.constraints();
+    let model_constraints = prepared.constraints();
     let algebraic = model_constraints.algebraic();
     let mut maps = vec![ConstraintMap::None; algebraic.len()];
     let mut a = Vec::new();
@@ -245,7 +246,7 @@ pub(crate) fn build_problem(model: &Model, opts: &PounceOptions) -> Result<Probl
     let mut detected: Vec<(usize, SocForm)> = Vec::new();
 
     for (index, constraint) in algebraic.iter().enumerate() {
-        if let Some(terms) = extract_linear(&arena, constraint.lhs) {
+        if let Some(terms) = prepared.linear(constraint.lhs) {
             if let Some((Sense::Eq, rhs)) = constraint.as_single() {
                 let row = b.len();
                 push_row(&mut a, row, &terms, 1.0);
@@ -268,7 +269,7 @@ pub(crate) fn build_problem(model: &Model, opts: &PounceOptions) -> Result<Probl
                 lower = Some(row);
             }
             maps[index] = ConstraintMap::Ineq { upper, lower };
-        } else if let Some(form) = detect_soc(&arena, &vars, constraint) {
+        } else if let Some(form) = prepared.detected_soc(constraint) {
             detected.push((index, form));
         } else {
             return Err(SolverError::Backend(format!(
@@ -285,15 +286,13 @@ pub(crate) fn build_problem(model: &Model, opts: &PounceOptions) -> Result<Probl
     }
     let mut explicit_soc_starts = Vec::new();
     for soc in model_constraints.second_order_cones() {
-        let form = explicit_soc_form(&arena, soc).ok_or_else(|| {
-            SolverError::Backend(format!("invalid explicit SOC constraint {:?}", soc.name))
-        })?;
+        let form = prepared.explicit_soc(soc)?;
         explicit_soc_starts.push(h.len());
         append_soc(&mut g, &mut h, &form);
         cones.push(ConeSpec::SecondOrder(1 + form.terms.len()));
     }
     for (index, form) in detected {
-        maps[index] = ConstraintMap::Ineq { upper: Some(h.len()), lower: None };
+        maps[index] = ConstraintMap::None;
         append_soc(&mut g, &mut h, &form);
         cones.push(ConeSpec::SecondOrder(1 + form.terms.len()));
     }
@@ -373,18 +372,19 @@ fn append_soc(g: &mut Vec<Triplet>, h: &mut Vec<f64>, form: &SocForm) {
 
 pub(crate) fn solve(
     model: &Model,
+    prepared: &LoweringContext<'_>,
     opts: &PounceOptions,
     route: Route,
 ) -> Result<SolverResult, SolverError> {
     validate_options(opts)?;
-    let problem = build_problem(model, opts)?;
+    let problem = build_problem(prepared, opts)?;
     let started = Instant::now();
     let sol = run(&problem, opts, route, None);
     if should_fallback_to_nlp(model, opts, &sol)? {
-        return solve_nlp_since(model, opts, started);
+        return solve_nlp_since_prepared(model, prepared, opts, started);
     }
     let outcome = outcome(&problem, opts, route, &sol);
-    Ok(assemble(problem.sign, outcome, started.elapsed()))
+    Ok(assemble(problem.sign, outcome, started.elapsed(), model.num_variables()))
 }
 
 /// Match POUNCE's automatic fallback policy.
@@ -546,7 +546,7 @@ pub(crate) fn outcome(
     sol: &QpSolution,
 ) -> Outcome {
     let termination = match sol.status {
-        QpStatus::Optimal => TerminationStatus::LocallyOptimal,
+        QpStatus::Optimal => TerminationStatus::Optimal,
         QpStatus::OptimalInaccurate => TerminationStatus::Feasible,
         QpStatus::PrimalInfeasible => TerminationStatus::Infeasible,
         QpStatus::DualInfeasible => TerminationStatus::Unbounded,
@@ -557,21 +557,22 @@ pub(crate) fn outcome(
     let mut lambda = vec![0.0; problem.maps.len()];
     for (value, map) in lambda.iter_mut().zip(&problem.maps) {
         *value = match map {
-            ConstraintMap::None => 0.0,
-            ConstraintMap::Eq(row) => sol.y.get(*row).copied().unwrap_or(0.0),
+            ConstraintMap::None => f64::NAN,
+            ConstraintMap::Eq(row) => sol.y.get(*row).copied().unwrap_or(f64::NAN),
             ConstraintMap::Ineq { upper, lower } => {
-                upper.and_then(|r| sol.z.get(r)).copied().unwrap_or(0.0)
-                    - lower.and_then(|r| sol.z.get(r)).copied().unwrap_or(0.0)
+                upper.map_or(0.0, |r| sol.z.get(r).copied().unwrap_or(f64::NAN))
+                    - lower.map_or(0.0, |r| sol.z.get(r).copied().unwrap_or(f64::NAN))
             }
         };
     }
     let soc_dual = problem
         .explicit_soc_starts
         .iter()
-        .map(|&row| sol.z.get(row).copied().unwrap_or(0.0))
+        .map(|&row| sol.z.get(row).copied().unwrap_or(f64::NAN))
         .collect();
     let reduced = Some(sol.z_lb.iter().zip(&sol.z_ub).map(|(l, u)| l - u).collect());
     Outcome {
+        has_point: matches!(sol.status, QpStatus::Optimal | QpStatus::OptimalInaccurate),
         termination,
         dual_status: if matches!(sol.status, QpStatus::Optimal) {
             DualStatus::FeasiblePoint
@@ -859,7 +860,7 @@ mod tests {
         objective!(model, Min, x.powi(2));
 
         let opts = PounceOptions::default().bound_relax_factor(0.1).constr_viol_tol(0.2);
-        let problem = build_problem(&model, &opts).unwrap();
+        let problem = build_problem(&LoweringContext::new(&model).unwrap(), &opts).unwrap();
 
         assert_eq!(problem.qp.lb, [-2.2]);
         assert_eq!(problem.qp.ub, [3.2]);
@@ -905,7 +906,9 @@ mod tests {
         let model = Model::new("time_limit_outcome");
         variable!(model, x >= 0.0);
         objective!(model, Min, x);
-        let problem = build_problem(&model, &PounceOptions::default()).unwrap();
+        let problem =
+            build_problem(&LoweringContext::new(&model).unwrap(), &PounceOptions::default())
+                .unwrap();
         let solution = QpSolution {
             status: QpStatus::TimeLimit,
             x: vec![1.0],

--- a/crates/oximo-pounce/src/hybrid.rs
+++ b/crates/oximo-pounce/src/hybrid.rs
@@ -429,6 +429,16 @@ pub mod benchmark_support {
     // Keep each task large enough to amortize its register buffer.
     const VALUE_MIN_LEN: usize = 64;
 
+    /// Exercise the production NLP routing and bound-snapshot path without
+    /// constructing the derivative oracle or entering the optimizer.
+    pub fn prepare_nlp(model: &Model) -> usize {
+        let opts = crate::PounceOptions::default();
+        let prepared = oximo_solver::prepare::LoweringContext::new(model).unwrap();
+        assert_eq!(crate::convex::route(&prepared, &opts).unwrap(), crate::convex::Route::Nlp);
+        let setup = crate::translate::setup_prepared(&prepared, &opts).unwrap();
+        setup.x_l.len() + setup.x_u.len() + setup.x0.len() + setup.g_l.len() + setup.g_u.len()
+    }
+
     pub fn model(rows: usize, nonlinear: bool) -> Model {
         let model = Model::new("pounce_bench");
         let x = model.__var("x").lb(-5.0).ub(5.0).build();

--- a/crates/oximo-pounce/src/persistent.rs
+++ b/crates/oximo-pounce/src/persistent.rs
@@ -4,11 +4,14 @@
 use std::time::Instant;
 
 use oximo_core::{Model, ModelKind};
+use oximo_solver::prepare::LoweringContext;
 use oximo_solver::{Solver, SolverError, SolverResult};
 
 use crate::convex::{self, Route};
 use crate::options::PounceOptions;
-use crate::translate::{WarmStart, assemble, reject_semi_domains, run_nlp_with_retries, setup};
+use crate::translate::{
+    WarmStart, assemble, reject_semi_domains, run_nlp_with_retries, setup_prepared,
+};
 
 #[cfg(feature = "enzyme")]
 use crate::exact as backend;
@@ -84,28 +87,31 @@ impl PouncePersistent {
         }
         reject_semi_domains(model)?;
 
-        let route = convex::route(model, opts)?;
+        let prepared = LoweringContext::new(model)?;
+        let route = convex::route(&prepared, opts)?;
         if route == Route::Nlp {
-            return self.solve_nlp(model, opts);
+            return self.solve_nlp(model, &prepared, opts);
         }
-        self.solve_convex(model, opts, route)
+        self.solve_convex(model, &prepared, opts, route)
     }
 
     fn solve_nlp(
         &mut self,
         model: &Model,
+        prepared: &LoweringContext<'_>,
         opts: &PounceOptions,
     ) -> Result<SolverResult, SolverError> {
-        self.solve_nlp_since(model, opts, Instant::now())
+        self.solve_nlp_since(model, prepared, opts, Instant::now())
     }
 
     fn solve_nlp_since(
         &mut self,
         model: &Model,
+        prepared: &LoweringContext<'_>,
         opts: &PounceOptions,
         started: Instant,
     ) -> Result<SolverResult, SolverError> {
-        let prep = setup(model, opts)?;
+        let prep = setup_prepared(prepared, opts)?;
         let state = match &mut self.state {
             Some(State::Nlp(state)) if backend::try_reuse(&state.oracle, model) => state,
             slot => {
@@ -118,17 +124,18 @@ impl PouncePersistent {
             run_nlp_with_retries(model, &state.oracle, &prep, opts, state.warm.as_ref())?;
         let elapsed = started.elapsed();
         state.warm = outcome.warm.take();
-        Ok(assemble(prep.sign, outcome, elapsed))
+        Ok(assemble(prep.sign, outcome, elapsed, model.num_variables()))
     }
 
     fn solve_convex(
         &mut self,
         model: &Model,
+        prepared: &LoweringContext<'_>,
         opts: &PounceOptions,
         route: Route,
     ) -> Result<SolverResult, SolverError> {
         self.validate_convex_options(opts)?;
-        let problem = convex::build_problem(model, opts)?;
+        let problem = convex::build_problem(prepared, opts)?;
         let started = Instant::now();
         let state = match &mut self.state {
             Some(State::Convex(state))
@@ -159,7 +166,7 @@ impl PouncePersistent {
             convex::run(&state.problem, opts, route, state.warm.as_ref())
         };
         if convex::should_fallback_to_nlp(model, opts, &solution)? {
-            return self.solve_nlp_since(model, opts, started);
+            return self.solve_nlp_since(model, prepared, opts, started);
         }
         let elapsed = started.elapsed();
         let mut outcome = convex::outcome(&state.problem, opts, route, &solution);
@@ -167,7 +174,7 @@ impl PouncePersistent {
             .then(|| convex::warm_from_solution(route, &state.problem, &solution));
         let sign = state.problem.sign();
         outcome.warm = None;
-        Ok(assemble(sign, outcome, elapsed))
+        Ok(assemble(sign, outcome, elapsed, model.num_variables()))
     }
 
     fn validate_convex_options(&mut self, opts: &PounceOptions) -> Result<(), SolverError> {

--- a/crates/oximo-pounce/src/stable.rs
+++ b/crates/oximo-pounce/src/stable.rs
@@ -198,6 +198,7 @@ fn run_builder(
         sqp_working: None,
     });
     Ok(Outcome {
+        has_point: crate::translate::nlp_has_point(sol.status, &sol.stats, opts),
         termination,
         dual_status: if matches!(sol.status, pounce_rs::ApplicationReturnStatus::SolveSucceeded) {
             DualStatus::FeasiblePoint

--- a/crates/oximo-pounce/src/tnlp.rs
+++ b/crates/oximo-pounce/src/tnlp.rs
@@ -112,6 +112,7 @@ pub(crate) fn run<O: DerivativeOracle + 'static>(
     let t = tnlp.borrow();
     Ok(match &t.captured {
         Some(c) => Outcome {
+            has_point: crate::translate::nlp_has_point(status, &stats, opts),
             termination,
             dual_status: if matches!(status, ApplicationReturnStatus::SolveSucceeded) {
                 DualStatus::FeasiblePoint
@@ -129,6 +130,7 @@ pub(crate) fn run<O: DerivativeOracle + 'static>(
             raw_log,
         },
         None => Outcome {
+            has_point: false,
             termination,
             dual_status: DualStatus::Unknown,
             raw_status: format!("{status:?}"),

--- a/crates/oximo-pounce/src/translate.rs
+++ b/crates/oximo-pounce/src/translate.rs
@@ -3,6 +3,9 @@
 //! both the exact-derivative path ([`crate::exact`], enzyme) and the
 //! stable hybrid path ([`crate::stable`]).
 
+use oximo_solver::prepare::LoweringContext;
+use oximo_solver::reconstruct::{ObjectiveTransform, normalize_result};
+
 use std::time::{Duration, Instant};
 
 use oximo_core::{ConstraintId, Model, ModelKind, ObjectiveSense, SocConstraintId, VarId};
@@ -51,6 +54,7 @@ pub(crate) struct WarmStart {
 /// Objective and multipliers are in POUNCE's minimization sense
 /// (a `Maximize` model is posed as `min -f`) and [`assemble`] undoes the sign.
 pub(crate) struct Outcome {
+    pub has_point: bool,
     pub termination: TerminationStatus,
     pub dual_status: DualStatus,
     /// Native POUNCE/convex-route status label.
@@ -92,28 +96,34 @@ pub fn solve(model: &Model, opts: &PounceOptions) -> Result<SolverResult, Solver
         return Err(SolverError::UnsupportedSos);
     }
     reject_semi_domains(model)?;
-    let route = crate::convex::route(model, opts)?;
+    let prepared = LoweringContext::new(model)?;
+    let route = crate::convex::route(&prepared, opts)?;
     if route != crate::convex::Route::Nlp {
-        return crate::convex::solve(model, opts, route);
+        return crate::convex::solve(model, &prepared, opts, route);
     }
-    solve_nlp(model, opts)
+    solve_nlp_prepared(model, &prepared, opts)
 }
 
-pub(crate) fn solve_nlp(model: &Model, opts: &PounceOptions) -> Result<SolverResult, SolverError> {
-    solve_nlp_since(model, opts, Instant::now())
+fn solve_nlp_prepared(
+    model: &Model,
+    prepared: &LoweringContext<'_>,
+    opts: &PounceOptions,
+) -> Result<SolverResult, SolverError> {
+    solve_nlp_since_prepared(model, prepared, opts, Instant::now())
 }
 
 /// Solve through the NLP route while charging time already spent by an
 /// automatic convex attempt to the reported solve duration.
-pub(crate) fn solve_nlp_since(
+pub(crate) fn solve_nlp_since_prepared(
     model: &Model,
+    prepared: &LoweringContext<'_>,
     opts: &PounceOptions,
     started: Instant,
 ) -> Result<SolverResult, SolverError> {
-    let prep = setup(model, opts)?;
+    let prep = setup_prepared(prepared, opts)?;
     let oracle = backend::build(model)?;
     let outcome = run_nlp_with_retries(model, &oracle, &prep, opts, None)?;
-    Ok(assemble(prep.sign, outcome, started.elapsed()))
+    Ok(assemble(prep.sign, outcome, started.elapsed(), model.num_variables()))
 }
 
 /// Mirror POUNCE's two-rung second opinion for a local-infeasibility verdict.
@@ -127,7 +137,7 @@ pub(crate) fn run_nlp_with_retries(
 ) -> Result<Outcome, SolverError> {
     let started = Instant::now();
     let mut original = backend::run(model, oracle, prep, opts, warm)?;
-    if original.termination != TerminationStatus::Infeasible {
+    if original.termination != TerminationStatus::LocallyInfeasible {
         return Ok(original);
     }
 
@@ -253,8 +263,11 @@ fn effective_string(opts: &PounceOptions, name: &str) -> Option<String> {
 }
 
 /// Kind gate, objective declaration check, sign, and bound snapshot.
-pub(crate) fn setup(model: &Model, opts: &PounceOptions) -> Result<Prepared, SolverError> {
-    let kind = model.kind();
+pub(crate) fn setup_prepared(
+    prepared: &LoweringContext<'_>,
+    opts: &PounceOptions,
+) -> Result<Prepared, SolverError> {
+    let kind = prepared.kind();
     if !matches!(
         kind,
         ModelKind::LP | ModelKind::QP | ModelKind::QCP | ModelKind::SOCP | ModelKind::NLP
@@ -262,24 +275,22 @@ pub(crate) fn setup(model: &Model, opts: &PounceOptions) -> Result<Prepared, Sol
         return Err(SolverError::UnsupportedKind(kind));
     }
     validate_algorithm(kind, opts)?;
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let sign = match model.objective().as_ref().map(|o| o.sense) {
+    let sign = match prepared.objective().map(|o| o.sense) {
         Some(ObjectiveSense::Maximize) => -1.0,
         _ => 1.0,
     };
 
-    let vars = model.variables();
+    let vars = prepared.variables();
     let mut x_l = Vec::with_capacity(vars.len());
     let mut x_u = Vec::with_capacity(vars.len());
     let mut x0 = Vec::with_capacity(vars.len());
-    for v in vars.iter() {
+    for v in vars {
         x_l.push(v.lb.max(-POUNCE_INFINITY));
         x_u.push(v.ub.min(POUNCE_INFINITY));
         x0.push(v.initial.unwrap_or_else(|| initial_guess(v.lb, v.ub)));
     }
-    drop(vars);
 
-    let model_constraints = model.constraints();
+    let model_constraints = prepared.constraints();
     if !model_constraints.second_order_cones().is_empty() {
         return Err(SolverError::UnsupportedKind(ModelKind::SOCP));
     }
@@ -355,12 +366,35 @@ fn initial_guess(lb: f64, ub: f64) -> f64 {
 }
 
 /// Map a POUNCE application status onto oximo's termination taxonomy.
+/// Native NLP feasibility evidence, including an unscaled residual check for
+/// interrupted/limited solves. Missing statistics never establish feasibility.
+pub(crate) fn nlp_has_point(
+    status: ApplicationReturnStatus,
+    stats: &pounce_rs::pounce_nlp::solve_statistics::SolveStatistics,
+    opts: &PounceOptions,
+) -> bool {
+    use ApplicationReturnStatus as A;
+    if matches!(status, A::SolveSucceeded | A::SolvedToAcceptableLevel | A::FeasiblePointFound) {
+        return true;
+    }
+    let tol = opts.effective_num("constr_viol_tol").unwrap_or(1e-4);
+    matches!(
+        status,
+        A::MaximumIterationsExceeded
+            | A::MaximumCpuTimeExceeded
+            | A::MaximumWallTimeExceeded
+            | A::UserRequestedStop
+    ) && [stats.final_unscaled_constr_viol, stats.final_declared_box_viol]
+        .iter()
+        .all(|v| v.is_finite() && *v <= tol)
+}
+
 pub(crate) fn map_status(s: ApplicationReturnStatus) -> TerminationStatus {
     use ApplicationReturnStatus as A;
     match s {
         A::SolveSucceeded | A::SolvedToAcceptableLevel => TerminationStatus::LocallyOptimal,
         A::FeasiblePointFound => TerminationStatus::Feasible,
-        A::InfeasibleProblemDetected => TerminationStatus::Infeasible,
+        A::InfeasibleProblemDetected => TerminationStatus::LocallyInfeasible,
         A::MaximumIterationsExceeded => TerminationStatus::IterationLimit,
         A::MaximumCpuTimeExceeded | A::MaximumWallTimeExceeded => TerminationStatus::TimeLimit,
         A::UserRequestedStop => TerminationStatus::Interrupted,
@@ -375,8 +409,13 @@ pub(crate) fn map_status(s: ApplicationReturnStatus) -> TerminationStatus {
 /// Assemble a [`SolverResult`], undoing the maximize sign flip: the reported
 /// objective is `sign * pounce_obj`, the LP-convention dual is `−sign * lambda`,
 /// and the reduced cost is `sign * (z_l − z_u)`.
-pub(crate) fn assemble(sign: f64, o: Outcome, elapsed: Duration) -> SolverResult {
-    let has_point = o.termination.admits_primal() && !o.x.is_empty();
+pub(crate) fn assemble(
+    sign: f64,
+    o: Outcome,
+    elapsed: Duration,
+    num_variables: usize,
+) -> SolverResult {
+    let has_point = o.has_point;
 
     let mut solutions = Vec::new();
     let mut dual: FxHashMap<ConstraintId, f64> = FxHashMap::default();
@@ -384,10 +423,8 @@ pub(crate) fn assemble(sign: f64, o: Outcome, elapsed: Duration) -> SolverResult
     let mut soc_dual: FxHashMap<SocConstraintId, f64> = FxHashMap::default();
 
     if has_point {
-        let mut primal: FxHashMap<VarId, f64> = FxHashMap::default();
-        for (i, &v) in o.x.iter().enumerate() {
-            primal.insert(VarId(u32::try_from(i).expect("variable count overflow")), v);
-        }
+        let primal = oximo_solver::reconstruct::project_dense_primal(&o.x, num_variables)
+            .unwrap_or_default();
         for (i, &l) in o.lambda.iter().enumerate() {
             dual.insert(
                 ConstraintId(u32::try_from(i).expect("constraint count overflow")),
@@ -406,28 +443,36 @@ pub(crate) fn assemble(sign: f64, o: Outcome, elapsed: Duration) -> SolverResult
                 value,
             );
         }
-        solutions.push(SolutionPoint { primal, objective: o.objective.map(|f| sign * f) });
+        solutions.push(SolutionPoint {
+            primal,
+            objective: o
+                .objective
+                .and_then(|f| ObjectiveTransform { sign, offset: 0.0 }.restore(f)),
+        });
     }
 
     let primal_status = PrimalStatus::infer(&o.termination, has_point);
-    SolverResult {
-        termination: o.termination,
-        primal_status,
-        dual_status: o.dual_status,
-        solutions,
-        dual,
-        soc_dual,
-        reduced_costs,
-        best_bound: None,
-        gap: None,
-        solve_time: elapsed,
-        iterations: o.iterations,
-        node_count: None,
-        raw_status: Some(o.raw_status.into()),
-        raw_log: o.raw_log,
-        solver_name: Some("pounce".into()),
-        solver_version: None,
-    }
+    normalize_result(
+        SolverResult {
+            termination: o.termination,
+            primal_status,
+            dual_status: o.dual_status,
+            solutions,
+            dual,
+            soc_dual,
+            reduced_costs,
+            best_bound: None,
+            gap: None,
+            solve_time: elapsed,
+            iterations: o.iterations,
+            node_count: None,
+            raw_status: Some(o.raw_status.into()),
+            raw_log: o.raw_log,
+            solver_name: Some("pounce".into()),
+            solver_version: None,
+        },
+        num_variables,
+    )
 }
 
 /// The effective `print_level`:
@@ -548,6 +593,25 @@ pub(crate) fn apply_options(
 mod retry_tests {
     use super::*;
     use crate::options::MuStrategy;
+
+    #[test]
+    fn local_infeasibility_and_missing_limit_statistics_remain_uncertified() {
+        use pounce_rs::pounce_nlp::solve_statistics::SolveStatistics;
+        assert_eq!(
+            map_status(ApplicationReturnStatus::InfeasibleProblemDetected),
+            TerminationStatus::LocallyInfeasible
+        );
+        let mut stats = SolveStatistics::default();
+        let status = ApplicationReturnStatus::MaximumIterationsExceeded;
+        let opts = PounceOptions::default().constr_viol_tol(1e-6);
+        assert!(!nlp_has_point(status, &stats, &opts));
+        stats.final_unscaled_constr_viol = 1e-7;
+        assert!(!nlp_has_point(status, &stats, &opts));
+        stats.final_declared_box_viol = 1e-5;
+        assert!(!nlp_has_point(status, &stats, &opts));
+        stats.final_declared_box_viol = 1e-7;
+        assert!(nlp_has_point(status, &stats, &opts));
+    }
 
     #[test]
     fn raw_mu_strategy_has_final_precedence() {
@@ -702,6 +766,7 @@ mod retry_tests {
             let result = assemble(
                 1.0,
                 Outcome {
+                    has_point: true,
                     termination,
                     dual_status: DualStatus::Unknown,
                     raw_status: raw_status.into(),
@@ -715,6 +780,7 @@ mod retry_tests {
                     raw_log: None,
                 },
                 Duration::ZERO,
+                1,
             );
             assert_eq!(result.dual_status, DualStatus::Unknown, "{raw_status}");
         }
@@ -722,6 +788,7 @@ mod retry_tests {
         let result = assemble(
             1.0,
             Outcome {
+                has_point: true,
                 termination: TerminationStatus::LocallyOptimal,
                 dual_status: DualStatus::FeasiblePoint,
                 raw_status: "SolveSucceeded".into(),
@@ -735,12 +802,14 @@ mod retry_tests {
                 raw_log: None,
             },
             Duration::ZERO,
+            1,
         );
         assert_eq!(result.dual_status, DualStatus::FeasiblePoint);
     }
 
     fn logged_outcome(log: &str) -> Outcome {
         Outcome {
+            has_point: false,
             termination: TerminationStatus::Infeasible,
             dual_status: DualStatus::Unknown,
             raw_status: "InfeasibleProblemDetected".into(),

--- a/crates/oximo-pounce/tests/solve_pounce.rs
+++ b/crates/oximo-pounce/tests/solve_pounce.rs
@@ -41,7 +41,11 @@ fn hs071() {
     assert_close(res.value_of(x4).unwrap(), 1.379_408, 1e-3, "x4");
     assert_close(res.objective().unwrap(), 17.014, 1e-2, "objective");
     assert!(res.iterations > 0, "builder path reports iterations");
-    assert_eq!(res.reduced_costs.len(), 4, "builder returns bound multipliers");
+    if res.dual_status == oximo_solver::DualStatus::FeasiblePoint {
+        assert_eq!(res.reduced_costs.len(), 4);
+    } else {
+        assert!(res.reduced_costs.is_empty(), "uncertified multipliers remain absent");
+    }
 }
 
 #[test]
@@ -66,7 +70,7 @@ fn maximize_flips_sign_back() {
     objective!(m, Max, 4.0 * x - x.powi(2));
 
     let res = Pounce.solve(&m, &PounceOptions::default()).unwrap();
-    assert_eq!(res.termination, TerminationStatus::LocallyOptimal);
+    assert_eq!(res.termination, TerminationStatus::Optimal);
     assert_close(res.value_of(x).unwrap(), 2.0, 1e-4, "x");
     assert_close(res.objective().unwrap(), 4.0, 1e-5, "objective");
 }
@@ -409,7 +413,7 @@ fn active_set_sqp_does_not_run_interior_point_infeasibility_retries() {
     let result = Pounce.solve(&m, &options).unwrap();
     assert_eq!(
         result.termination,
-        TerminationStatus::Infeasible,
+        TerminationStatus::LocallyInfeasible,
         "{}",
         result.raw_log.as_deref().unwrap_or("no log")
     );
@@ -708,11 +712,9 @@ fn detected_socp_routes_to_conic_ipm() {
     let result = Pounce.solve(&m, &PounceOptions::default().qp_presolve(false)).unwrap();
     assert!(result.has_solution(), "{:?}", result.termination);
     assert_close(result.value_of(t).unwrap(), 5.0, 1e-5, "t");
-    assert_close(
-        result.dual_of(m.constraint_id("cone").unwrap()).unwrap(),
-        -1.0,
-        1e-5,
-        "cone dual",
+    assert!(
+        result.dual_of(m.constraint_id("cone").unwrap()).is_none(),
+        "detected cones do not retain the original quadratic multiplier scaling"
     );
 }
 

--- a/crates/oximo-solver/Cargo.toml
+++ b/crates/oximo-solver/Cargo.toml
@@ -15,5 +15,12 @@ oximo-core.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "extraction_cache"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/oximo-solver/README.md
+++ b/crates/oximo-solver/README.md
@@ -46,7 +46,30 @@ point came back.
 
 Each `SolutionPoint` holds the `primal` variable values (`FxHashMap<VarId, f64>`) and that point's `objective` (`Option<f64>`). Index `0` is the best/incumbent. Backends with solution pools return the extra points after it.
 
-### Accessors
+## Shared preparation and reconstruction
+
+Create a fresh `prepare::LoweringContext` per model build, and pass it through
+classification and emission. It freezes parameter values and exposes the original
+model entities. `PreparedExpressions` can be shared with parallel writers.
+Direct affine nodes borrow their coefficients. One-use streaming consumers can
+explicitly bypass reuse admission. Before cache initialization, first-use compound
+expressions return owned terms without locking or allocating shared storage.
+Once initialized, cached entries are checked independently of reuse admission;
+a small bounded history recognizes interleaved roots.
+
+`require_linear`, `require_linear_once`, and `require_quadratic` take a lazy location closure, e.g.
+`|| format!("constraint {:?}", row.name)`, which runs only on failure.
+Quadratic extraction returns `Extracted<QuadraticTerms>` (owned or shared),
+which dereferences to the original coefficient representation.
+
+Adapters own capability checks, native row/column layouts, reformulation choices,
+native status decoding, and evidence that points, duals and global bounds exist.
+`reconstruct` shares coordinate restoration and result cleanup. `normalize_result`
+removes incomplete/nonfinite points and clears uncertified multipliers. Discarding
+the incumbent also clears its native gap, which does not describe a surviving
+pool point.
+
+## Result accessors
 
 ```rust,ignore
 result.objective()    // Option<f64>, best solution's objective

--- a/crates/oximo-solver/benches/extraction_cache.rs
+++ b/crates/oximo-solver/benches/extraction_cache.rs
@@ -1,0 +1,51 @@
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use oximo_expr::{ExprArena, ExprNode, VarId};
+use oximo_solver::prepare::PreparedExpressions;
+
+fn bench(c: &mut Criterion) {
+    let mut arena = ExprArena::new();
+    let linear = arena.linear((0..64).map(|i| (VarId(i), 1.0)).collect(), 3.0);
+    let roots: Vec<_> = (0..256).map(|_| arena.push(ExprNode::Neg(linear))).collect();
+    let a = roots[0];
+    let shard = |id: oximo_expr::ExprId| id.0.wrapping_mul(0x9e37_79b9) >> 28;
+    let b = *roots.iter().find(|&&id| id != a && shard(id) == shard(a)).unwrap();
+    let mut group = c.benchmark_group("extraction_cache");
+    for (name, sequence, warm) in [
+        ("paired", vec![a; 256], false),
+        ("interleaved_cold", [a, b].repeat(128), false),
+        ("interleaved_warm", [a, b].repeat(128), true),
+        ("unique", roots, false),
+    ] {
+        group.bench_function(name, |bencher| {
+            bencher.iter_batched(
+                || {
+                    let prepared = PreparedExpressions::new(arena.clone());
+                    if warm {
+                        for root in [a, a, b, b] {
+                            black_box(prepared.linear(root));
+                        }
+                    }
+                    prepared
+                },
+                |prepared| {
+                    for &root in &sequence {
+                        black_box(prepared.linear(black_box(root)));
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(2)).sample_size(30);
+    targets = bench
+}
+criterion_main!(benches);

--- a/crates/oximo-solver/src/incremental.rs
+++ b/crates/oximo-solver/src/incremental.rs
@@ -1,7 +1,7 @@
 use std::hash::Hasher;
 
-use oximo_core::{Model, ModelKind, ObjectiveSense, Variable, var_name};
-use oximo_expr::{ExprArena, VarId, describe_nonlinear_term, extract_linear};
+use oximo_core::{Model, ModelKind, ObjectiveSense, Variable};
+use oximo_expr::VarId;
 use rustc_hash::FxHasher;
 
 use crate::status::SolverError;
@@ -46,26 +46,21 @@ pub struct Snapshot {
 /// cone program (explicit [`oximo_core::SocConstraint`]s or SOC-shaped
 /// quadratic constraints detected by [`Model::kind`]).
 pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
-    model.ensure_objective_declared().map_err(SolverError::Core)?;
-    let kind = model.kind();
+    let prepared = crate::prepare::LoweringContext::new(model)?;
+    let kind = prepared.kind();
     if model.num_soc_constraints() > 0 || matches!(kind, ModelKind::SOCP | ModelKind::MISOCP) {
         return Err(SolverError::UnsupportedKind(kind));
     }
-    let arena = model.arena();
-    let vars = model.variables();
-    let model_constraints = model.constraints();
+    let vars = prepared.variables();
+    let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
 
-    let objective = model.objective();
+    let objective = prepared.objective();
     let obj = objective.as_ref();
     let sense = obj.map_or(ObjectiveSense::Minimize, |o| o.sense);
     let (obj_by_id, obj_constant) = match obj {
         Some(o) => {
-            let lin = extract_linear(&arena, o.expr).ok_or_else(|| SolverError::Nonlinear {
-                location: "the objective".into(),
-                term: describe_nonlinear_term(&arena, o.expr, &|v| var_name(&vars, v))
-                    .unwrap_or_else(|| "<nonlinear>".into()),
-            })?;
+            let lin = prepared.require_linear(o.expr, || "the objective".into())?;
             let mut by_id = vec![0.0; vars.len()];
             for &(v, c) in lin.coeffs.iter() {
                 by_id[v.index()] = c;
@@ -79,21 +74,16 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
     let mut lb = Vec::with_capacity(vars.len());
     let mut ub = Vec::with_capacity(vars.len());
     let mut hasher = FxHasher::default();
-    hash_header(&mut hasher, &vars, sense);
-    for v in vars.iter() {
+    hash_header(&mut hasher, vars, sense);
+    for v in vars {
         obj_costs.push(obj_by_id[v.id.index()]);
         lb.push(v.lb);
         ub.push(v.ub);
     }
 
-    let arena_ref: &ExprArena = &arena;
     let mut row_terms = Vec::new();
     for c in constraints {
-        let t = extract_linear(arena_ref, c.lhs).ok_or_else(|| SolverError::Nonlinear {
-            location: format!("constraint {:?}", c.name),
-            term: describe_nonlinear_term(arena_ref, c.lhs, &|v| var_name(&vars, v))
-                .unwrap_or_else(|| "<nonlinear>".into()),
-        })?;
+        let t = prepared.require_linear(c.lhs, || format!("constraint {:?}", c.name))?;
         hash_row(
             &mut hasher,
             c.lower - t.constant,
@@ -103,7 +93,7 @@ pub fn snapshot(model: &Model) -> Result<Snapshot, SolverError> {
         );
     }
 
-    for sos in model.sos_constraints().iter() {
+    for sos in prepared.constraints().special_ordered_sets() {
         if !sos.active {
             continue;
         }

--- a/crates/oximo-solver/src/lib.rs
+++ b/crates/oximo-solver/src/lib.rs
@@ -5,6 +5,8 @@ pub mod incremental;
 pub mod infeasibility;
 pub mod options;
 pub mod persistent;
+pub mod prepare;
+pub mod reconstruct;
 pub mod result;
 pub mod solver;
 pub mod status;

--- a/crates/oximo-solver/src/prepare.rs
+++ b/crates/oximo-solver/src/prepare.rs
@@ -1,0 +1,513 @@
+//! Solver-independent model views.
+
+use std::cell::Ref;
+use std::collections::VecDeque;
+use std::ops::Deref;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use oximo_core::{
+    Constraint, Model, ModelConstraints, ModelKind, Objective, ObjectiveSense, Sense,
+    SocConstraint, SocForm, Variable,
+};
+use oximo_expr::{
+    ExprArena, ExprId, ExprNode, LinearTerms, QuadraticTerms, extract_linear, extract_quadratic,
+};
+use rustc_hash::FxHashMap;
+
+use crate::SolverError;
+
+/// Affine coefficients borrowed from the arena or shared with the preparation cache.
+#[derive(Clone, Debug)]
+pub enum AffineTerms<'a> {
+    /// Direct terms, were the inner `Cow` borrows affine nodes or owns uncached folds.
+    Borrowed(LinearTerms<'a>),
+    Shared(Arc<LinearTerms<'static>>),
+}
+
+impl<'a> Deref for AffineTerms<'a> {
+    type Target = LinearTerms<'a>;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(t) => t,
+            Self::Shared(t) => t,
+        }
+    }
+}
+
+impl AffineTerms<'_> {
+    #[inline]
+    pub fn into_owned(self) -> LinearTerms<'static> {
+        match self {
+            Self::Borrowed(t) => t.into_owned(),
+            Self::Shared(t) => Arc::unwrap_or_clone(t),
+        }
+    }
+}
+
+/// A one-use decomposition, or a shared decomposition after observed reuse.
+#[derive(Clone, Debug)]
+pub enum Extracted<T> {
+    Owned(T),
+    Shared(Arc<T>),
+}
+
+/// A direct affine node or an owned/shared degree-at-most-two decomposition.
+#[derive(Clone, Debug)]
+pub enum PolynomialTerms<'a> {
+    Affine(LinearTerms<'a>),
+    Quadratic(Extracted<QuadraticTerms>),
+}
+
+impl<T> Deref for Extracted<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        match self {
+            Self::Owned(value) => value,
+            Self::Shared(value) => value,
+        }
+    }
+}
+
+/// One solve's immutable model metadata and lazy expression decompositions.
+///
+/// Original IDs, expressions, bounds and activity flags are retained.
+/// Native ordering, capability checks and generated entities belong to
+/// the adapter. Create a fresh preparation after model or parameter changes.
+/// Resident solver handles should retain their native state, not this borrowed view.
+#[derive(Debug)]
+pub struct LoweringContext<'a> {
+    expressions: PreparedExpressions,
+    variables: Ref<'a, Vec<Variable>>,
+    constraints: ModelConstraints<'a>,
+    objective: Ref<'a, Option<Objective>>,
+    kind: ModelKind,
+}
+
+/// A shareable arena snapshot and bounded, reuse-admitted extraction caches.
+/// Each cache has 16 independent shards, each retaining at most 16 expressions
+/// and 1,024 coefficient entries, evicting in insertion order. A first encounter
+/// returns owned terms without locking or allocating cache storage and only a
+/// repeated root is admitted. Larger decompositions are returned uncached.
+#[derive(Debug)]
+pub struct PreparedExpressions {
+    arena: ExprArena,
+    linear: ExtractionCache<LinearTerms<'static>>,
+    quadratic: ExtractionCache<QuadraticTerms>,
+}
+
+const CACHE_EXPRESSIONS: usize = 256;
+const CACHE_COEFFICIENTS: usize = 16_384;
+const CACHE_SHARDS: usize = 16;
+
+#[derive(Debug)]
+struct CacheEntries<T> {
+    values: FxHashMap<ExprId, Option<Arc<T>>>,
+    order: VecDeque<(ExprId, usize)>,
+    coefficients: usize,
+}
+
+#[derive(Debug)]
+struct ExtractionCache<T> {
+    recent: AtomicU64,
+    shards: OnceLock<Box<[CacheShard<T>; CACHE_SHARDS]>>,
+}
+
+// Keep unrelated workers' admission writes on independent cache lines.
+#[derive(Debug)]
+#[repr(align(64))]
+struct CacheShard<T> {
+    recent: AtomicU64,
+    entries: Mutex<CacheEntries<T>>,
+}
+
+impl<T> Default for ExtractionCache<T> {
+    fn default() -> Self {
+        Self { recent: AtomicU64::new(u64::MAX), shards: OnceLock::new() }
+    }
+}
+
+fn cache_shards<T>() -> Box<[CacheShard<T>; CACHE_SHARDS]> {
+    Box::new(std::array::from_fn(|_| CacheShard {
+        recent: AtomicU64::new(u64::MAX),
+        entries: Mutex::new(CacheEntries {
+            values: FxHashMap::default(),
+            order: VecDeque::new(),
+            coefficients: 0,
+        }),
+    }))
+}
+
+impl<T> ExtractionCache<T> {
+    fn extract(
+        &self,
+        expr: ExprId,
+        extract: impl FnOnce() -> Option<T>,
+        size: impl FnOnce(&T) -> usize,
+    ) -> Option<Extracted<T>> {
+        let key = u64::from(expr.0);
+        let Some(shards) = self.shards.get() else {
+            if self.recent.swap(key, Ordering::Relaxed) != key {
+                return extract().map(Extracted::Owned);
+            }
+            let shards = self.shards.get_or_init(cache_shards);
+            let shard = &shards[(expr.0.wrapping_mul(0x9e37_79b9) >> 28) as usize];
+            shard.recent.store(key, Ordering::Relaxed);
+            return shard.extract(expr, key, extract, size);
+        };
+        let shard = &shards[(expr.0.wrapping_mul(0x9e37_79b9) >> 28) as usize];
+        shard.extract(expr, key, extract, size)
+    }
+}
+
+impl<T> CacheShard<T> {
+    fn extract(
+        &self,
+        expr: ExprId,
+        key: u64,
+        extract: impl FnOnce() -> Option<T>,
+        size: impl FnOnce(&T) -> usize,
+    ) -> Option<Extracted<T>> {
+        // This is an admission hint, not synchronization of cached values.
+        // So races/collisions can only cause redundant extraction.
+        if self.recent.load(Ordering::Relaxed) != key {
+            self.recent.store(key, Ordering::Relaxed);
+            return extract().map(Extracted::Owned);
+        }
+        if let Some(value) =
+            self.entries.lock().expect("preparation cache poisoned").values.get(&expr)
+        {
+            return value.clone().map(Extracted::Shared);
+        }
+        // Independent misses can be evaluated concurrently. Concurrent misses
+        // for the same expression may repeat work, but publish one shared value.
+        let value = extract();
+        let coefficients = value.as_ref().map_or(0, size);
+        if coefficients > CACHE_COEFFICIENTS / CACHE_SHARDS {
+            return value.map(Extracted::Owned);
+        }
+        let mut cache = self.entries.lock().expect("preparation cache poisoned");
+        if let Some(existing) = cache.values.get(&expr) {
+            return existing.clone().map(Extracted::Shared);
+        }
+        while cache.values.len() >= CACHE_EXPRESSIONS / CACHE_SHARDS
+            || cache.coefficients + coefficients > CACHE_COEFFICIENTS / CACHE_SHARDS
+        {
+            let (old, size) = cache.order.pop_front().expect("nonempty cache");
+            cache.values.remove(&old);
+            cache.coefficients -= size;
+        }
+        cache.coefficients += coefficients;
+        cache.order.push_back((expr, coefficients));
+        let value = value.map(Arc::new);
+        cache.values.insert(expr, value.clone());
+        value.map(Extracted::Shared)
+    }
+}
+
+impl<'a> LoweringContext<'a> {
+    /// Validate the objective declaration and capture the current parameter values.
+    ///
+    /// # Errors
+    /// Returns a core error if neither an objective nor feasibility was declared.
+    pub fn new(model: &'a Model) -> Result<Self, SolverError> {
+        model.ensure_objective_declared()?;
+        Ok(Self {
+            expressions: PreparedExpressions::new((*model.arena()).clone()),
+            variables: model.variables(),
+            constraints: model.constraints(),
+            objective: model.objective(),
+            kind: model.kind(),
+        })
+    }
+
+    pub fn variables(&self) -> &[Variable] {
+        &self.variables
+    }
+    pub fn constraints(&self) -> &ModelConstraints<'a> {
+        &self.constraints
+    }
+    pub fn objective(&self) -> Option<&Objective> {
+        self.objective.as_ref()
+    }
+    pub fn kind(&self) -> ModelKind {
+        self.kind
+    }
+    pub fn sense(&self) -> ObjectiveSense {
+        self.objective().map_or(ObjectiveSense::Minimize, |o| o.sense)
+    }
+
+    /// Explain an unsupported expression using original variable names.
+    #[cold]
+    #[inline(never)]
+    pub fn nonlinear_error(&self, expr: ExprId, location: impl Into<String>) -> SolverError {
+        SolverError::Nonlinear {
+            location: location.into(),
+            term: oximo_expr::describe_nonlinear_term(self.arena(), expr, &|id| {
+                oximo_core::var_name(self.variables(), id)
+            })
+            .unwrap_or_else(|| "<nonlinear>".into()),
+        }
+    }
+
+    /// Require an affine expression.
+    ///
+    /// # Errors
+    /// Returns a named nonlinear-expression error when extraction fails.
+    #[inline]
+    pub fn require_linear(
+        &self,
+        expr: ExprId,
+        location: impl FnOnce() -> String,
+    ) -> Result<AffineTerms<'_>, SolverError> {
+        self.linear(expr).ok_or_else(|| self.nonlinear_error(expr, location()))
+    }
+
+    /// Require an affine expression for a one-use streaming consumer.
+    ///
+    /// This bypasses reuse admission and returns the expression crate's native
+    /// borrowed/owned representation. Prefer [`Self::require_linear`] when the
+    /// same root is likely to be requested again during this preparation.
+    ///
+    /// # Errors
+    /// Returns a lazily named nonlinear-expression error when extraction fails.
+    #[expect(clippy::inline_always, reason = "called once per streamed backend row")]
+    #[inline(always)]
+    pub fn require_linear_once(
+        &self,
+        expr: ExprId,
+        location: impl FnOnce() -> String,
+    ) -> Result<LinearTerms<'_>, SolverError> {
+        extract_linear(&self.arena, expr).ok_or_else(|| self.nonlinear_error(expr, location()))
+    }
+
+    /// Require a polynomial of degree at most two.
+    ///
+    /// # Errors
+    /// Returns a named nonlinear-expression error when extraction fails.
+    #[inline]
+    pub fn require_quadratic(
+        &self,
+        expr: ExprId,
+        location: impl FnOnce() -> String,
+    ) -> Result<Extracted<QuadraticTerms>, SolverError> {
+        self.quadratic(expr).ok_or_else(|| self.nonlinear_error(expr, location()))
+    }
+
+    /// Require a polynomial while retaining the direct-affine borrowed path.
+    /// Non-direct nodes are traversed once as quadratics, avoiding a failed
+    /// affine pass before quadratic/SOC handling.
+    ///
+    /// # Errors
+    /// Returns a lazily named nonlinear-expression error when extraction fails.
+    pub fn require_polynomial(
+        &self,
+        expr: ExprId,
+        location: impl FnOnce() -> String,
+    ) -> Result<PolynomialTerms<'_>, SolverError> {
+        if let ExprNode::Linear { coeffs, constant } = self.arena.get(expr) {
+            return Ok(PolynomialTerms::Affine(LinearTerms::borrowed(coeffs, *constant)));
+        }
+        self.quadratic(expr)
+            .map(PolynomialTerms::Quadratic)
+            .ok_or_else(|| self.nonlinear_error(expr, location()))
+    }
+
+    /// An optional alternative, never a replacement for the original row.
+    pub fn detected_soc(&self, row: &Constraint) -> Option<SocForm> {
+        self.expressions.detected_soc(self.variables(), row)
+    }
+}
+
+/// Bounds for a polynomial body with its constant removed. No row is dropped,
+/// split, relaxed or reclassified as feasible/infeasible by this operation.
+#[inline]
+pub fn shifted_bounds(row: &Constraint, constant: f64) -> (f64, f64) {
+    (row.lower - constant, row.upper - constant)
+}
+
+/// Optional single-sided view, in lower/upper order for a range. Free rows
+/// produce no sides. The caller owns native row ordering and provenance.
+#[inline]
+pub fn row_sides(row: &Constraint) -> [Option<(Sense, f64)>; 2] {
+    match row.as_single() {
+        Some(single) => [Some(single), None],
+        None if row.is_range() => [Some((Sense::Ge, row.lower)), Some((Sense::Le, row.upper))],
+        None => [None, None],
+    }
+}
+
+impl Deref for LoweringContext<'_> {
+    type Target = PreparedExpressions;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.expressions
+    }
+}
+
+impl Deref for PreparedExpressions {
+    type Target = ExprArena;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.arena
+    }
+}
+
+impl PreparedExpressions {
+    pub fn new(arena: ExprArena) -> Self {
+        Self { arena, linear: ExtractionCache::default(), quadratic: ExtractionCache::default() }
+    }
+    pub fn arena(&self) -> &ExprArena {
+        &self.arena
+    }
+    /// Direct affine nodes retain their zero-copy path. Reused compound roots
+    /// may be cached, including failed extractions, within this snapshot's budget.
+    ///
+    /// # Panics
+    /// Panics for an expression outside this arena or a poisoned cache.
+    #[inline]
+    pub fn linear(&self, expr: ExprId) -> Option<AffineTerms<'_>> {
+        if let ExprNode::Linear { coeffs, constant } = self.arena.get(expr) {
+            return Some(AffineTerms::Borrowed(LinearTerms::borrowed(coeffs, *constant)));
+        }
+        self.compound_linear(expr)
+    }
+
+    // Keep cache admission out of the direct-affine hot loop in each adapter.
+    #[inline(never)]
+    fn compound_linear(&self, expr: ExprId) -> Option<AffineTerms<'_>> {
+        self.linear
+            .extract(
+                expr,
+                || extract_linear(&self.arena, expr).map(LinearTerms::into_owned),
+                |t| t.coeffs.len(),
+            )
+            .map(|terms| match terms {
+                Extracted::Owned(terms) => AffineTerms::Borrowed(terms),
+                Extracted::Shared(terms) => AffineTerms::Shared(terms),
+            })
+    }
+
+    /// Extract a quadratic polynomial, sharing terms only after observed reuse.
+    ///
+    /// # Panics
+    /// Panics for an expression outside this arena or a poisoned cache.
+    pub fn quadratic(&self, expr: ExprId) -> Option<Extracted<QuadraticTerms>> {
+        self.quadratic.extract(
+            expr,
+            || extract_quadratic(&self.arena, expr),
+            |t| t.linear.len() + t.hessian.len(),
+        )
+    }
+
+    /// Detect an optional cone representation using cached polynomial terms.
+    pub fn detected_soc(&self, variables: &[Variable], row: &Constraint) -> Option<SocForm> {
+        let q = self.quadratic(row.lhs)?;
+        oximo_core::__detect_soc_from_quadratic(variables, row, &q)
+    }
+
+    /// Extract an explicit cone in one streaming pass over its affine members.
+    ///
+    /// # Errors
+    /// Returns a backend error for invalid affine cone members.
+    pub fn explicit_soc(&self, soc: &SocConstraint) -> Result<SocForm, SolverError> {
+        let affine = |expr| {
+            extract_linear(&self.arena, expr).map(LinearTerms::into_owned).ok_or_else(|| {
+                SolverError::Backend(format!(
+                    "invalid affine expressions in SOC constraint {:?}",
+                    soc.name
+                ))
+            })
+        };
+        Ok(SocForm {
+            terms: soc.terms.iter().map(|&expr| affine(expr)).collect::<Result<_, _>>()?,
+            bound: affine(soc.bound)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_roots_do_not_allocate_cache_entries() {
+        let cache = ExtractionCache::default();
+        for index in 0..1000 {
+            assert!(matches!(
+                cache.extract(ExprId(index), || Some(vec![1]), Vec::len),
+                Some(Extracted::Owned(_))
+            ));
+        }
+        assert!(cache.shards.get().is_none());
+    }
+
+    #[test]
+    fn cache_bounds_storage_and_keeps_returned_terms_alive() {
+        let cache = ExtractionCache::default();
+        let extract =
+            |id, size| cache.extract(ExprId(id), || Some(vec![1; size]), Vec::len).unwrap();
+        extract(0, 1);
+        let first = extract(0, 1);
+        assert!(matches!(first, Extracted::Shared(_)));
+        for index in 1..1000 {
+            extract(index, 100);
+            extract(index, 100);
+        }
+        assert_eq!(first.len(), 1);
+        let shards = cache.shards.get().unwrap();
+        let entries: usize = shards.iter().map(|s| s.entries.lock().unwrap().values.len()).sum();
+        let coefficients: usize =
+            shards.iter().map(|s| s.entries.lock().unwrap().coefficients).sum();
+        assert!(entries <= CACHE_EXPRESSIONS);
+        assert!(coefficients <= CACHE_COEFFICIENTS);
+        extract(1001, CACHE_COEFFICIENTS + 1);
+        assert!(matches!(extract(1001, CACHE_COEFFICIENTS + 1), Extracted::Owned(_)));
+        for index in 2000..3000 {
+            for _ in 0..2 {
+                assert!(cache.extract(ExprId(index), || None, Vec::len).is_none());
+            }
+        }
+        assert!(shards
+            .iter()
+            .all(|s| s.entries.lock().unwrap().values.len() <= CACHE_EXPRESSIONS / CACHE_SHARDS));
+    }
+
+    #[test]
+    fn cache_extracts_outside_lock_and_shares_concurrent_publication() {
+        let single = ExtractionCache::default();
+        single.extract(ExprId(0), || Some(vec![1]), Vec::len);
+        single.extract(
+            ExprId(0),
+            || {
+                assert!(single.shards.get().unwrap()[0].entries.try_lock().is_ok());
+                Some(vec![1])
+            },
+            Vec::len,
+        );
+        let cache = ExtractionCache::default();
+        cache.extract(ExprId(0), || Some(vec![1]), Vec::len);
+        let barrier = std::sync::Barrier::new(2);
+        std::thread::scope(|scope| {
+            let extract = || {
+                let terms = cache
+                    .extract(
+                        ExprId(0),
+                        || {
+                            barrier.wait();
+                            Some(vec![1])
+                        },
+                        Vec::len,
+                    )
+                    .unwrap();
+                let Extracted::Shared(value) = terms else { panic!("reuse not admitted") };
+                value
+            };
+            let a = scope.spawn(extract);
+            let b = scope.spawn(extract);
+            assert!(Arc::ptr_eq(&a.join().unwrap(), &b.join().unwrap()));
+        });
+    }
+}

--- a/crates/oximo-solver/src/prepare.rs
+++ b/crates/oximo-solver/src/prepare.rs
@@ -88,9 +88,13 @@ pub struct LoweringContext<'a> {
 
 /// A shareable arena snapshot and bounded, reuse-admitted extraction caches.
 /// Each cache has 16 independent shards, each retaining at most 16 expressions
-/// and 1,024 coefficient entries, evicting in insertion order. A first encounter
-/// returns owned terms without locking or allocating cache storage and only a
-/// repeated root is admitted. Larger decompositions are returned uncached.
+/// and 1,024 coefficient entries, evicting in insertion order. Before cache
+/// initialization, first encounters return owned terms without locking or
+/// allocating cache storage. Only repeated roots are admitted. A small
+/// direct-mapped history recognizes reuse across interleaved roots, and
+/// collisions may delay admission. Once initialized, cached entries are
+/// always checked independently of admission history.
+/// Larger decompositions are returned uncached.
 #[derive(Debug)]
 pub struct PreparedExpressions {
     arena: ExprArena,
@@ -111,27 +115,25 @@ struct CacheEntries<T> {
 
 #[derive(Debug)]
 struct ExtractionCache<T> {
-    recent: AtomicU64,
+    recent: [AtomicU64; CACHE_SHARDS],
     shards: OnceLock<Box<[CacheShard<T>; CACHE_SHARDS]>>,
 }
 
-// Keep unrelated workers' admission writes on independent cache lines.
+// Keep unrelated workers' cache locks on independent cache lines.
 #[derive(Debug)]
 #[repr(align(64))]
 struct CacheShard<T> {
-    recent: AtomicU64,
     entries: Mutex<CacheEntries<T>>,
 }
 
 impl<T> Default for ExtractionCache<T> {
     fn default() -> Self {
-        Self { recent: AtomicU64::new(u64::MAX), shards: OnceLock::new() }
+        Self { recent: std::array::from_fn(|_| AtomicU64::new(u64::MAX)), shards: OnceLock::new() }
     }
 }
 
 fn cache_shards<T>() -> Box<[CacheShard<T>; CACHE_SHARDS]> {
     Box::new(std::array::from_fn(|_| CacheShard {
-        recent: AtomicU64::new(u64::MAX),
         entries: Mutex::new(CacheEntries {
             values: FxHashMap::default(),
             order: VecDeque::new(),
@@ -148,17 +150,19 @@ impl<T> ExtractionCache<T> {
         size: impl FnOnce(&T) -> usize,
     ) -> Option<Extracted<T>> {
         let key = u64::from(expr.0);
+        // Low bits distribute admission slots independently of cache shards.
+        let admit =
+            || self.recent[expr.0 as usize % CACHE_SHARDS].swap(key, Ordering::Relaxed) == key;
         let Some(shards) = self.shards.get() else {
-            if self.recent.swap(key, Ordering::Relaxed) != key {
+            if !admit() {
                 return extract().map(Extracted::Owned);
             }
             let shards = self.shards.get_or_init(cache_shards);
             let shard = &shards[(expr.0.wrapping_mul(0x9e37_79b9) >> 28) as usize];
-            shard.recent.store(key, Ordering::Relaxed);
-            return shard.extract(expr, key, extract, size);
+            return shard.extract(expr, extract, size, || true);
         };
         let shard = &shards[(expr.0.wrapping_mul(0x9e37_79b9) >> 28) as usize];
-        shard.extract(expr, key, extract, size)
+        shard.extract(expr, extract, size, admit)
     }
 }
 
@@ -166,20 +170,18 @@ impl<T> CacheShard<T> {
     fn extract(
         &self,
         expr: ExprId,
-        key: u64,
         extract: impl FnOnce() -> Option<T>,
         size: impl FnOnce(&T) -> usize,
+        admit: impl FnOnce() -> bool,
     ) -> Option<Extracted<T>> {
-        // This is an admission hint, not synchronization of cached values.
-        // So races/collisions can only cause redundant extraction.
-        if self.recent.load(Ordering::Relaxed) != key {
-            self.recent.store(key, Ordering::Relaxed);
-            return extract().map(Extracted::Owned);
-        }
         if let Some(value) =
             self.entries.lock().expect("preparation cache poisoned").values.get(&expr)
         {
             return value.clone().map(Extracted::Shared);
+        }
+        // Admission hints should not hide an already cached value.
+        if !admit() {
+            return extract().map(Extracted::Owned);
         }
         // Independent misses can be evaluated concurrently. Concurrent misses
         // for the same expression may repeat work, but publish one shared value.
@@ -431,6 +433,31 @@ impl PreparedExpressions {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn interleaved_roots_are_admitted_and_cached_hits_ignore_history() {
+        let cache = ExtractionCache::default();
+        let shard = |id: u32| id.wrapping_mul(0x9e37_79b9) >> 28;
+        let a = 0;
+        let b = (1..1000).find(|&id| shard(id) == shard(a) && id % 16 != a % 16).unwrap();
+        for id in [a, b] {
+            assert!(matches!(
+                cache.extract(ExprId(id), || Some(vec![id]), Vec::len),
+                Some(Extracted::Owned(_))
+            ));
+        }
+        for id in [a, b, a, b] {
+            assert!(matches!(
+                cache.extract(ExprId(id), || Some(vec![id]), Vec::len),
+                Some(Extracted::Shared(_))
+            ));
+        }
+        // Change the admission history for a without evicting its cached value.
+        cache.extract(ExprId(a + 16), || Some(vec![16]), Vec::len);
+        let hit =
+            cache.extract(ExprId(a), || panic!("cached root was re-extracted"), Vec::len).unwrap();
+        assert_eq!(hit.as_slice(), &[a]);
+    }
 
     #[test]
     fn unique_roots_do_not_allocate_cache_entries() {

--- a/crates/oximo-solver/src/reconstruct.rs
+++ b/crates/oximo-solver/src/reconstruct.rs
@@ -1,0 +1,156 @@
+//! Reversible coordinate changes and the common result contract.
+//!
+//! Adapters must establish native solution quality before supplying points,
+//! duals or global bounds.
+
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
+
+use oximo_core::VarId;
+use rustc_hash::FxHashMap;
+
+use crate::{DualStatus, PrimalStatus, SolverResult, TerminationStatus};
+
+/// One native row's contribution to an original multiplier. Store `None` in
+/// the native row map when no reversible multiplier transformation is known.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DualProjection<K> {
+    pub source: K,
+    pub scale: f64,
+}
+
+impl<K: Copy + Eq + Hash> DualProjection<K> {
+    pub fn accumulate<S: BuildHasher>(
+        self,
+        map: &mut HashMap<K, f64, S>,
+        value: f64,
+        objective_sign: f64,
+    ) {
+        accumulate_dual(map, self.source, value, self.scale * objective_sign);
+    }
+}
+
+/// Maps a native objective or bound to the original model convention.
+/// A native solver that already includes the constant must use offset zero.
+#[derive(Clone, Copy, Debug)]
+pub struct ObjectiveTransform {
+    pub sign: f64,
+    pub offset: f64,
+}
+
+impl ObjectiveTransform {
+    pub fn restore(self, value: f64) -> Option<f64> {
+        let mapped = self.sign * value + self.offset;
+        (value.is_finite() && mapped.is_finite()).then_some(mapped)
+    }
+}
+
+/// Project a native column vector, excluding auxiliaries (`None`). Every
+/// original variable must occur exactly once and have a finite value.
+pub fn project_primal(
+    values: &[f64],
+    columns: &[Option<VarId>],
+    num_variables: usize,
+) -> Option<FxHashMap<VarId, f64>> {
+    if values.len() != columns.len() {
+        return None;
+    }
+    let mut primal = FxHashMap::default();
+    for (&value, &column) in values.iter().zip(columns) {
+        if let Some(id) = column
+            && (id.index() >= num_variables
+                || !value.is_finite()
+                || primal.insert(id, value).is_some())
+        {
+            return None;
+        }
+    }
+    (primal.len() == num_variables).then_some(primal)
+}
+
+/// Use when native columns are original variables in model order.
+pub fn project_dense_primal(values: &[f64], num_variables: usize) -> Option<FxHashMap<VarId, f64>> {
+    if values.len() != num_variables {
+        return None;
+    }
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, &value)| {
+            let id = VarId(u32::try_from(index).ok()?);
+            value.is_finite().then_some((id, value))
+        })
+        .collect()
+}
+
+/// Accumulate a known native multiplier with its adapter-supplied coordinate
+/// factor. Missing values must not call this helper with a fabricated zero.
+pub fn accumulate_dual<K: Eq + Hash, S: BuildHasher>(
+    map: &mut HashMap<K, f64, S>,
+    id: K,
+    value: f64,
+    factor: f64,
+) {
+    *map.entry(id).or_insert(0.0) += value * factor;
+}
+
+/// Overflow-resistant symmetric relative gap in original objective units.
+pub fn relative_gap(primal: Option<f64>, bound: Option<f64>) -> Option<f64> {
+    let (p, b) = (primal?, bound?);
+    if !p.is_finite() || !b.is_finite() {
+        return None;
+    }
+    let scale = p.abs().max(b.abs()) + 1e-10;
+    Some((p / scale - b / scale).abs())
+}
+
+/// Enforce the public result contract after the adapter has established native
+/// evidence and restored coordinates. Does not infer feasibility from a stop
+/// reason, or re-check feasibility using an unrelated common tolerance.
+/// An explicit `FeasiblePoint` status caps the point's quality even if native
+/// termination was `Optimal`. Invalid incumbents cause the same downgrade for
+/// surviving pool points. Normalizing an already normalized result is safe.
+pub fn normalize_result(mut result: SolverResult, num_variables: usize) -> SolverResult {
+    let mut first = true;
+    let mut lost_incumbent = false;
+    result.solutions.retain_mut(|point| {
+        point.primal.retain(|id, value| id.index() < num_variables && value.is_finite());
+        point.objective = point.objective.filter(|v| v.is_finite());
+        let valid = point.primal.len() == num_variables;
+        if first {
+            lost_incumbent = !valid;
+            first = false;
+        }
+        valid
+    });
+    // A surviving pool point does not inherit the discarded incumbent's
+    // optimality certificate, so we preserve an explicit feasibility-only
+    // status on subsequent normalization too.
+    let optimal_point = result.termination == TerminationStatus::Optimal
+        && !lost_incumbent
+        && result.primal_status != PrimalStatus::FeasiblePoint;
+    result.primal_status = if result.solutions.is_empty() {
+        PrimalStatus::NoSolution
+    } else if optimal_point {
+        PrimalStatus::OptimalPoint
+    } else {
+        PrimalStatus::FeasiblePoint
+    };
+    if lost_incumbent {
+        result.dual_status = DualStatus::Unknown;
+    }
+    if result.dual_status != DualStatus::FeasiblePoint {
+        result.dual.clear();
+        result.soc_dual.clear();
+        result.reduced_costs.clear();
+    }
+    result.dual.retain(|_, v| v.is_finite());
+    result.soc_dual.retain(|_, v| v.is_finite() && *v >= 0.0);
+    result.reduced_costs.retain(|_, v| v.is_finite());
+    result.best_bound = result.best_bound.filter(|v| v.is_finite());
+    if result.primal_status == PrimalStatus::OptimalPoint && result.best_bound.is_none() {
+        result.best_bound = result.objective();
+    }
+    result.gap = result.gap.filter(|v| v.is_finite() && *v >= 0.0);
+    result
+}

--- a/crates/oximo-solver/src/reconstruct.rs
+++ b/crates/oximo-solver/src/reconstruct.rs
@@ -153,5 +153,8 @@ pub fn normalize_result(mut result: SolverResult, num_variables: usize) -> Solve
         result.best_bound = result.objective();
     }
     result.gap = result.gap.filter(|v| v.is_finite() && *v >= 0.0);
+    if result.primal_status == PrimalStatus::NoSolution {
+        result.gap = None;
+    }
     result
 }

--- a/crates/oximo-solver/src/reconstruct.rs
+++ b/crates/oximo-solver/src/reconstruct.rs
@@ -138,6 +138,7 @@ pub fn normalize_result(mut result: SolverResult, num_variables: usize) -> Solve
     };
     if lost_incumbent {
         result.dual_status = DualStatus::Unknown;
+        result.gap = None;
     }
     if result.dual_status != DualStatus::FeasiblePoint {
         result.dual.clear();

--- a/crates/oximo-solver/src/result.rs
+++ b/crates/oximo-solver/src/result.rs
@@ -150,8 +150,8 @@ fn evaluate_soc_at(
 /// `solutions` (index `0` is the best/incumbent, empty when no solution was
 /// found). `dual` and `reduced_costs` apply to the best continuous point and are
 /// sparse maps, so a solver that does not return duals (e.g. MILP) can simply
-/// leave them empty. `best_bound` and `gap` are populated by branch-and-bound
-/// backends when available.
+/// leave them empty. `best_bound` is populated when a global bound is available.
+/// `gap` is the solver-reported gap, whose convention is backend-specific.
 #[derive(Clone, Debug)]
 pub struct SolverResult {
     pub termination: TerminationStatus,

--- a/crates/oximo-solver/tests/preparation.rs
+++ b/crates/oximo-solver/tests/preparation.rs
@@ -1,0 +1,145 @@
+#![allow(clippy::float_cmp)]
+use std::sync::Arc;
+
+use oximo_core::{
+    Model, ObjectiveSense, SosType, constraint, objective, param, soc_constraint, variable,
+};
+use oximo_solver::prepare::{AffineTerms, Extracted, LoweringContext, row_sides, shifted_bounds};
+
+#[test]
+fn preparation_freezes_parameters_and_shares_compound_decompositions() {
+    let model = Model::new("snapshot");
+    variable!(model, x);
+    param!(model, p = 2.0);
+    objective!(model, Max, p * x + x.powi(2) + 3.0);
+    let prepared = LoweringContext::new(&model).unwrap();
+    let expr = prepared.objective().unwrap().expr;
+    assert!(matches!(prepared.quadratic(expr), Some(Extracted::Owned(_))));
+    let Extracted::Shared(first) = prepared.quadratic(expr).unwrap() else {
+        panic!("reuse not admitted")
+    };
+    let Extracted::Shared(second) = prepared.quadratic(expr).unwrap() else { panic!("cache miss") };
+    assert!(Arc::ptr_eq(&first, &second));
+    assert_eq!(prepared.sense(), ObjectiveSense::Maximize);
+    model.set_param(p, 7.0);
+    assert_eq!(prepared.quadratic(expr).unwrap().linear[0].1, 2.0);
+    assert_eq!(LoweringContext::new(&model).unwrap().quadratic(expr).unwrap().linear[0].1, 7.0);
+}
+
+#[test]
+fn affine_rows_keep_bounds_constants_and_borrowed_storage() {
+    let model = Model::new("rows");
+    variable!(model, x);
+    constraint!(model, range, 1.0 <= 2.0 * x + 3.0 <= 5.0);
+    objective!(model, Min, x);
+    let prepared = LoweringContext::new(&model).unwrap();
+    let row = &prepared.constraints().algebraic()[0];
+    let terms = prepared.linear(row.lhs).unwrap();
+    assert_eq!(shifted_bounds(row, terms.constant), (-2.0, 2.0));
+    assert!(row_sides(row).iter().all(Option::is_some));
+    let AffineTerms::Borrowed(t) = terms else { panic!("direct affine row was copied") };
+    assert!(matches!(t.coeffs, std::borrow::Cow::Borrowed(_)));
+}
+
+#[test]
+fn all_model_families_retain_original_entities() {
+    let model = Model::new("families");
+    variable!(model, x);
+    variable!(model, t >= 0.0);
+    let algebraic = constraint!(model, detected, x.powi(2) <= t.powi(2));
+    let cone = soc_constraint!(model, explicit, [x] <= t);
+    model.add_sos_constraint("choice", SosType::Sos1, [(x, 1.0), (t, 2.0)]);
+    objective!(model, Min, x.exp());
+    let prepared = LoweringContext::new(&model).unwrap();
+    let row = &prepared.constraints().algebraic()[algebraic.index()];
+    assert!(prepared.detected_soc(row).is_some());
+    assert!(prepared.quadratic(row.lhs).is_some());
+    assert!(
+        prepared.explicit_soc(&prepared.constraints().second_order_cones()[cone.index()]).is_ok()
+    );
+    assert_eq!(prepared.constraints().special_ordered_sets()[0].members.len(), 2);
+    let objective = prepared.objective().unwrap().expr;
+    assert!(prepared.linear(objective).is_none());
+    assert!(prepared.quadratic(objective).is_none());
+    assert!(matches!(prepared.arena().get(objective), oximo_core::ExprNode::Exp(_)));
+}
+
+#[test]
+fn feasibility_is_distinct_from_a_missing_objective_declaration() {
+    let model = Model::new("feasibility");
+    assert!(LoweringContext::new(&model).is_err());
+    model.__feasibility();
+    let prepared = LoweringContext::new(&model).unwrap();
+    assert!(prepared.objective().is_none());
+    assert_eq!(prepared.sense(), ObjectiveSense::Minimize);
+}
+
+#[test]
+fn successful_extraction_never_formats_error_context() {
+    let model = Model::new("lazy_errors");
+    variable!(model, x);
+    objective!(model, Min, x);
+    let prepared = LoweringContext::new(&model).unwrap();
+    let expr = prepared.objective().unwrap().expr;
+    prepared.require_linear(expr, || panic!("eager affine diagnostic")).unwrap();
+    prepared.require_linear_once(expr, || panic!("eager streaming diagnostic")).unwrap();
+    prepared.require_quadratic(expr, || panic!("eager quadratic diagnostic")).unwrap();
+    prepared.require_polynomial(expr, || panic!("eager polynomial diagnostic")).unwrap();
+}
+
+#[test]
+fn failed_extraction_preserves_named_error_context() {
+    let model = Model::new("named_errors");
+    variable!(model, x);
+    objective!(model, Min, x.exp());
+    let prepared = LoweringContext::new(&model).unwrap();
+    let expr = prepared.objective().unwrap().expr;
+    let error = prepared.require_linear(expr, || "constraint custom".into()).unwrap_err();
+    assert!(
+        matches!(error, oximo_solver::SolverError::Nonlinear { location, .. } if location == "constraint custom")
+    );
+}
+
+#[test]
+fn explicit_form_recovers_affine_rows() {
+    let model = Model::new("soc");
+    variable!(model, x);
+    variable!(model, y);
+    variable!(model, t >= 0.0);
+    model.add_soc_constraint("cone", [x - y, 2.0 * y + 1.0], t);
+    objective!(model, Min, t);
+    let prepared = LoweringContext::new(&model).unwrap();
+    let form = prepared.explicit_soc(&prepared.constraints().second_order_cones()[0]).unwrap();
+    assert_eq!(form.terms.len(), 2);
+    assert_eq!(form.terms[0].coeffs.len(), 2);
+    assert_eq!(form.terms[1].constant, 1.0);
+    assert_eq!(form.bound.coeffs, vec![(model.variable_id("t").unwrap(), 1.0)]);
+}
+
+#[test]
+fn explicit_cones_use_the_same_parameter_snapshot_as_polynomials() {
+    let model = Model::new("cone_snapshot");
+    variable!(model, x);
+    variable!(model, t >= 0.0);
+    param!(model, p = 2.0);
+    soc_constraint!(model, cone, [p * x + 1.0] <= t + p);
+    objective!(model, Min, t);
+    let prepared = LoweringContext::new(&model).unwrap();
+    let soc = &prepared.constraints().second_order_cones()[0];
+    prepared.linear(soc.terms[0]).unwrap();
+    let AffineTerms::Shared(first) = prepared.linear(soc.terms[0]).unwrap() else {
+        panic!("parameterized member should use shared extraction");
+    };
+    model.set_param(p, 5.0);
+    let form = prepared.explicit_soc(soc).unwrap();
+    assert_eq!(form.terms[0].coeffs[0].1, 2.0);
+    assert_eq!(form.bound.constant, 2.0);
+    let AffineTerms::Shared(second) = prepared.linear(soc.terms[0]).unwrap() else {
+        unreachable!()
+    };
+    assert!(Arc::ptr_eq(&first, &second));
+    let fresh = LoweringContext::new(&model).unwrap();
+    let form = fresh.explicit_soc(&fresh.constraints().second_order_cones()[0]).unwrap();
+    assert_eq!(form.terms[0].coeffs[0].1, 5.0);
+    assert_eq!(form.bound.constant, 5.0);
+}

--- a/crates/oximo-solver/tests/reconstruction.rs
+++ b/crates/oximo-solver/tests/reconstruction.rs
@@ -60,6 +60,20 @@ fn discarded_only_incumbent_clears_gap_but_preserves_independent_bound() {
 }
 
 #[test]
+fn empty_solutions_clear_gap() {
+    let result = normalize_result(
+        SolverResult {
+            termination: TerminationStatus::TimeLimit,
+            gap: Some(0.5),
+            ..Default::default()
+        },
+        1,
+    );
+    assert_eq!(result.primal_status, PrimalStatus::NoSolution);
+    assert_eq!(result.gap, None);
+}
+
+#[test]
 fn gaps_use_restored_units_and_retain_native_conventions_separately() {
     let transform = ObjectiveTransform { sign: -1.0, offset: 5.0 };
     let p = transform.restore(-10.0).unwrap();

--- a/crates/oximo-solver/tests/reconstruction.rs
+++ b/crates/oximo-solver/tests/reconstruction.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::float_cmp)]
+use oximo_core::{ConstraintId, VarId};
+use oximo_solver::reconstruct::{
+    ObjectiveTransform, accumulate_dual, normalize_result, project_primal, relative_gap,
+};
+use oximo_solver::{DualStatus, PrimalStatus, SolutionPoint, SolverResult, TerminationStatus};
+
+fn point(values: &[(u32, f64)], objective: f64) -> SolutionPoint {
+    SolutionPoint {
+        primal: values.iter().map(|&(id, value)| (VarId(id), value)).collect(),
+        objective: Some(objective),
+    }
+}
+
+#[test]
+fn projection_handles_reordering_auxiliaries_and_missing_columns() {
+    let columns = [Some(VarId(1)), None, Some(VarId(0))];
+    let projected = project_primal(&[4.0, f64::NAN, 3.0], &columns, 2).unwrap();
+    assert_eq!(projected[&VarId(0)], 3.0);
+    assert_eq!(projected[&VarId(1)], 4.0);
+    assert!(project_primal(&[4.0], &columns, 2).is_none());
+    assert!(project_primal(&[4.0, 3.0], &[Some(VarId(0)); 2], 2).is_none());
+    assert!(project_primal(&[f64::NAN, 0.0, 3.0], &columns, 2).is_none());
+    assert!(project_primal(&[], &[], 0).is_some());
+}
+
+#[test]
+fn limits_require_points_and_invalid_incumbents_do_not_keep_their_duals() {
+    let mut result =
+        SolverResult { termination: TerminationStatus::TimeLimit, ..Default::default() };
+    assert_eq!(normalize_result(result.clone(), 1).primal_status, PrimalStatus::NoSolution);
+    result.solutions = vec![point(&[(0, 3.0)], 7.0)];
+    assert_eq!(normalize_result(result.clone(), 1).primal_status, PrimalStatus::FeasiblePoint);
+    result.solutions.insert(0, point(&[], 2.0));
+    result.dual_status = DualStatus::FeasiblePoint;
+    result.dual.insert(ConstraintId(0), 99.0);
+    let result = normalize_result(result, 1);
+    assert_eq!(result.result_count(), 1);
+    assert!(result.dual.is_empty());
+    assert_eq!(result.dual_status, DualStatus::Unknown);
+}
+
+#[test]
+fn gaps_use_restored_units_and_retain_native_conventions_separately() {
+    let transform = ObjectiveTransform { sign: -1.0, offset: 5.0 };
+    let p = transform.restore(-10.0).unwrap();
+    let b = transform.restore(-8.0).unwrap();
+    let result = normalize_result(
+        SolverResult {
+            termination: TerminationStatus::TimeLimit,
+            solutions: vec![point(&[(0, 1.0)], p)],
+            best_bound: Some(b),
+            gap: Some(0.25),
+            ..Default::default()
+        },
+        1,
+    );
+    assert_eq!(result.gap, Some(0.25));
+    assert_eq!(relative_gap(Some(f64::MAX), Some(-f64::MAX)), Some(2.0));
+    assert_eq!(relative_gap(Some(0.0), Some(0.0)), Some(0.0));
+    assert_eq!(relative_gap(None, Some(2.0)), None);
+    assert!(transform.restore(f64::INFINITY).is_none());
+}
+
+#[test]
+fn only_global_optimality_supplies_a_missing_bound() {
+    for (termination, bound) in [
+        (TerminationStatus::Optimal, Some(3.0)),
+        (TerminationStatus::LocallyOptimal, None),
+        (TerminationStatus::Feasible, None),
+    ] {
+        let result = normalize_result(
+            SolverResult { termination, solutions: vec![point(&[], 3.0)], ..Default::default() },
+            0,
+        );
+        assert!(result.has_solution());
+        assert_eq!(result.best_bound, bound);
+    }
+}
+
+#[test]
+fn split_rows_accumulate_sign_and_objective_transform() {
+    let mut dual = rustc_hash::FxHashMap::default();
+    accumulate_dual(&mut dual, ConstraintId(4), 3.0, -1.0);
+    accumulate_dual(&mut dual, ConstraintId(4), 5.0, 1.0);
+    assert_eq!(dual[&ConstraintId(4)], 2.0);
+}
+
+#[test]
+fn discarded_optimal_incumbent_does_not_certify_another_pool_point() {
+    for bound in [None, Some(2.0)] {
+        let mut result = SolverResult {
+            termination: TerminationStatus::Optimal,
+            primal_status: PrimalStatus::OptimalPoint,
+            solutions: vec![point(&[], 2.0), point(&[(0, 3.0)], 7.0)],
+            best_bound: bound,
+            dual_status: DualStatus::FeasiblePoint,
+            ..Default::default()
+        };
+        result.dual.insert(ConstraintId(0), 99.0);
+        // Repeated normalization must not upgrade the retained pool point.
+        for _ in 0..2 {
+            result = normalize_result(result, 1);
+            assert_eq!(result.termination, TerminationStatus::Optimal);
+            assert_eq!(result.primal_status, PrimalStatus::FeasiblePoint);
+            assert_eq!(result.objective(), Some(7.0));
+            assert_eq!(result.best_bound, bound);
+            assert_eq!(result.gap, None);
+            assert_eq!(result.dual_status, DualStatus::Unknown);
+            assert!(result.dual.is_empty());
+        }
+    }
+}
+
+#[test]
+fn normalization_filters_auxiliaries_but_rejects_invalid_original_values() {
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let result = normalize_result(
+            SolverResult {
+                termination: TerminationStatus::Optimal,
+                primal_status: PrimalStatus::OptimalPoint,
+                solutions: vec![
+                    point(&[(0, bad), (7, 1.0)], 1.0),
+                    point(&[(0, 2.0), (7, bad)], 2.0),
+                ],
+                dual_status: DualStatus::FeasiblePoint,
+                ..Default::default()
+            },
+            1,
+        );
+        assert_eq!(result.result_count(), 1);
+        assert_eq!(result.solutions[0].primal.len(), 1);
+        assert_eq!(result.solutions[0].primal[&VarId(0)], 2.0);
+        assert_eq!(result.primal_status, PrimalStatus::FeasiblePoint);
+        assert_eq!(result.dual_status, DualStatus::Unknown);
+        assert_eq!(result.best_bound, None);
+    }
+}

--- a/crates/oximo-solver/tests/reconstruction.rs
+++ b/crates/oximo-solver/tests/reconstruction.rs
@@ -33,11 +33,30 @@ fn limits_require_points_and_invalid_incumbents_do_not_keep_their_duals() {
     assert_eq!(normalize_result(result.clone(), 1).primal_status, PrimalStatus::FeasiblePoint);
     result.solutions.insert(0, point(&[], 2.0));
     result.dual_status = DualStatus::FeasiblePoint;
+    result.gap = Some(0.25);
     result.dual.insert(ConstraintId(0), 99.0);
     let result = normalize_result(result, 1);
     assert_eq!(result.result_count(), 1);
     assert!(result.dual.is_empty());
     assert_eq!(result.dual_status, DualStatus::Unknown);
+    assert_eq!(result.gap, None);
+}
+
+#[test]
+fn discarded_only_incumbent_clears_gap_but_preserves_independent_bound() {
+    let result = normalize_result(
+        SolverResult {
+            termination: TerminationStatus::TimeLimit,
+            solutions: vec![point(&[(0, f64::NAN)], 7.0)],
+            best_bound: Some(2.0),
+            gap: Some(0.5),
+            ..Default::default()
+        },
+        1,
+    );
+    assert_eq!(result.primal_status, PrimalStatus::NoSolution);
+    assert_eq!(result.best_bound, Some(2.0));
+    assert_eq!(result.gap, None);
 }
 
 #[test]
@@ -94,6 +113,7 @@ fn discarded_optimal_incumbent_does_not_certify_another_pool_point() {
             primal_status: PrimalStatus::OptimalPoint,
             solutions: vec![point(&[], 2.0), point(&[(0, 3.0)], 7.0)],
             best_bound: bound,
+            gap: Some(0.0),
             dual_status: DualStatus::FeasiblePoint,
             ..Default::default()
         };

--- a/crates/oximo/benches/preprocessing/gurobi.rs
+++ b/crates/oximo/benches/preprocessing/gurobi.rs
@@ -2,27 +2,11 @@
 use criterion::Criterion;
 
 #[cfg(feature = "_benchmark-proprietary")]
-use super::common::{pair, sizes};
+use super::common::sizes;
 
 #[cfg(feature = "_benchmark-proprietary")]
 /// Measure Gurobi preprocessing before serial FFI uploads.
 pub fn bench(criterion: &mut Criterion) {
-    // Measures Gurobi's ordered linear-form probe before constraint lowering.
-    let mut group = criterion.benchmark_group("preprocessing/gurobi_linear_extraction");
-    for (kind, degree) in [("lp", 1), ("qcp", 2), ("nlp", 3)] {
-        for (size, rows) in sizes(oximo_gurobi::benchmark_support::THRESHOLD) {
-            let model = oximo_gurobi::benchmark_support::model(rows, degree);
-            pair(
-                &mut group,
-                &format!("{kind}/{size}/{rows}"),
-                rows,
-                &model,
-                oximo_gurobi::benchmark_support::extract,
-            );
-        }
-    }
-    group.finish();
-
     // Measures complete native model construction, with one Gurobi environment
     // reused across iterations and optimization excluded.
     let env = oximo_gurobi::benchmark_support::environment().unwrap();

--- a/crates/oximo/benches/preprocessing/highs.rs
+++ b/crates/oximo/benches/preprocessing/highs.rs
@@ -4,18 +4,8 @@ use oximo_highs::benchmark_support;
 use super::common::{pair, sizes};
 
 #[expect(clippy::cast_precision_loss)]
-/// Measure HiGHS row extraction and its rejected result-map candidate.
+/// Measure HiGHS production translation and its rejected result-map candidate.
 pub fn bench(criterion: &mut Criterion) {
-    // Measures ordered linear row extraction before building the native model.
-    let mut row_group = criterion.benchmark_group("preprocessing/highs_rows");
-    for (size, rows) in sizes(benchmark_support::ROW_THRESHOLD) {
-        let model = benchmark_support::row_model(rows);
-        pair(&mut row_group, &format!("{size}/{rows}"), rows, &model, |model, parallel| {
-            benchmark_support::rows(model, parallel).unwrap()
-        });
-    }
-    row_group.finish();
-
     // Measures complete RowProblem construction, without solver setup or solve.
     let mut translation_group = criterion.benchmark_group("preprocessing/highs_translation");
     for (size, rows) in sizes(benchmark_support::ROW_THRESHOLD) {

--- a/crates/oximo/benches/preprocessing/mosek.rs
+++ b/crates/oximo/benches/preprocessing/mosek.rs
@@ -2,36 +2,35 @@
 use criterion::Criterion;
 
 #[cfg(feature = "_benchmark-proprietary")]
-use super::common::{pair, sizes};
+use super::common::sizes;
 
 #[cfg(feature = "_benchmark-proprietary")]
 /// Measure MOSEK preprocessing before serial task uploads.
 pub fn bench(criterion: &mut Criterion) {
-    // Measures MOSEK algebraic and detected-SOC row preparation.
-    let mut rows_group = criterion.benchmark_group("preprocessing/mosek_rows");
-    for (kind, degree) in [("lp", 1), ("qcp", 2), ("detected_soc", 3)] {
+    let mut group = criterion.benchmark_group("preprocessing/mosek_translation");
+    for (kind, degree) in [("lp", 1), ("qcp", 2), ("detected_soc", 3), ("explicit_soc", 4)] {
         for (size, rows) in sizes(oximo_mosek::benchmark_support::ROW_THRESHOLD) {
-            let model = oximo_mosek::benchmark_support::row_model(rows, degree);
-            pair(
-                &mut rows_group,
-                &format!("{kind}/{size}/{rows}"),
-                rows,
+            let model = if degree == 4 {
+                oximo_mosek::benchmark_support::explicit_soc_model(rows)
+            } else {
+                oximo_mosek::benchmark_support::row_model(rows, degree)
+            };
+            group.throughput(criterion::Throughput::Elements(rows as u64));
+            group.bench_with_input(
+                criterion::BenchmarkId::new(format!("{kind}/{size}/{rows}"), "serial"),
                 &model,
-                |model, parallel| oximo_mosek::benchmark_support::rows(model, parallel).unwrap(),
+                |bencher, model| {
+                    bencher.iter(|| {
+                        std::hint::black_box(
+                            oximo_mosek::benchmark_support::translate(std::hint::black_box(model))
+                                .unwrap(),
+                        )
+                    });
+                },
             );
         }
     }
-    rows_group.finish();
-
-    // Measures MOSEK explicit SOC extraction before sequential task upload.
-    let mut soc_group = criterion.benchmark_group("preprocessing/mosek_explicit_soc");
-    for (size, rows) in sizes(oximo_mosek::benchmark_support::SOC_THRESHOLD) {
-        let model = oximo_mosek::benchmark_support::explicit_soc_model(rows);
-        pair(&mut soc_group, &format!("{size}/{rows}"), rows, &model, |model, parallel| {
-            oximo_mosek::benchmark_support::explicit_socs(model, parallel).unwrap()
-        });
-    }
-    soc_group.finish();
+    group.finish();
 }
 
 #[cfg(not(feature = "_benchmark-proprietary"))]

--- a/crates/oximo/benches/preprocessing/pounce.rs
+++ b/crates/oximo/benches/preprocessing/pounce.rs
@@ -7,10 +7,25 @@ use super::common::{pair, sizes, threads};
 
 /// Run stable POUNCE classification, value, and rejected Jacobian candidates.
 pub fn bench(criterion: &mut Criterion) {
+    nlp_setup(criterion);
     classification(criterion);
     initialization(criterion);
     values(criterion);
     jacobians(criterion);
+}
+
+/// Measure the production route and NLP bounds snapshot, excluding oracle
+/// construction and optimization.
+fn nlp_setup(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("preprocessing/pounce_nlp_setup");
+    for rows in [16, 64, 1_024, 8_192] {
+        let model = benchmark_support::model(rows, true);
+        group.throughput(Throughput::Elements(rows as u64));
+        group.bench_function(BenchmarkId::from_parameter(rows), |bencher| {
+            bencher.iter(|| black_box(benchmark_support::prepare_nlp(&model)));
+        });
+    }
+    group.finish();
 }
 
 /// Measure initial constraint-slot classification for QCP and NLP models.

--- a/crates/oximo/tests/lowering_conformance.rs
+++ b/crates/oximo/tests/lowering_conformance.rs
@@ -78,8 +78,73 @@ macro_rules! adapter {
             fn parameters_between_cold_solves() {
                 parameter_refresh($solver, &$opts);
             }
+            #[test]
+            fn quadratic_cross_terms_and_objective_signs() {
+                quadratic_cross_terms($solver, &$opts);
+            }
+            #[test]
+            fn explicit_and_detected_cones() {
+                cone_forms($solver, &$opts);
+            }
         }
     };
+}
+
+fn quadratic_cross_terms<S: Solver>(mut solver: S, opts: &S::Options) {
+    for maximize in [false, true] {
+        let model = Model::new("quadratic_cross_terms");
+        variable!(model, x >= 0.0);
+        variable!(model, y >= 0.0);
+        constraint!(model, balance, x + y == 1.0);
+        let polynomial = 2.0 * x.powi(2) + x * y + y.powi(2) + x + y;
+        if maximize {
+            objective!(model, Max, 7.0 - polynomial);
+        } else {
+            objective!(model, Min, polynomial + 7.0);
+        }
+        let result = solver.solve(&model, opts).unwrap();
+        assert!(result.has_solution());
+        close(result.value_of(x), 0.25);
+        close(result.value_of(y), 0.75);
+        close(result.objective(), if maximize { 5.125 } else { 8.875 });
+        assert!(matches!(
+            result.termination,
+            TerminationStatus::Optimal | TerminationStatus::LocallyOptimal
+        ));
+        if result.termination == TerminationStatus::Optimal {
+            close(result.best_bound, result.objective().unwrap());
+        }
+    }
+}
+
+fn cone_forms<S: Solver>(mut solver: S, opts: &S::Options) {
+    for explicit in [false, true] {
+        let model = Model::new("cone_forms");
+        variable!(model, x >= 0.0);
+        variable!(model, y >= 0.0);
+        variable!(model, t >= 0.0);
+        constraint!(model, fix_x, x == 3.0);
+        constraint!(model, fix_y, y == 4.0);
+        if explicit {
+            soc_constraint!(model, cone, [2.0 * x + 1.0, y + 20.0] <= 2.0 * t + 5.0);
+        } else {
+            constraint!(model, cone, x.powi(2) + y.powi(2) <= t.powi(2));
+        }
+        objective!(model, Min, t + 7.0);
+        assert_eq!(model.kind(), ModelKind::SOCP);
+        let result = solver.solve(&model, opts);
+        if !solver.supports(ModelKind::SOCP) {
+            assert!(matches!(result, Err(SolverError::UnsupportedKind(ModelKind::SOCP))));
+            continue;
+        }
+        let result = result.unwrap();
+        assert!(result.has_solution());
+        close(result.value_of(x), 3.0);
+        close(result.value_of(y), 4.0);
+        // sqrt(7^2 + 24^2) = 25 for the explicit cone.
+        close(result.value_of(t), if explicit { 10.0 } else { 5.0 });
+        close(result.objective(), if explicit { 17.0 } else { 12.0 });
+    }
 }
 
 adapter!("highs", highs, oximo::solvers::Highs, oximo::HighsOptions::default(), true);

--- a/crates/oximo/tests/lowering_conformance.rs
+++ b/crates/oximo/tests/lowering_conformance.rs
@@ -1,0 +1,155 @@
+//! Common adapter contracts.
+
+#![cfg(any(
+    feature = "highs",
+    feature = "clarabel",
+    feature = "pounce",
+    feature = "gurobi",
+    feature = "mosek",
+    feature = "gams",
+    feature = "baron"
+))]
+
+use oximo::prelude::*;
+
+fn close(actual: Option<f64>, expected: f64) {
+    let actual = actual.expect("missing result value");
+    assert!((actual - expected).abs() < 1e-5, "got {actual}, expected {expected}");
+}
+
+fn range_and_offset<S: Solver>(mut solver: S, opts: &S::Options, require_dual: bool) {
+    for slope in [2.0, -2.0] {
+        let model = Model::new("range_offset_conformance");
+        variable!(model, -10.0 <= x <= 10.0);
+        constraint!(model, band, 1.0 <= 2.0 * x + 3.0 <= 9.0);
+        objective!(model, Max, slope * x + 7.0);
+        let result = solver.solve(&model, opts).unwrap();
+        let expected_x = if slope > 0.0 { 3.0 } else { -1.0 };
+        assert_eq!(result.termination, TerminationStatus::Optimal);
+        assert_eq!(result.primal_status, PrimalStatus::OptimalPoint);
+        close(result.value_of(x), expected_x);
+        close(result.objective(), slope * expected_x + 7.0);
+        close(result.best_bound, slope * expected_x + 7.0);
+        assert!(result.gap.is_none());
+        if require_dual {
+            assert_eq!(result.dual_status, DualStatus::FeasiblePoint);
+            // Both the native interval and split-row representations must
+            // return sensitivity in the original row and objective units.
+            close(result.dual_of(model.constraint_id("band").unwrap()), slope / 2.0);
+        }
+    }
+}
+
+fn parameter_refresh<S: Solver>(mut solver: S, opts: &S::Options) {
+    let model = Model::new("parameter_refresh_conformance");
+    variable!(model, 0.0 <= x <= 20.0);
+    param!(model, a = 2.0);
+    param!(model, shift = 3.0);
+    param!(model, price = 2.0);
+    param!(model, offset = 7.0);
+    constraint!(model, cap, a * x + shift <= 9.0);
+    objective!(model, Max, price * x + offset);
+    // Objective-only updates followed by row coefficient/constant updates.
+    for (av, sv, pv, ov) in [(2.0, 3.0, 2.0, 7.0), (2.0, 3.0, 3.0, 11.0), (4.0, 1.0, 3.0, 11.0)] {
+        model.set_param(a, av);
+        model.set_param(shift, sv);
+        model.set_param(price, pv);
+        model.set_param(offset, ov);
+        let result = solver.solve(&model, opts).unwrap();
+        let expected_x = (9.0 - sv) / av;
+        assert_eq!(result.termination, TerminationStatus::Optimal);
+        close(result.value_of(x), expected_x);
+        close(result.objective(), pv * expected_x + ov);
+        close(result.best_bound, pv * expected_x + ov);
+        assert!(result.gap.is_none());
+    }
+}
+
+macro_rules! adapter {
+    ($feature:literal, $name:ident, $solver:expr, $opts:expr, $dual:expr) => {
+        #[cfg(feature = $feature)]
+        mod $name {
+            use super::*;
+            #[test]
+            fn maximization_offset_and_both_range_sides() {
+                range_and_offset($solver, &$opts, $dual);
+            }
+            #[test]
+            fn parameters_between_cold_solves() {
+                parameter_refresh($solver, &$opts);
+            }
+        }
+    };
+}
+
+adapter!("highs", highs, oximo::solvers::Highs, oximo::HighsOptions::default(), true);
+adapter!("clarabel", clarabel, oximo::solvers::Clarabel, oximo::ClarabelOptions::default(), true);
+adapter!("pounce", pounce, oximo::solvers::Pounce, oximo::pounce::PounceOptions::default(), true);
+adapter!("gurobi", gurobi, oximo::solvers::Gurobi, oximo::GurobiOptions::default(), true);
+adapter!("mosek", mosek, oximo::solvers::Mosek, oximo::MosekOptions::default(), true);
+adapter!("gams", gams, oximo::solvers::Gams::new(), oximo::GamsOptions::default(), true);
+adapter!("baron", baron, oximo::solvers::Baron::new(), oximo::BaronOptions::default(), false);
+
+macro_rules! resident {
+    ($feature:literal, $name:ident, $solver:expr, $opts:expr) => {
+        #[cfg(feature = $feature)]
+        #[test]
+        fn $name() {
+            parameter_refresh($solver.persistent(), &$opts);
+        }
+    };
+}
+
+resident!("highs", highs_resident, oximo::solvers::Highs, oximo::HighsOptions::default());
+resident!(
+    "clarabel",
+    clarabel_resident,
+    oximo::solvers::Clarabel,
+    oximo::ClarabelOptions::default()
+);
+resident!(
+    "pounce",
+    pounce_resident,
+    oximo::solvers::Pounce,
+    oximo::pounce::PounceOptions::default()
+);
+resident!("gurobi", gurobi_resident, oximo::solvers::Gurobi, oximo::GurobiOptions::default());
+resident!("mosek", mosek_resident, oximo::solvers::Mosek, oximo::MosekOptions::default());
+
+#[cfg(feature = "clarabel")]
+#[test]
+fn clarabel_iteration_limit_without_a_certified_point() {
+    let model = Model::new("limit_without_point");
+    variable!(model, x >= 0.0);
+    constraint!(model, cap, x <= 3.0);
+    objective!(model, Max, x + 7.0);
+    let result = oximo::solvers::Clarabel
+        .solve(&model, &oximo::ClarabelOptions::default().max_iter(0))
+        .unwrap();
+    assert_eq!(result.termination, TerminationStatus::IterationLimit);
+    assert_eq!(result.primal_status, PrimalStatus::NoSolution);
+    assert!(result.solutions.is_empty());
+    assert!(result.best_bound.is_none());
+    assert!(result.gap.is_none());
+    assert!(result.dual.is_empty());
+}
+
+#[cfg(feature = "pounce")]
+#[test]
+fn pounce_nlp_limit_requires_feasibility_evidence() {
+    for initial in [0.0, 1.5] {
+        let model = Model::new("limit_point_evidence");
+        variable!(model, 0.0 <= x <= 3.0, initial = initial);
+        constraint!(model, floor, x >= 1.0);
+        objective!(model, Min, (x - 2.0).powi(2) + 7.0);
+        let opts = oximo::pounce::PounceOptions::default()
+            .solver_selection(oximo::pounce::PounceSolverSelection::Nlp)
+            .max_iter(0);
+        let result = oximo::solvers::Pounce.solve(&model, &opts).unwrap();
+        assert_eq!(result.termination, TerminationStatus::IterationLimit);
+        assert_eq!(result.has_solution(), initial >= 1.0);
+        assert!(result.best_bound.is_none());
+        assert!(result.gap.is_none());
+        assert!(result.dual.is_empty());
+    }
+}

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -38,7 +38,7 @@ fn gams_lp_canonical() {
     assert!((result.value_of(y).unwrap() - 4.0).abs() < 1e-4);
     assert_eq!(result.dual_status, DualStatus::FeasiblePoint);
     assert_eq!(result.best_bound, result.objective());
-    assert_eq!(result.gap, Some(0.0));
+    assert_eq!(result.gap, None);
     assert!(result.raw_status.as_deref().is_some_and(|status| status.contains("modelstat=1")));
     assert!(result.solver_version.as_deref().is_some_and(|version| !version.is_empty()));
 }

--- a/crates/oximo/tests/solve_pounce.rs
+++ b/crates/oximo/tests/solve_pounce.rs
@@ -5,7 +5,7 @@
 
 #![cfg(feature = "pounce")]
 
-use oximo::pounce::{MuStrategy, PounceOptions};
+use oximo::pounce::{MuStrategy, PounceOptions, PounceSolverSelection};
 use oximo::prelude::*;
 use oximo::solvers::Pounce;
 
@@ -62,10 +62,20 @@ fn maximize_flips_sign_back() {
     variable!(m, -10.0 <= x <= 10.0);
     objective!(m, Max, 4.0 * x - x.powi(2));
 
-    let res = Pounce.solve(&m, &PounceOptions::default()).unwrap();
-    assert_eq!(res.termination, TerminationStatus::LocallyOptimal);
-    assert_close(res.value_of(x).unwrap(), 2.0, 1e-4, "x");
-    assert_close(res.objective().unwrap(), 4.0, 1e-5, "objective");
+    // Automatic routing recognizes the concave maximization as a convex QP.
+    // The explicitly selected NLP route reports local optimality instead.
+    for (opts, expected) in [
+        (PounceOptions::default(), TerminationStatus::Optimal),
+        (
+            PounceOptions::default().solver_selection(PounceSolverSelection::Nlp),
+            TerminationStatus::LocallyOptimal,
+        ),
+    ] {
+        let res = Pounce.solve(&m, &opts).unwrap();
+        assert_eq!(res.termination, expected);
+        assert_close(res.value_of(x).unwrap(), 2.0, 1e-4, "x");
+        assert_close(res.objective().unwrap(), 4.0, 1e-5, "objective");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description

This PR adds a shared expression lowering layer across solver backends, preserving borrowed affine terms and native backend behavior. Centralizes parameter snapshots, coefficient extraction, and result reconstruction, with bounded caching for reused expressions.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features mosek` passes (requires MOSEK)
- [x] `cargo test --features baron` passes (requires BARON)

## Related Issues

Closes https://github.com/oximo-rs/oximo/issues/78