### PR TITLE
Expand nonlinear operators

### DIFF
--- a/crates/oximo-autodiff/src/sparsity.rs
+++ b/crates/oximo-autodiff/src/sparsity.rs
@@ -4,7 +4,7 @@
 
 use std::ops::Range;
 
-use oximo_expr::{ExprArena, ExprId, ExprNode};
+use oximo_expr::{ExprArena, ExprId, ExprNode, UnaryOp};
 use rustc_hash::FxHashSet;
 
 use crate::slot::{FunctionSlot, SlotKind};
@@ -30,16 +30,14 @@ pub fn variable_support(arena: &ExprArena, root: ExprId) -> Vec<u32> {
             ExprNode::Linear { coeffs, .. } => {
                 support.extend(coeffs.iter().map(|(v, _)| v.0));
             }
-            ExprNode::Add(children) | ExprNode::Mul(children) => {
+            ExprNode::Add(children)
+            | ExprNode::Mul(children)
+            | ExprNode::Min(children)
+            | ExprNode::Max(children) => {
                 stack.extend(children.iter().copied());
             }
-            ExprNode::Neg(inner)
-            | ExprNode::Sin(inner)
-            | ExprNode::Cos(inner)
-            | ExprNode::Exp(inner)
-            | ExprNode::Log(inner)
-            | ExprNode::Abs(inner) => stack.push(*inner),
-            ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) => {
+            ExprNode::Unary(_, inner) => stack.push(*inner),
+            ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) | ExprNode::Atan2(base, exp) => {
                 stack.push(*base);
                 stack.push(*exp);
             }
@@ -297,7 +295,8 @@ fn finish_sparse_union(scratch: &mut Vec<usize>) {
 /// "Exact structural" means a superset of the numerically nonzero second
 /// partials that ignores value cancellation. Parameters stay symbolic, so the
 /// pattern is independent of current parameter values.
-/// `Abs` contributes only its argument's pattern.
+/// `Abs` and `Min`/`Max` conservatively union branch patterns without adding
+/// synthetic cross terms between branches.
 pub fn hessian_pattern(arena: &ExprArena, root: ExprId) -> Vec<(u32, u32)> {
     structural_sparsity(arena, root).hess_pairs
 }
@@ -314,16 +313,14 @@ fn collect_node_vars(node: &ExprNode, vars: &mut Vec<u32>) {
 
 fn push_syntax_children(node: &ExprNode, walk: &mut Vec<WalkAction>) {
     match node {
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             walk.extend(children.iter().copied().map(WalkAction::Syntax));
         }
-        ExprNode::Neg(inner)
-        | ExprNode::Sin(inner)
-        | ExprNode::Cos(inner)
-        | ExprNode::Exp(inner)
-        | ExprNode::Log(inner)
-        | ExprNode::Abs(inner) => walk.push(WalkAction::Syntax(*inner)),
-        ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) => {
+        ExprNode::Unary(_, inner) => walk.push(WalkAction::Syntax(*inner)),
+        ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) | ExprNode::Atan2(base, exp) => {
             walk.push(WalkAction::Syntax(*base));
             walk.push(WalkAction::Syntax(*exp));
         }
@@ -333,15 +330,13 @@ fn push_syntax_children(node: &ExprNode, walk: &mut Vec<WalkAction>) {
 
 fn push_active_children(arena: &ExprArena, id: ExprId, walk: &mut Vec<WalkAction>) {
     match arena.get(id) {
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             walk.extend(children.iter().rev().copied().map(WalkAction::ActiveEnter));
         }
-        ExprNode::Neg(inner)
-        | ExprNode::Sin(inner)
-        | ExprNode::Cos(inner)
-        | ExprNode::Exp(inner)
-        | ExprNode::Log(inner)
-        | ExprNode::Abs(inner) => walk.push(WalkAction::ActiveEnter(*inner)),
+        ExprNode::Unary(_, inner) => walk.push(WalkAction::ActiveEnter(*inner)),
         ExprNode::Div(num, den) => {
             walk.push(WalkAction::ActiveEnter(*den));
             walk.push(WalkAction::ActiveEnter(*num));
@@ -357,6 +352,10 @@ fn push_active_children(arena: &ExprArena, id: ExprId, walk: &mut Vec<WalkAction
                 walk.push(WalkAction::ActiveEnter(*base));
             }
         },
+        ExprNode::Atan2(y, x) => {
+            walk.push(WalkAction::ActiveEnter(*x));
+            walk.push(WalkAction::ActiveEnter(*y));
+        }
         ExprNode::Const(_) | ExprNode::Var(_) | ExprNode::Param(_) | ExprNode::Linear { .. } => {}
     }
 }
@@ -422,6 +421,7 @@ fn prepare_storage(workspace: &mut SparsityWorkspace) -> StorageMode {
     StorageMode::Dense { words }
 }
 
+#[expect(clippy::too_many_lines)]
 fn build_dense_support_rows(arena: &ExprArena, workspace: &mut SparsityWorkspace, words: usize) {
     for order_index in 0..workspace.order.len() {
         let id = workspace.order[order_index];
@@ -443,11 +443,13 @@ fn build_dense_support_rows(arena: &ExprArena, workspace: &mut SparsityWorkspace
                 }
                 row
             }
-            ExprNode::Neg(inner) | ExprNode::Abs(inner) => workspace.meta[inner.index()].row,
+            ExprNode::Unary(UnaryOp::Neg | UnaryOp::Abs, inner) => {
+                workspace.meta[inner.index()].row
+            }
             ExprNode::Add(children) if children.len() == 1 => {
                 workspace.meta[children[0].index()].row
             }
-            ExprNode::Add(children) => {
+            ExprNode::Add(children) | ExprNode::Min(children) | ExprNode::Max(children) => {
                 let row = workspace.alloc_row(words);
                 for child in children {
                     union_rows(
@@ -478,11 +480,15 @@ fn build_dense_support_rows(arena: &ExprArena, workspace: &mut SparsityWorkspace
                 union_rows(&mut workspace.supports, row, den, words);
                 row
             }
-            ExprNode::Sin(inner)
-            | ExprNode::Cos(inner)
-            | ExprNode::Exp(inner)
-            | ExprNode::Log(inner) => {
+            ExprNode::Unary(_, inner) => {
                 let row = workspace.meta[inner.index()].row;
+                workspace.add_clique_once(row, words);
+                row
+            }
+            ExprNode::Atan2(y, x) => {
+                let row = workspace.alloc_row(words);
+                union_rows(&mut workspace.supports, row, workspace.meta[y.index()].row, words);
+                union_rows(&mut workspace.supports, row, workspace.meta[x.index()].row, words);
                 workspace.add_clique_once(row, words);
                 row
             }
@@ -618,18 +624,25 @@ fn build_sparse_support_rows(arena: &ExprArena, workspace: &mut SparsityWorkspac
                 finish_sparse_union(&mut workspace.sparse_scratch);
                 store_sparse_scratch(workspace)
             }
-            ExprNode::Neg(inner) | ExprNode::Abs(inner) => workspace.meta[inner.index()].row,
+            ExprNode::Unary(UnaryOp::Neg | UnaryOp::Abs, inner) => {
+                workspace.meta[inner.index()].row
+            }
             ExprNode::Add(children) if children.len() == 1 => {
                 workspace.meta[children[0].index()].row
             }
             ExprNode::Add(children) => sparse_union_row(workspace, children.iter().copied()),
+            ExprNode::Min(children) | ExprNode::Max(children) => {
+                sparse_union_row(workspace, children.iter().copied())
+            }
             ExprNode::Mul(children) => sparse_product_row(workspace, children.iter().copied()),
             ExprNode::Div(num, den) => sparse_division_row(workspace, *num, *den),
-            ExprNode::Sin(inner)
-            | ExprNode::Cos(inner)
-            | ExprNode::Exp(inner)
-            | ExprNode::Log(inner) => {
+            ExprNode::Unary(_, inner) => {
                 let row = workspace.meta[inner.index()].row;
+                workspace.add_sparse_clique_once(row);
+                row
+            }
+            ExprNode::Atan2(y, x) => {
+                let row = sparse_union_row(workspace, [*y, *x]);
                 workspace.add_sparse_clique_once(row);
                 row
             }

--- a/crates/oximo-autodiff/src/tape.rs
+++ b/crates/oximo-autodiff/src/tape.rs
@@ -7,7 +7,7 @@
 //! once at compile time.
 //!
 //! The tape is in SSA form.
-use oximo_expr::{ExprArena, ExprId, ExprNode};
+use oximo_expr::{ExprArena, ExprId, ExprNode, UnaryOp};
 use rustc_hash::FxHashMap;
 
 // Opcodes. `a`/`b` are operand register indices unless noted.
@@ -27,6 +27,26 @@ pub(crate) const OP_EXP: u32 = 12;
 pub(crate) const OP_LOG: u32 = 13;
 pub(crate) const OP_ABS: u32 = 14;
 pub(crate) const OP_LINEAR: u32 = 15; // sum of lin_coeffs[a..b] * x[lin_vars[a..b]]
+pub(crate) const OP_SQRT: u32 = 16;
+pub(crate) const OP_CBRT: u32 = 17;
+pub(crate) const OP_EXP2: u32 = 18;
+pub(crate) const OP_EXPM1: u32 = 19;
+pub(crate) const OP_LOG2: u32 = 20;
+pub(crate) const OP_LOG10: u32 = 21;
+pub(crate) const OP_LOG1P: u32 = 22;
+pub(crate) const OP_TAN: u32 = 23;
+pub(crate) const OP_ASIN: u32 = 24;
+pub(crate) const OP_ACOS: u32 = 25;
+pub(crate) const OP_ATAN: u32 = 26;
+pub(crate) const OP_SINH: u32 = 27;
+pub(crate) const OP_COSH: u32 = 28;
+pub(crate) const OP_TANH: u32 = 29;
+pub(crate) const OP_ASINH: u32 = 30;
+pub(crate) const OP_ACOSH: u32 = 31;
+pub(crate) const OP_ATANH: u32 = 32;
+pub(crate) const OP_ATAN2: u32 = 33;
+pub(crate) const OP_MIN: u32 = 34;
+pub(crate) const OP_MAX: u32 = 35;
 
 /// An expression (or weighted sum of expressions) compiled to a flat
 /// instruction tape, evaluable at any point without touching the arena.
@@ -161,31 +181,60 @@ pub(crate) fn eval_tape(
     for i in 0..n {
         let ai = a[i] as usize;
         let bi = b[i] as usize;
-        match ops[i] {
-            OP_CONST => regs[i] = consts[ai],
-            OP_VAR => regs[i] = x[ai],
-            OP_PARAM => regs[i] = params[ai],
-            OP_MULT => regs[i] = mults[ai],
-            OP_ADD => regs[i] = regs[ai] + regs[bi],
-            OP_MUL => regs[i] = regs[ai] * regs[bi],
-            OP_DIV => regs[i] = regs[ai] / regs[bi],
-            OP_NEG => regs[i] = -regs[ai],
-            OP_POWC => regs[i] = regs[ai].powf(consts[bi]),
-            OP_POW => regs[i] = regs[ai].powf(regs[bi]),
-            OP_SIN => regs[i] = regs[ai].sin(),
-            OP_COS => regs[i] = regs[ai].cos(),
-            OP_EXP => regs[i] = regs[ai].exp(),
-            OP_LOG => regs[i] = regs[ai].ln(),
-            OP_ABS => regs[i] = regs[ai].abs(),
-            OP_LINEAR => {
-                regs[i] = lin_coeffs[ai] * x[lin_vars[ai] as usize];
-                for k in (ai + 1)..bi {
-                    regs[i] += lin_coeffs[k] * x[lin_vars[k] as usize];
+        let op = ops[i];
+        // Keep the common opcodes in a compact dispatch table.
+		// The extended nonlinear vocabulary is cold for existing tapes.
+        if op <= OP_LINEAR {
+            match op {
+                OP_CONST => regs[i] = consts[ai],
+                OP_VAR => regs[i] = x[ai],
+                OP_PARAM => regs[i] = params[ai],
+                OP_MULT => regs[i] = mults[ai],
+                OP_ADD => regs[i] = regs[ai] + regs[bi],
+                OP_MUL => regs[i] = regs[ai] * regs[bi],
+                OP_DIV => regs[i] = regs[ai] / regs[bi],
+                OP_NEG => regs[i] = -regs[ai],
+                OP_POWC => regs[i] = regs[ai].powf(consts[bi]),
+                OP_POW => regs[i] = regs[ai].powf(regs[bi]),
+                OP_SIN => regs[i] = regs[ai].sin(),
+                OP_COS => regs[i] = regs[ai].cos(),
+                OP_EXP => regs[i] = regs[ai].exp(),
+                OP_LOG => regs[i] = regs[ai].ln(),
+                OP_ABS => regs[i] = regs[ai].abs(),
+                OP_LINEAR => {
+                    regs[i] = lin_coeffs[ai] * x[lin_vars[ai] as usize];
+                    for k in (ai + 1)..bi {
+                        regs[i] += lin_coeffs[k] * x[lin_vars[k] as usize];
+                    }
                 }
+                _ => regs[i] = f64::NAN,
             }
-            // Unreachable for a well-formed tape (the builder emits only the
-            // opcodes above).
-            _ => regs[i] = f64::NAN,
+        } else {
+            match op {
+                OP_SQRT => regs[i] = regs[ai].sqrt(),
+                OP_CBRT => regs[i] = regs[ai].cbrt(),
+                OP_EXP2 => regs[i] = regs[ai].exp2(),
+                OP_EXPM1 => regs[i] = regs[ai].exp_m1(),
+                OP_LOG2 => regs[i] = regs[ai].log2(),
+                OP_LOG10 => regs[i] = regs[ai].log10(),
+                OP_LOG1P => regs[i] = regs[ai].ln_1p(),
+                OP_TAN => regs[i] = regs[ai].tan(),
+                OP_ASIN => regs[i] = regs[ai].asin(),
+                OP_ACOS => regs[i] = regs[ai].acos(),
+                OP_ATAN => regs[i] = regs[ai].atan(),
+                OP_SINH => regs[i] = regs[ai].sinh(),
+                OP_COSH => regs[i] = regs[ai].cosh(),
+                OP_TANH => regs[i] = regs[ai].tanh(),
+                OP_ASINH => regs[i] = regs[ai].asinh(),
+                OP_ACOSH => regs[i] = regs[ai].acosh(),
+                OP_ATANH => regs[i] = regs[ai].atanh(),
+                OP_ATAN2 => regs[i] = regs[ai].atan2(regs[bi]),
+                OP_MIN => regs[i] = regs[ai].min(regs[bi]),
+                OP_MAX => regs[i] = regs[ai].max(regs[bi]),
+                // Unreachable for a well-formed tape (the builder emits only
+                // the opcodes above).
+                _ => regs[i] = f64::NAN,
+            }
         }
     }
     out[0] = regs[n - 1];
@@ -254,9 +303,9 @@ impl Builder {
             ExprNode::Param(p) => self.push(OP_PARAM, p.0, 0),
             ExprNode::Add(children) => self.lower_nary(arena, children, OP_ADD, 0.0),
             ExprNode::Mul(children) => self.lower_nary(arena, children, OP_MUL, 1.0),
-            ExprNode::Neg(inner) => {
+            ExprNode::Unary(op, inner) => {
                 let r = self.lower(arena, *inner);
-                self.push(OP_NEG, r, 0)
+                self.push(unary_opcode(*op), r, 0)
             }
             ExprNode::Pow(base, exp) => {
                 let base_reg = self.lower(arena, *base);
@@ -273,26 +322,13 @@ impl Builder {
                 let d = self.lower(arena, *den);
                 self.push(OP_DIV, n, d)
             }
-            ExprNode::Sin(inner) => {
-                let r = self.lower(arena, *inner);
-                self.push(OP_SIN, r, 0)
+            ExprNode::Atan2(y, x) => {
+                let y = self.lower(arena, *y);
+                let x = self.lower(arena, *x);
+                self.push(OP_ATAN2, y, x)
             }
-            ExprNode::Cos(inner) => {
-                let r = self.lower(arena, *inner);
-                self.push(OP_COS, r, 0)
-            }
-            ExprNode::Exp(inner) => {
-                let r = self.lower(arena, *inner);
-                self.push(OP_EXP, r, 0)
-            }
-            ExprNode::Log(inner) => {
-                let r = self.lower(arena, *inner);
-                self.push(OP_LOG, r, 0)
-            }
-            ExprNode::Abs(inner) => {
-                let r = self.lower(arena, *inner);
-                self.push(OP_ABS, r, 0)
-            }
+            ExprNode::Min(children) => self.lower_nary(arena, children, OP_MIN, f64::INFINITY),
+            ExprNode::Max(children) => self.lower_nary(arena, children, OP_MAX, f64::NEG_INFINITY),
             // OP_LINEAR requires a non-empty range (see `eval_tape`), so a
             // coefficient-free Linear node lowers to its constant.
             ExprNode::Linear { coeffs, constant } if coeffs.is_empty() => {
@@ -334,5 +370,33 @@ impl Builder {
             acc = self.push(op, acc, r);
         }
         acc
+    }
+}
+
+fn unary_opcode(op: UnaryOp) -> u32 {
+    match op {
+        UnaryOp::Neg => OP_NEG,
+        UnaryOp::Abs => OP_ABS,
+        UnaryOp::Sqrt => OP_SQRT,
+        UnaryOp::Cbrt => OP_CBRT,
+        UnaryOp::Exp => OP_EXP,
+        UnaryOp::Exp2 => OP_EXP2,
+        UnaryOp::Expm1 => OP_EXPM1,
+        UnaryOp::Log => OP_LOG,
+        UnaryOp::Log2 => OP_LOG2,
+        UnaryOp::Log10 => OP_LOG10,
+        UnaryOp::Log1p => OP_LOG1P,
+        UnaryOp::Sin => OP_SIN,
+        UnaryOp::Cos => OP_COS,
+        UnaryOp::Tan => OP_TAN,
+        UnaryOp::Asin => OP_ASIN,
+        UnaryOp::Acos => OP_ACOS,
+        UnaryOp::Atan => OP_ATAN,
+        UnaryOp::Sinh => OP_SINH,
+        UnaryOp::Cosh => OP_COSH,
+        UnaryOp::Tanh => OP_TANH,
+        UnaryOp::Asinh => OP_ASINH,
+        UnaryOp::Acosh => OP_ACOSH,
+        UnaryOp::Atanh => OP_ATANH,
     }
 }

--- a/crates/oximo-autodiff/src/tape.rs
+++ b/crates/oximo-autodiff/src/tape.rs
@@ -183,7 +183,7 @@ pub(crate) fn eval_tape(
         let bi = b[i] as usize;
         let op = ops[i];
         // Keep the common opcodes in a compact dispatch table.
-		// The extended nonlinear vocabulary is cold for existing tapes.
+        // The extended nonlinear vocabulary is cold for existing tapes.
         if op <= OP_LINEAR {
             match op {
                 OP_CONST => regs[i] = consts[ai],

--- a/crates/oximo-autodiff/tests/derivatives.rs
+++ b/crates/oximo-autodiff/tests/derivatives.rs
@@ -11,6 +11,7 @@
 use oximo_autodiff::{AutodiffError, NlpEvaluator, gradient_at};
 use oximo_core::Model;
 use oximo_core::prelude::*;
+use oximo_expr::UnaryOp;
 
 fn assert_close(got: f64, want: f64, tol: f64, what: &str) {
     let denom = want.abs().max(1.0);
@@ -368,6 +369,173 @@ fn gradient_at_rejects_wrong_dimension() {
         matches!(err, AutodiffError::DimensionMismatch { expected: 2, got: 1 }),
         "unexpected error: {err:?}"
     );
+}
+
+/// Check the entire smooth unary vocabulary through Enzyme's gradient and
+/// forward-over-reverse Hessian entry points.
+#[test]
+fn smooth_unary_gradients_and_hessians_match_analytic() {
+    let m = Model::new("smooth_unary");
+    variable!(m, -5.0 <= x <= 5.0);
+    let point: f64 = 0.5;
+
+    let cases = [
+        (UnaryOp::Neg, -x.sin(), -point.cos(), point.sin()),
+        (UnaryOp::Sqrt, x, 1.0 / (2.0 * point.sqrt()), -1.0 / (4.0 * point.powf(1.5))),
+        (
+            UnaryOp::Cbrt,
+            x,
+            1.0 / (3.0 * point.powf(2.0 / 3.0)),
+            -2.0 / (9.0 * point.powf(5.0 / 3.0)),
+        ),
+        (UnaryOp::Exp, x, point.exp(), point.exp()),
+        (
+            UnaryOp::Exp2,
+            x,
+            point.exp2() * std::f64::consts::LN_2,
+            point.exp2() * std::f64::consts::LN_2.powi(2),
+        ),
+        (UnaryOp::Expm1, x, point.exp(), point.exp()),
+        (UnaryOp::Log, x, 1.0 / point, -1.0 / point.powi(2)),
+        (
+            UnaryOp::Log2,
+            x,
+            1.0 / (point * std::f64::consts::LN_2),
+            -1.0 / (point.powi(2) * std::f64::consts::LN_2),
+        ),
+        (
+            UnaryOp::Log10,
+            x,
+            1.0 / (point * std::f64::consts::LN_10),
+            -1.0 / (point.powi(2) * std::f64::consts::LN_10),
+        ),
+        (UnaryOp::Log1p, x, 1.0 / (1.0 + point), -1.0 / (1.0 + point).powi(2)),
+        (UnaryOp::Sin, x, point.cos(), -point.sin()),
+        (UnaryOp::Cos, x, -point.sin(), -point.cos()),
+        (UnaryOp::Tan, x, 1.0 / point.cos().powi(2), 2.0 * point.tan() / point.cos().powi(2)),
+        (
+            UnaryOp::Asin,
+            x / 2.0,
+            0.5 / (1.0 - 0.25 * point.powi(2)).sqrt(),
+            0.25 * (0.5 * point) / (1.0 - 0.25 * point.powi(2)).powf(1.5),
+        ),
+        (
+            UnaryOp::Acos,
+            x / 2.0,
+            -0.5 / (1.0 - 0.25 * point.powi(2)).sqrt(),
+            -0.25 * (0.5 * point) / (1.0 - 0.25 * point.powi(2)).powf(1.5),
+        ),
+        (
+            UnaryOp::Atan,
+            x,
+            1.0 / (1.0 + point.powi(2)),
+            -2.0 * point / (1.0 + point.powi(2)).powi(2),
+        ),
+        (UnaryOp::Sinh, x, point.cosh(), point.sinh()),
+        (UnaryOp::Cosh, x, point.sinh(), point.cosh()),
+        (
+            UnaryOp::Tanh,
+            x,
+            1.0 - point.tanh().powi(2),
+            -2.0 * point.tanh() * (1.0 - point.tanh().powi(2)),
+        ),
+        (
+            UnaryOp::Asinh,
+            x,
+            1.0 / (1.0 + point.powi(2)).sqrt(),
+            -point / (1.0 + point.powi(2)).powf(1.5),
+        ),
+        (
+            UnaryOp::Acosh,
+            x + 1.0,
+            1.0 / ((point + 1.0).powi(2) - 1.0).sqrt(),
+            -(point + 1.0) / ((point + 1.0).powi(2) - 1.0).powf(1.5),
+        ),
+        (
+            UnaryOp::Atanh,
+            x / 2.0,
+            0.5 / (1.0 - (point / 2.0).powi(2)),
+            0.25 * point / (1.0 - (point / 2.0).powi(2)).powi(2),
+        ),
+    ];
+
+    for (op, expr, expected_grad, expected_hess) in cases {
+        let expr = match op {
+            UnaryOp::Neg => expr,
+            UnaryOp::Sqrt => expr.sqrt(),
+            UnaryOp::Cbrt => expr.cbrt(),
+            UnaryOp::Exp => expr.exp(),
+            UnaryOp::Exp2 => expr.exp2(),
+            UnaryOp::Expm1 => expr.expm1(),
+            UnaryOp::Log => expr.log(),
+            UnaryOp::Log2 => expr.log2(),
+            UnaryOp::Log10 => expr.log10(),
+            UnaryOp::Log1p => expr.log1p(),
+            UnaryOp::Sin => expr.sin(),
+            UnaryOp::Cos => expr.cos(),
+            UnaryOp::Tan => expr.tan(),
+            UnaryOp::Asin => expr.asin(),
+            UnaryOp::Acos => expr.acos(),
+            UnaryOp::Atan => expr.atan(),
+            UnaryOp::Sinh => expr.sinh(),
+            UnaryOp::Cosh => expr.cosh(),
+            UnaryOp::Tanh => expr.tanh(),
+            UnaryOp::Asinh => expr.asinh(),
+            UnaryOp::Acosh => expr.acosh(),
+            UnaryOp::Atanh => expr.atanh(),
+            _ => unreachable!("nonsmooth/binary operation in smooth test"),
+        };
+        let grad = gradient_at(&m, expr, &[point]).unwrap();
+        assert_close(grad[0], expected_grad, 1e-10, &format!("{op} gradient"));
+
+        objective!(m, Min, expr);
+        let ev = NlpEvaluator::new(&m).unwrap();
+        let mut hess = vec![0.0; ev.hessian_lagrangian_structure().len()];
+        ev.eval_hessian_lagrangian(&[point], 1.0, &[], &mut hess);
+        assert_eq!(hess.len(), 1, "{op} should have one Hessian entry");
+        assert_close(hess[0], expected_hess, 1e-9, &format!("{op} Hessian"));
+    }
+}
+
+#[test]
+fn atan2_and_branch_derivatives_match_away_from_kinks() {
+    let m = Model::new("branches");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+
+    let (xv, yv) = (2.0, 1.0);
+    let r2 = xv * xv + yv * yv;
+    let atan2 = y.atan2(x);
+    let grad = gradient_at(&m, atan2, &[xv, yv]).unwrap();
+    assert_close(grad[0], -yv / r2, 1e-10, "atan2 dx");
+    assert_close(grad[1], xv / r2, 1e-10, "atan2 dy");
+    objective!(m, Min, atan2);
+    let ev = NlpEvaluator::new(&m).unwrap();
+    let mut hess = vec![0.0; ev.hessian_lagrangian_structure().len()];
+    ev.eval_hessian_lagrangian(&[xv, yv], 1.0, &[], &mut hess);
+    let r4 = r2 * r2;
+    let expected = [2.0 * xv * yv / r4, (yv * yv - xv * xv) / r4, -2.0 * xv * yv / r4];
+    for (got, want) in hess.iter().zip(expected) {
+        assert_close(*got, want, 1e-9, "atan2 Hessian");
+    }
+
+    for (name, expr, point, expected) in [
+        ("abs", x.abs(), [1.5, 0.0], [1.0, 0.0]),
+        ("min", x.min(y), [1.0, 2.0], [1.0, 0.0]),
+        ("max", x.max(y), [2.0, 1.0], [1.0, 0.0]),
+    ] {
+        let grad = gradient_at(&m, expr, &point).unwrap();
+        for (got, want) in grad.iter().zip(expected) {
+            assert_close(*got, want, 1e-10, &format!("{name} gradient"));
+        }
+        objective!(m, Min, expr);
+        let ev = NlpEvaluator::new(&m).unwrap();
+        let mut hess = vec![0.0; ev.hessian_lagrangian_structure().len()];
+        ev.eval_hessian_lagrangian(&point, 1.0, &[], &mut hess);
+        for value in hess {
+            assert_close(value, 0.0, 1e-9, &format!("{name} Hessian"));
+        }
+    }
 }
 
 /// A dense Hessian yields one seed per column, crossing the parallel-HVP

--- a/crates/oximo-autodiff/tests/sparsity.rs
+++ b/crates/oximo-autodiff/tests/sparsity.rs
@@ -5,7 +5,7 @@
 use oximo_autodiff::sparsity::{
     HessianColoring, hessian_pattern, star_hessian_coloring, variable_support,
 };
-use oximo_expr::{ExprArena, ExprNode, VarId, extract_quadratic};
+use oximo_expr::{ExprArena, ExprNode, UnaryOp, VarId, extract_quadratic};
 use rustc_hash::FxHashSet;
 
 fn var(arena: &mut ExprArena, i: u32) -> oximo_expr::ExprId {
@@ -18,7 +18,7 @@ fn separable_sum_of_sins_is_diagonal() {
     let sins: Vec<_> = (0..5)
         .map(|i| {
             let x = var(&mut arena, i);
-            arena.push(ExprNode::Sin(x))
+            arena.push(ExprNode::Unary(UnaryOp::Sin, x))
         })
         .collect();
     let root = arena.push(ExprNode::Add(sins.into_iter().collect()));
@@ -33,7 +33,7 @@ fn product_and_unary_patterns() {
     let x2 = var(&mut arena, 2);
 
     let mul = arena.push(ExprNode::Mul([x0, x1].into_iter().collect()));
-    let sin = arena.push(ExprNode::Sin(x2));
+    let sin = arena.push(ExprNode::Unary(UnaryOp::Sin, x2));
     let root = arena.push(ExprNode::Add([mul, sin].into_iter().collect()));
     assert_eq!(hessian_pattern(&arena, root), vec![(1, 0), (2, 2)]);
 
@@ -53,13 +53,13 @@ fn product_and_unary_patterns() {
 fn abs_passes_through_its_argument_pattern() {
     let mut arena = ExprArena::new();
     let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), -1.0)], 0.0);
-    let abs_lin = arena.push(ExprNode::Abs(lin));
+    let abs_lin = arena.push(ExprNode::Unary(UnaryOp::Abs, lin));
     assert_eq!(hessian_pattern(&arena, abs_lin), vec![]);
 
     let x0 = var(&mut arena, 0);
     let three = arena.constant(3.0);
     let cube = arena.push(ExprNode::Pow(x0, three));
-    let abs_cube = arena.push(ExprNode::Abs(cube));
+    let abs_cube = arena.push(ExprNode::Unary(UnaryOp::Abs, cube));
     assert_eq!(hessian_pattern(&arena, abs_cube), vec![(0, 0)]);
 }
 
@@ -67,7 +67,7 @@ fn abs_passes_through_its_argument_pattern() {
 fn dag_shared_subexpression() {
     let mut arena = ExprArena::new();
     let x0 = var(&mut arena, 0);
-    let s = arena.push(ExprNode::Sin(x0));
+    let s = arena.push(ExprNode::Unary(UnaryOp::Sin, x0));
     let mul = arena.push(ExprNode::Mul([s, s].into_iter().collect()));
     let root = arena.push(ExprNode::Add([mul, s].into_iter().collect()));
     assert_eq!(hessian_pattern(&arena, root), vec![(0, 0)]);
@@ -120,7 +120,7 @@ fn sin_of_sum_is_a_full_clique() {
     let x = var(&mut arena, 0);
     let y = var(&mut arena, 1);
     let sum = arena.push(ExprNode::Add([x, y].into_iter().collect()));
-    let s = arena.push(ExprNode::Sin(sum));
+    let s = arena.push(ExprNode::Unary(UnaryOp::Sin, sum));
     assert_eq!(hessian_pattern(&arena, s), vec![(0, 0), (1, 0), (1, 1)]);
 }
 
@@ -148,7 +148,7 @@ fn packed_support_spans_multiple_words() {
     let mut arena = ExprArena::new();
     let vars: Vec<_> = (0..70).map(|i| var(&mut arena, i)).collect();
     let sum = arena.push(ExprNode::Add(vars.into_iter().collect()));
-    let root = arena.push(ExprNode::Sin(sum));
+    let root = arena.push(ExprNode::Unary(UnaryOp::Sin, sum));
     let pattern = hessian_pattern(&arena, root);
     assert_eq!(pattern.len(), 70 * 71 / 2);
     assert_eq!(pattern.first(), Some(&(0, 0)));
@@ -162,7 +162,7 @@ fn wide_sparse_support_avoids_dense_pair_storage() {
     let mut arena = ExprArena::new();
     let vars: Vec<_> = (0..1_025).map(|i| var(&mut arena, i)).collect();
     let endpoints = arena.push(ExprNode::Add([vars[0], vars[1_024]].into_iter().collect()));
-    let nonlinear = arena.push(ExprNode::Sin(endpoints));
+    let nonlinear = arena.push(ExprNode::Unary(UnaryOp::Sin, endpoints));
     let root =
         arena.push(ExprNode::Add(vars.into_iter().chain(std::iter::once(nonlinear)).collect()));
 
@@ -176,7 +176,7 @@ fn sparse_variable_ids_are_coordinate_compressed() {
     let low = var(&mut arena, 7);
     let high = var(&mut arena, u32::MAX);
     let sum = arena.push(ExprNode::Add([high, low].into_iter().collect()));
-    let root = arena.push(ExprNode::Sin(sum));
+    let root = arena.push(ExprNode::Unary(UnaryOp::Sin, sum));
     assert_eq!(variable_support(&arena, root), vec![7, u32::MAX]);
     assert_eq!(hessian_pattern(&arena, root), vec![(7, 7), (u32::MAX, 7), (u32::MAX, u32::MAX)]);
 }
@@ -185,7 +185,7 @@ fn sparse_variable_ids_are_coordinate_compressed() {
 fn zero_power_keeps_syntactic_support_but_has_no_hessian() {
     let mut arena = ExprArena::new();
     let x = var(&mut arena, 11);
-    let nonlinear_base = arena.push(ExprNode::Sin(x));
+    let nonlinear_base = arena.push(ExprNode::Unary(UnaryOp::Sin, x));
     let zero = arena.constant(0.0);
     let root = arena.push(ExprNode::Pow(nonlinear_base, zero));
     assert_eq!(variable_support(&arena, root), vec![11]);
@@ -201,7 +201,7 @@ fn deep_sparsity_walks_are_iterative() {
     let mut arena = ExprArena::with_capacity(50_001);
     let mut root = var(&mut arena, 3);
     for _ in 0..50_000 {
-        root = arena.push(ExprNode::Neg(root));
+        root = arena.push(ExprNode::Unary(UnaryOp::Neg, root));
     }
     assert_eq!(variable_support(&arena, root), vec![3]);
     assert_eq!(hessian_pattern(&arena, root), vec![]);
@@ -365,4 +365,20 @@ fn sparse_ids_and_duplicate_entries_are_deterministic() {
     assert_eq!(first.groups, second.groups);
     assert_eq!(first.recover, second.recover);
     assert_eq!(first.groups.len(), 2);
+}
+
+#[test]
+fn nonsmooth_branch_unions_do_not_add_cross_terms() {
+    let mut arena = ExprArena::new();
+    let x = var(&mut arena, 0);
+    let y = var(&mut arena, 1);
+    let two = arena.constant(2.0);
+    let x2 = arena.push(ExprNode::Pow(x, two));
+    let sin_y = arena.push(ExprNode::Unary(UnaryOp::Sin, y));
+    let minimum = arena.push(ExprNode::Min([x2, sin_y].into_iter().collect()));
+    assert_eq!(hessian_pattern(&arena, minimum), vec![(0, 0), (1, 1)]);
+
+    let affine_min = arena.push(ExprNode::Min([x, y].into_iter().collect()));
+    assert!(hessian_pattern(&arena, affine_min).is_empty());
+    assert_eq!(variable_support(&arena, affine_min), vec![0, 1]);
 }

--- a/crates/oximo-autodiff/tests/tape.rs
+++ b/crates/oximo-autodiff/tests/tape.rs
@@ -10,7 +10,7 @@ use oximo_autodiff::sparsity::{
     hessian_lagrangian_structure, jacobian_structure, variable_support,
 };
 use oximo_autodiff::tape::Tape;
-use oximo_expr::{ExprArena, ExprId, ExprNode, VarId, evaluate};
+use oximo_expr::{ExprArena, ExprId, ExprNode, UnaryOp, VarId, evaluate};
 
 fn assert_close(got: f64, want: f64, tol: f64, what: &str) {
     let denom = want.abs().max(1.0);
@@ -60,15 +60,15 @@ fn every_node_kind_matches_evaluate() {
 
     let add = arena.push(ExprNode::Add([x0, x1, c2].into_iter().collect()));
     let mul = arena.push(ExprNode::Mul([x0, x1, p0].into_iter().collect()));
-    let neg = arena.push(ExprNode::Neg(mul));
+    let neg = arena.push(ExprNode::Unary(UnaryOp::Neg, mul));
     let powc = arena.push(ExprNode::Pow(x0, c3));
     let pow = arena.push(ExprNode::Pow(add, x1)); // expression exponent
     let div = arena.push(ExprNode::Div(powc, x1));
-    let sin = arena.push(ExprNode::Sin(x0));
-    let cos = arena.push(ExprNode::Cos(x1));
-    let exp = arena.push(ExprNode::Exp(sin));
-    let log = arena.push(ExprNode::Log(exp));
-    let abs = arena.push(ExprNode::Abs(neg));
+    let sin = arena.push(ExprNode::Unary(UnaryOp::Sin, x0));
+    let cos = arena.push(ExprNode::Unary(UnaryOp::Cos, x1));
+    let exp = arena.push(ExprNode::Unary(UnaryOp::Exp, sin));
+    let log = arena.push(ExprNode::Unary(UnaryOp::Log, exp));
+    let abs = arena.push(ExprNode::Unary(UnaryOp::Abs, neg));
     let lin = arena.linear(vec![(VarId(0), 2.0), (VarId(1), -0.5)], 4.0);
     let root =
         arena.push(ExprNode::Add([add, neg, pow, div, cos, log, abs, lin].into_iter().collect()));
@@ -85,7 +85,7 @@ fn every_node_kind_matches_evaluate() {
 fn shared_subexpressions_lower_once() {
     let mut arena = ExprArena::new();
     let x0 = arena.var(VarId(0));
-    let sin = arena.push(ExprNode::Sin(x0));
+    let sin = arena.push(ExprNode::Unary(UnaryOp::Sin, x0));
     // sin(x0) used three times: as a DAG the tape must reuse the register.
     let mul = arena.push(ExprNode::Mul([sin, sin].into_iter().collect()));
     let root = arena.push(ExprNode::Add([mul, sin].into_iter().collect()));
@@ -101,9 +101,9 @@ fn weighted_tape_matches_manual_sum() {
     let mut arena = ExprArena::new();
     let x0 = arena.var(VarId(0));
     let x1 = arena.var(VarId(1));
-    let sin = arena.push(ExprNode::Sin(x0));
+    let sin = arena.push(ExprNode::Unary(UnaryOp::Sin, x0));
     let f0 = arena.push(ExprNode::Mul([sin, x1].into_iter().collect()));
-    let f1 = arena.push(ExprNode::Exp(x1));
+    let f1 = arena.push(ExprNode::Unary(UnaryOp::Exp, x1));
     let f2 = arena.push(ExprNode::Mul([sin, sin].into_iter().collect())); // shares sin
 
     let tape = Tape::compile_weighted(&arena, &[f0, f1, f2]);
@@ -147,7 +147,7 @@ fn classification_fast_paths() {
     assert!(matches!(slot.kind, SlotKind::Quadratic(_)), "quadratic slot");
     assert_eq!(slot.support, vec![0, 1]);
 
-    let sin = arena.push(ExprNode::Sin(x0));
+    let sin = arena.push(ExprNode::Unary(UnaryOp::Sin, x0));
     let slot = FunctionSlot::classify(&arena, sin);
     assert!(slot.is_nonlinear(), "nonlinear slot");
     assert_eq!(slot.support, vec![0]);
@@ -196,7 +196,7 @@ fn sparsity_patterns() {
     let mut arena = ExprArena::new();
     let x0 = arena.var(VarId(0));
     let x2 = arena.var(VarId(2));
-    let sin = arena.push(ExprNode::Sin(x2));
+    let sin = arena.push(ExprNode::Unary(UnaryOp::Sin, x2));
     let mul = arena.push(ExprNode::Mul([x0, sin].into_iter().collect()));
     let lin = arena.linear(vec![(VarId(1), 1.0), (VarId(3), 2.0)], 0.0);
     let root = arena.push(ExprNode::Add([mul, lin].into_iter().collect()));
@@ -220,8 +220,47 @@ fn sparsity_patterns() {
 fn lagrangian_structure_handles_wide_sparse_variable_ids() {
     let mut arena = ExprArena::new();
     let high = arena.var(VarId(1_024));
-    let nonlinear = arena.push(ExprNode::Sin(high));
+    let nonlinear = arena.push(ExprNode::Unary(UnaryOp::Sin, high));
     let slots = [FunctionSlot::classify(&arena, nonlinear)];
 
     assert_eq!(hessian_lagrangian_structure(&slots), vec![(1_024, 1_024)]);
+}
+
+#[test]
+fn tape_matches_direct_evaluation_for_full_nonlinear_vocabulary() {
+    let cell = oximo_expr::ExprArenaCell::new(ExprArena::new());
+    let x = oximo_expr::Expr::from_var(&cell, VarId(0));
+    let y = oximo_expr::Expr::from_var(&cell, VarId(1));
+    let roots = [
+        x.abs(),
+        (x + 2.0).sqrt(),
+        y.cbrt(),
+        x.exp(),
+        x.exp2(),
+        x.expm1(),
+        (x + 2.0).log(),
+        (x + 2.0).log2(),
+        (x + 2.0).log10(),
+        x.log1p(),
+        x.sin(),
+        x.cos(),
+        x.tan(),
+        (x / 2.0).asin(),
+        (x / 2.0).acos(),
+        x.atan(),
+        y.sinh(),
+        y.cosh(),
+        y.tanh(),
+        y.asinh(),
+        (x + 1.0).acosh(),
+        (y / 2.0).atanh(),
+        y.atan2(x),
+        x.min(y),
+        x.max(y),
+    ];
+    let arena = cell.borrow();
+    let points = [vec![0.75, -0.5], vec![1.25, 0.25]];
+    for root in roots {
+        check_matches_evaluate(&arena, root.id, &points);
+    }
 }

--- a/crates/oximo-baron/README.md
+++ b/crates/oximo-baron/README.md
@@ -74,6 +74,35 @@ cargo run -p oximo --example baron_robot --features baron
 | `.threads(u32)`         | `threads: <n>`       | none    |
 | `.verbose(bool)`        | `PrLevel: 1/0`       | none    |
 
+### Nonlinear expressions
+
+The [BARON User Manual and Installation Guide, version 2026.9.10, Sections
+6--7](https://minlp-downloads.nyc3.cdn.digitaloceanspaces.com/docs/baron%20manual.pdf#page=18)
+explicitly documents the variable-power rewrite `x^y = exp(y * log(x))`, the
+absolute-value rewrite `abs(x) = (x^2)^0.5`, and the base-10 logarithm rewrite
+`log10(x) = 0.4342944819032518 * log(x)`. Because BARON accepts `x^alpha` and
+`beta^x` for real constants `alpha` and `beta`, the adapter emits `sqrt(x)` as
+`x^0.5` and `exp2(x)` as `2^x`.
+
+### Convex equation hints
+
+BARON can generate supporting hyperplanes for an entire convex feasible set
+instead of relaxing its expression term by term. Pass the corresponding
+algebraic constraint IDs to [`BaronOptions::convex_equations`]:
+
+```rust,no_run
+use oximo_baron::BaronOptions;
+use oximo_core::prelude::*;
+
+let m = Model::new("convex_hint");
+variable!(m, -1.0 <= x <= 1.0);
+variable!(m, -1.0 <= y <= 1.0);
+let disk = constraint!(m, disk, x.powi(2) + y.powi(2) <= 1.0);
+objective!(m, Min, x + y);
+
+let options = BaronOptions::default().convex_equations([disk]);
+```
+
 ### BARON-specific options
 
 Each builder method is the snake_case form of a BARON keyword. Highlights:

--- a/crates/oximo-baron/src/lib.rs
+++ b/crates/oximo-baron/src/lib.rs
@@ -1,9 +1,10 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
-//! References:
-//! N. Sahinidis, BARON User Manual, version 2026.4.12.
-//! The Optimization Firm, LLC, Apr. 12, 2026.
+//! Reference: [N. Sahinidis, *BARON User Manual and Installation Guide*, version
+//! 2026.9.10, The Optimization Firm, LLC, September 10, 2026][baron-manual].
+//!
+//! [baron-manual]: https://minlp-downloads.nyc3.cdn.digitaloceanspaces.com/docs/baron%20manual.pdf
 
 mod options;
 mod translate;

--- a/crates/oximo-baron/src/options.rs
+++ b/crates/oximo-baron/src/options.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write as FmtWrite;
 use std::path::PathBuf;
 
+use oximo_core::ConstraintId;
 use oximo_solver::{HasUniversal, UniversalOptions};
 
 /// BARON-specific solver options.
@@ -30,6 +31,7 @@ pub struct BaronOptions {
     dbl_opts: Vec<(&'static str, f64)>,
     str_opts: Vec<(&'static str, String)>,
     raw: Vec<(String, String)>,
+    convex_equation_ids: Vec<ConstraintId>,
 }
 
 /// BARON keywords the backend writes itself; user attempts to set these via
@@ -251,6 +253,38 @@ impl BaronOptions {
         self
     }
 
+    /// Assert that one algebraic constraint defines a convex feasible set.
+    ///
+    /// BARON emits the corresponding row in `CONVEX_EQUATIONS`, allowing it to
+    /// generate supporting hyperplanes for the complete set instead of relaxing
+    /// the expression operation by operation. This is a correctness-sensitive
+    /// assertion: incorrectly marking a nonconvex constraint can make BARON
+    /// return an incorrect answer without warning.
+    ///
+    /// Two-sided range constraints are currently rejected because the BARON
+    /// adapter emits them as separate lower and upper equations. Use two explicit
+    /// single-sided constraints and mark only sides whose feasible sets are known
+    /// to be convex.
+    #[must_use]
+    pub fn convex_equation(self, constraint: ConstraintId) -> Self {
+        self.convex_equations([constraint])
+    }
+
+    /// Assert that each algebraic constraint defines a convex feasible set.
+    ///
+    /// Duplicate IDs are ignored while preserving their first occurrence.
+    /// See [`Self::convex_equation`] for correctness and range-constraint
+    /// requirements.
+    #[must_use]
+    pub fn convex_equations(mut self, constraints: impl IntoIterator<Item = ConstraintId>) -> Self {
+        for constraint in constraints {
+            if !self.convex_equation_ids.contains(&constraint) {
+                self.convex_equation_ids.push(constraint);
+            }
+        }
+        self
+    }
+
     /// Set an arbitrary BARON option by keyword, written verbatim as
     /// `keyword: value;` in the `OPTIONS{ ... }` block. Use this for any option
     /// without a dedicated builder. The `value` is emitted as-is, so use quote
@@ -270,6 +304,10 @@ impl BaronOptions {
     pub(crate) fn has_comp_iis(&self) -> bool {
         self.int_opts.iter().any(|(k, _)| *k == "CompIIS")
             || self.raw.iter().any(|(k, _)| k.eq_ignore_ascii_case("CompIIS"))
+    }
+
+    pub(crate) fn convex_equation_ids(&self) -> &[ConstraintId] {
+        &self.convex_equation_ids
     }
 }
 
@@ -351,6 +389,7 @@ pub fn write_options(bar: &mut String, o: &BaronOptions, res_name: &str, tim_nam
 mod tests {
     use std::time::Duration;
 
+    use oximo_core::ConstraintId;
     use oximo_solver::UniversalOptionsExt;
 
     use super::*;
@@ -374,6 +413,20 @@ mod tests {
         assert_eq!(o.universal.verbose, Some(true));
         assert_eq!(o.dbl_opts, vec![("EpsR", 1e-4)]);
         assert_eq!(o.baron_path.as_deref(), Some(std::path::Path::new("/opt/baron/baron")));
+    }
+
+    #[test]
+    fn convex_equation_builders_preserve_order_and_deduplicate() {
+        let options = BaronOptions::default().convex_equation(ConstraintId(2)).convex_equations([
+            ConstraintId(0),
+            ConstraintId(2),
+            ConstraintId(1),
+        ]);
+
+        assert_eq!(
+            options.convex_equation_ids(),
+            &[ConstraintId(2), ConstraintId(0), ConstraintId(1)]
+        );
     }
 
     #[test]

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -11,7 +11,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, Objective, ObjectiveSense, Sense, SocConstraint,
     SocConstraintId, VarId, Variable,
 };
-use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms};
+use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, UnaryOp};
 use oximo_solver::{
     DualStatus, Iis, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
     VarBoundKind,
@@ -541,6 +541,7 @@ fn write_linear(bar: &mut String, t: &LinearTerms<'_>, include_constant: bool) {
 }
 
 /// Recursive infix printer for a BARON-compatible expression.
+#[expect(clippy::too_many_lines)]
 fn write_bar_expr(bar: &mut String, arena: &ExprArena, id: ExprId) -> Result<(), SolverError> {
     match arena.get(id) {
         ExprNode::Const(c) => write!(bar, "{}", fmt(*c)).unwrap(),
@@ -552,7 +553,7 @@ fn write_bar_expr(bar: &mut String, arena: &ExprArena, id: ExprId) -> Result<(),
             write_linear(bar, &t, true);
             write!(bar, ")").unwrap();
         }
-        ExprNode::Neg(inner) => {
+        ExprNode::Unary(UnaryOp::Neg, inner) => {
             write!(bar, "(-").unwrap();
             write_bar_expr(bar, arena, *inner)?;
             write!(bar, ")").unwrap();
@@ -604,35 +605,62 @@ fn write_bar_expr(bar: &mut String, arena: &ExprArena, id: ExprId) -> Result<(),
             write_bar_expr(bar, arena, *den)?;
             write!(bar, ")").unwrap();
         }
-        ExprNode::Exp(a) => {
+        ExprNode::Unary(UnaryOp::Exp, a) => {
             write!(bar, "exp(").unwrap();
             write_bar_expr(bar, arena, *a)?;
             write!(bar, ")").unwrap();
         }
-        ExprNode::Log(a) => {
+        ExprNode::Unary(UnaryOp::Log, a) => {
             write!(bar, "log(").unwrap();
             write_bar_expr(bar, arena, *a)?;
             write!(bar, ")").unwrap();
         }
-        ExprNode::Sin(_) => {
-            return Err(SolverError::Backend(
-                "BARON does not support sin(); the .bar format has no trigonometric intrinsics"
-                    .into(),
-            ));
+        ExprNode::Unary(UnaryOp::Sqrt, a) => {
+            write!(bar, "((").unwrap();
+            write_bar_expr(bar, arena, *a)?;
+            write!(bar, ") ^ 0.5)").unwrap();
         }
-        ExprNode::Cos(_) => {
-            return Err(SolverError::Backend(
-                "BARON does not support cos(); the .bar format has no trigonometric intrinsics"
-                    .into(),
-            ));
+        ExprNode::Unary(UnaryOp::Exp2, a) => {
+            write!(bar, "(2 ^ (").unwrap();
+            write_bar_expr(bar, arena, *a)?;
+            write!(bar, "))").unwrap();
         }
-        ExprNode::Abs(a) => {
+        ExprNode::Unary(UnaryOp::Log10, a) => {
+            write!(bar, "(0.4342944819032518 * log(").unwrap();
+            write_bar_expr(bar, arena, *a)?;
+            write!(bar, "))").unwrap();
+        }
+        ExprNode::Unary(UnaryOp::Abs, a) => {
             // BARON has no abs() intrinsic.
             // We reformulate: |x| = (x^2)^(1/2),
             // As suggested by the BARON user manual.
             write!(bar, "(((").unwrap();
             write_bar_expr(bar, arena, *a)?;
             write!(bar, ") ^ 2) ^ 0.5)").unwrap();
+        }
+        ExprNode::Unary(op, _) => {
+            return Err(SolverError::UnsupportedNonlinearOperator {
+                backend: "BARON",
+                operator: op.name(),
+            });
+        }
+        ExprNode::Atan2(_, _) => {
+            return Err(SolverError::UnsupportedNonlinearOperator {
+                backend: "BARON",
+                operator: "atan2",
+            });
+        }
+        ExprNode::Min(_) => {
+            return Err(SolverError::UnsupportedNonlinearOperator {
+                backend: "BARON",
+                operator: "min",
+            });
+        }
+        ExprNode::Max(_) => {
+            return Err(SolverError::UnsupportedNonlinearOperator {
+                backend: "BARON",
+                operator: "max",
+            });
         }
     }
     Ok(())
@@ -646,18 +674,14 @@ fn expr_has_var(arena: &ExprArena, id: ExprId) -> bool {
         ExprNode::Var(_) => true,
         ExprNode::Const(_) | ExprNode::Param(_) => false,
         ExprNode::Linear { coeffs, .. } => coeffs.iter().any(|(_, c)| *c != 0.0),
-        ExprNode::Neg(a)
-        | ExprNode::Sin(a)
-        | ExprNode::Cos(a)
-        | ExprNode::Exp(a)
-        | ExprNode::Log(a)
-        | ExprNode::Abs(a) => expr_has_var(arena, *a),
-        ExprNode::Pow(a, b) | ExprNode::Div(a, b) => {
+        ExprNode::Unary(_, a) => expr_has_var(arena, *a),
+        ExprNode::Pow(a, b) | ExprNode::Div(a, b) | ExprNode::Atan2(a, b) => {
             expr_has_var(arena, *a) || expr_has_var(arena, *b)
         }
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
-            children.iter().any(|c| expr_has_var(arena, *c))
-        }
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => children.iter().any(|c| expr_has_var(arena, *c)),
     }
 }
 
@@ -1474,10 +1498,21 @@ mod tests {
         variable!(m, -1.0 <= x <= 1.0);
         objective!(m, Min, x.sin());
         let err = build_bar(&m, &BaronOptions::default()).unwrap_err();
-        match err {
-            SolverError::Backend(msg) => assert!(msg.contains("sin"), "{msg}"),
-            other => panic!("expected Backend error, got {other:?}"),
-        }
+        assert!(matches!(
+            err,
+            SolverError::UnsupportedNonlinearOperator { backend: "BARON", operator: "sin" }
+        ));
+    }
+
+    #[test]
+    fn structural_extrema_are_rejected_without_automatic_reformulation() {
+        let m = Model::new("extrema");
+        variable!(m, -1.0 <= x <= 1.0);
+        objective!(m, Min, x.min(-x));
+        assert!(matches!(
+            build_bar(&m, &BaronOptions::default()),
+            Err(SolverError::UnsupportedNonlinearOperator { backend: "BARON", operator: "min" })
+        ));
     }
 
     #[test]

--- a/crates/oximo-baron/src/translate.rs
+++ b/crates/oximo-baron/src/translate.rs
@@ -234,7 +234,8 @@ fn build_bar(model: &Model, opts: &BaronOptions) -> Result<BarParts, SolverError
     write_options(&mut bar, opts, RES_NAME, TIM_NAME);
     let var_order = write_var_declarations(&mut bar, vars)?;
     write_bounds(&mut bar, vars);
-    let con_order = write_equations(&mut bar, &prepared, constraints, socs)?;
+    let con_order =
+        write_equations(&mut bar, &prepared, constraints, socs, opts.convex_equation_ids())?;
     write_objective(&mut bar, &prepared, objective)?;
     write_starting_point(&mut bar, vars);
     let soc_bounds = socs
@@ -374,6 +375,7 @@ fn write_equations(
     prepared: &PreparedExpressions,
     constraints: &[Constraint],
     socs: &[SocConstraint],
+    convex_equation_ids: &[ConstraintId],
 ) -> Result<Vec<ConstraintId>, SolverError> {
     let arena = prepared.arena();
     let mut emit_map: Vec<ConstraintId> = Vec::with_capacity(constraints.len());
@@ -407,15 +409,59 @@ fn write_equations(
         names.push(format!("soc{i}"));
         names.push(format!("soc{i}_sign"));
     }
+    let convex_names = convex_equation_names(constraints, convex_equation_ids)?;
     if names.is_empty() {
         return Ok(emit_map);
     }
 
     writeln!(bar, "EQUATIONS {};", names.join(", ")).unwrap();
+    if !convex_names.is_empty() {
+        writeln!(bar, "CONVEX_EQUATIONS {};", convex_names.join(", ")).unwrap();
+    }
     bar.push_str(&bodies);
     write_soc_rows(bar, prepared, socs);
     writeln!(bar).unwrap();
     Ok(emit_map)
+}
+
+/// Resolve user-supplied algebraic IDs to the exact BARON row names emitted by
+/// [`write_equations`]. A range becomes two BARON rows and is rejected: asserting
+/// convexity for both sides is not implied by convexity of the combined range.
+fn convex_equation_names(
+    constraints: &[Constraint],
+    requested: &[ConstraintId],
+) -> Result<Vec<String>, SolverError> {
+    let mut names = Vec::with_capacity(requested.len());
+    for &id in requested {
+        let Some(constraint) = constraints.get(id.index()) else {
+            return Err(SolverError::Backend(format!(
+                "BARON convex-equation assertion references unknown algebraic constraint {id:?}"
+            )));
+        };
+        if !constraint.active {
+            return Err(SolverError::Backend(format!(
+                "BARON convex-equation assertion references inactive constraint '{}' ({id:?})",
+                constraint.name
+            )));
+        }
+        if constraint.is_range() {
+            return Err(SolverError::Backend(format!(
+                "BARON convex-equation assertion cannot mark two-sided range constraint '{}' \
+                 ({id:?}); express it as separate single-sided constraints and mark only the \
+                 convex sides",
+                constraint.name
+            )));
+        }
+        let Some((suffix, _, _)) = equation_rows(constraint).into_iter().flatten().next() else {
+            return Err(SolverError::Backend(format!(
+                "BARON convex-equation assertion references constraint '{}' ({id:?}), which \
+                 emits no equation",
+                constraint.name
+            )));
+        };
+        names.push(format!("c{}{suffix}", id.index()));
+    }
+    Ok(names)
 }
 
 /// Emit each explicit SOC constraint `||terms||_2 <= bound` as the polynomial
@@ -1284,7 +1330,7 @@ pub mod benchmark_support {
         let map = if parallel {
             render_parallel(&mut out, &arena, &constraints, &socs)?
         } else {
-            write_equations(&mut out, &arena, &constraints, &socs)?
+            write_equations(&mut out, &arena, &constraints, &socs, &[])?
         };
         std::hint::black_box(map);
         Ok(out)
@@ -1368,6 +1414,64 @@ mod tests {
         assert!(bar.contains("EQUATIONS c0;"), "{bar}");
         assert!(bar.contains("<= 5"), "{bar}");
         assert!(bar.contains("UPPER_BOUNDS{"), "{bar}");
+    }
+
+    #[test]
+    fn convex_equation_hint_names_selected_rows_before_their_definitions() {
+        let m = Model::new("convex_rows");
+        variable!(m, -1.0 <= x <= 1.0);
+        variable!(m, -1.0 <= y <= 1.0);
+        let disk = constraint!(m, disk, x.powi(2) + y.powi(2) <= 1.0);
+        constraint!(m, cap, x + y <= 1.0);
+        objective!(m, Min, x + y);
+
+        let options = BaronOptions::default().convex_equations([disk, disk]);
+        let bar = build_bar(&m, &options).expect("build convex equation hint").0;
+        assert!(bar.contains("EQUATIONS c0, c1;"), "{bar}");
+        assert!(bar.contains("CONVEX_EQUATIONS c0;"), "{bar}");
+        let declaration = bar.find("CONVEX_EQUATIONS c0;").unwrap();
+        let definition = bar.find("c0:").unwrap();
+        assert!(declaration < definition, "declaration must precede equation body:\n{bar}");
+    }
+
+    #[test]
+    fn convex_equation_hint_rejects_unknown_id() {
+        let m = Model::new("unknown_convex_row");
+        variable!(m, 0.0 <= x <= 1.0);
+        constraint!(m, cap, x <= 1.0);
+        objective!(m, Min, x);
+
+        let error =
+            build_bar(&m, &BaronOptions::default().convex_equation(ConstraintId(99))).unwrap_err();
+        assert!(error.to_string().contains("unknown algebraic constraint"), "{error}");
+    }
+
+    #[test]
+    fn convex_equation_hint_rejects_free_and_two_sided_rows() {
+        let m = Model::new("invalid_convex_rows");
+        variable!(m, -1.0 <= x <= 1.0);
+        let free = m.__add_constraint_interval("free", x, f64::NEG_INFINITY, f64::INFINITY);
+        let range = m.__add_constraint_interval("range", x, -0.5, 0.5);
+        objective!(m, Min, x);
+
+        let free_error = build_bar(&m, &BaronOptions::default().convex_equation(free)).unwrap_err();
+        assert!(free_error.to_string().contains("emits no equation"), "{free_error}");
+
+        let range_error =
+            build_bar(&m, &BaronOptions::default().convex_equation(range)).unwrap_err();
+        assert!(range_error.to_string().contains("two-sided range"), "{range_error}");
+    }
+
+    #[test]
+    fn convex_equation_hint_rejects_inactive_row() {
+        let m = Model::new("inactive_convex_row");
+        variable!(m, 0.0 <= x <= 1.0);
+        constraint!(m, cap, x <= 1.0);
+        let mut constraints = m.constraints().algebraic().to_vec();
+        constraints[0].active = false;
+
+        let error = convex_equation_names(&constraints, &[ConstraintId(0)]).unwrap_err();
+        assert!(error.to_string().contains("inactive constraint"), "{error}");
     }
 
     #[test]
@@ -1468,6 +1572,17 @@ mod tests {
         assert!(bar.contains("exp("), "{bar}");
         assert!(bar.contains("log("), "{bar}");
         assert!(!bar.contains('^'), "must not emit caret for variable exponent:\n{bar}");
+    }
+
+    #[test]
+    fn added_functions_use_supported_powers_and_documented_log10_mapping() {
+        let m = Model::new("added_functions");
+        variable!(m, 0.1 <= x <= 10.0);
+        objective!(m, Min, x.sqrt() + x.exp2() + x.log10());
+        let bar = render(&m);
+        assert!(bar.contains(") ^ 0.5)"), "sqrt mapping:\n{bar}");
+        assert!(bar.contains("2 ^ ("), "exp2 mapping:\n{bar}");
+        assert!(bar.contains("0.4342944819032518 * log("), "log10 mapping:\n{bar}");
     }
 
     #[test]

--- a/crates/oximo-core/README.md
+++ b/crates/oximo-core/README.md
@@ -2,7 +2,7 @@
 
 Core modeling types for [oximo](https://github.com/oximo-rs/oximo): `Model`, `Variable`, `Set`, `Constraint`, `Objective`, `Parameter`, `IndexedVar`, `Domain`, and `ModelKind`.
 
-Re-exports `oximo-expr` types (`Expr`, `ExprArena`, `ExprId`, `ExprNode`, `ParamId`, `VarId`) so downstream code does not need a separate `oximo-expr` import. End users typically depend on the umbrella `oximo` crate rather than this one directly.
+Re-exports `oximo-expr` types (`Expr`, `ExprArena`, `ExprId`, `ExprNode`, `UnaryOp`, `Children`, `ParamId`, `VarId`) so downstream code does not need a separate `oximo-expr` import. End users typically depend on the umbrella `oximo` crate rather than this one directly.
 
 ## Usage
 
@@ -43,7 +43,7 @@ println!("kind = {:?}", m.kind()); // LP
 ## Modeling API
 
 The modeling surface is a set of macros: `variable!`, `constraint!`, `objective!`,
-`sum!`, `set!`, and `param!`. Each expands to the underlying typed model operations,
+`sum!`, `min!`, `max!`, `set!`, and `param!`. Each expands to the underlying typed model operations,
 so there is no runtime cost and full compile-time type/borrow checking is preserved.
 
 `Model` uses interior mutability, so a macro can take `&m`, register
@@ -310,6 +310,10 @@ The method form `m.add_soc_constraint("cone", [x, y], t)` is equivalent.
 objective!(m, Min, cost_expr);
 objective!(m, Max, revenue_expr);
 ```
+
+Nonlinear expressions use `Expr` methods such as `sqrt`, `exp2`, `log1p`,
+`atan2`, `min`, and `max`. `min!`/`max!` provide the same indexed-domain
+syntax as `sum!` and preserve deterministic child order.
 
 ## Parameters
 

--- a/crates/oximo-core/src/lib.rs
+++ b/crates/oximo-core/src/lib.rs
@@ -51,10 +51,11 @@ pub use var::{VarBuilder, Variable, var_name};
 // Re-export the expression handle so downstream code does not need a separate
 // `oximo-expr` import.
 pub use oximo_expr::{
-    EvalError, Expr, ExprArena, ExprArenaCell, ExprArenaSnapshot, ExprArenaWriteGuard, ExprId,
-    ExprNode, ParamId, VarId, describe_nonlinear_term, dot, render_expr, render_linear_terms,
+    Children, EvalError, Expr, ExprArena, ExprArenaCell, ExprArenaSnapshot, ExprArenaWriteGuard,
+    ExprId, ExprNode, ParamId, UnaryOp, VarId, describe_nonlinear_term, dot, render_expr,
+    render_linear_terms,
 };
 
 pub use oximo_macros::{
-    constraint, objective, param, set, soc_constraint, sos_constraint, sum, variable,
+    constraint, max, min, objective, param, set, soc_constraint, sos_constraint, sum, variable,
 };

--- a/crates/oximo-core/src/macro_support.rs
+++ b/crates/oximo-core/src/macro_support.rs
@@ -19,6 +19,34 @@ pub fn sum_terms<'a>(terms: Vec<oximo_expr::Expr<'a>>) -> oximo_expr::Expr<'a> {
     terms.into_iter().sum()
 }
 
+#[must_use]
+pub fn min_terms<'a>(terms: Vec<oximo_expr::Expr<'a>>) -> oximo_expr::Expr<'a> {
+    oximo_expr::Expr::__min_terms(terms.into_iter())
+        .expect("min! with an `if` filter produced no terms")
+}
+
+#[must_use]
+pub fn max_terms<'a>(terms: Vec<oximo_expr::Expr<'a>>) -> oximo_expr::Expr<'a> {
+    oximo_expr::Expr::__max_terms(terms.into_iter())
+        .expect("max! with an `if` filter produced no terms")
+}
+
+pub fn min_over<'a, K, D, F>(domain: &D, f: F) -> oximo_expr::Expr<'a>
+where
+    D: SumDomain<K> + ?Sized,
+    F: FnMut(K) -> oximo_expr::Expr<'a>,
+{
+    oximo_expr::Expr::__min_terms(domain.keys().map(f)).expect("min! on empty domain")
+}
+
+pub fn max_over<'a, K, D, F>(domain: &D, f: F) -> oximo_expr::Expr<'a>
+where
+    D: SumDomain<K> + ?Sized,
+    F: FnMut(K) -> oximo_expr::Expr<'a>,
+{
+    oximo_expr::Expr::__max_terms(domain.keys().map(f)).expect("max! on empty domain")
+}
+
 /// Filter a [`Set`] by a typed predicate over its decoded keys. Backs the
 /// filtered family form `name[i in dom if cond]` of `variable!`/`constraint!`.
 pub fn filter_keys<K, F>(set: &Set<K>, pred: F) -> Set<K>

--- a/crates/oximo-core/src/prelude.rs
+++ b/crates/oximo-core/src/prelude.rs
@@ -17,8 +17,8 @@ pub use crate::soc::{SocConstraint, SocConstraintId, SocForm};
 pub use crate::sos::{SosConstraint, SosConstraintHandle, SosConstraintId, SosMember, SosType};
 pub use crate::sum::SumDomain;
 pub use crate::var::{VarBuilder, Variable};
-pub use oximo_expr::{Expr, ExprId, ParamId, VarId, dot};
+pub use oximo_expr::{Children, Expr, ExprId, ParamId, UnaryOp, VarId, dot};
 
 pub use oximo_macros::{
-    constraint, objective, param, set, soc_constraint, sos_constraint, sum, variable,
+    constraint, max, min, objective, param, set, soc_constraint, sos_constraint, sum, variable,
 };

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -767,6 +767,17 @@ fn extrema_macros_accept_typed_sets() {
 }
 
 #[test]
+fn filtered_extrema_macro_does_not_capture_caller_terms_binding() {
+    let m = Model::new("extrema_hygiene");
+    variable!(m, x);
+    let __terms = x;
+
+    let lo = min!(__terms for i in 0..2 if i == 1);
+
+    assert_eq!(lo.id, x.id);
+}
+
+#[test]
 #[should_panic(expected = "expressions belong to different arenas")]
 fn extrema_macro_rejects_foreign_arenas() {
     let m = Model::new("local_extrema");

--- a/crates/oximo-core/tests/macros.rs
+++ b/crates/oximo-core/tests/macros.rs
@@ -733,3 +733,61 @@ fn soc_macro_rejects_quadratic_term() {
     variable!(m, t >= 0.0);
     soc_constraint!(m, cone, [x * x] <= t);
 }
+
+#[test]
+fn extrema_macros_flatten_indices_filters_and_keep_order() {
+    let m = Model::new("extrema");
+    variable!(m, x[i in 0..6]);
+
+    let lo = min!(x[2 * i + j] for i in 0..2, j in 0..2);
+    let hi = max!(x[i] for i in 0..6 if i % 2 == 1);
+    let arena = m.arena();
+    assert!(matches!(
+        arena.get(lo.id),
+        oximo_core::ExprNode::Min(children)
+            if children.as_slice() == [x[0].id, x[1].id, x[2].id, x[3].id]
+    ));
+    assert!(matches!(
+        arena.get(hi.id),
+        oximo_core::ExprNode::Max(children)
+            if children.as_slice() == [x[1].id, x[3].id, x[5].id]
+    ));
+}
+
+#[test]
+fn extrema_macros_accept_typed_sets() {
+    let m = Model::new("typed_extrema");
+    let plants = Set::strings(["a", "b", "c"]);
+    variable!(m, x[p in plants]);
+    let lo = min!(x[&p] for p: String in plants);
+    let hi = max!(x[&p] for p: String in plants if p != "b");
+    let arena = m.arena();
+    assert!(matches!(arena.get(lo.id), oximo_core::ExprNode::Min(children) if children.len() == 3));
+    assert!(matches!(arena.get(hi.id), oximo_core::ExprNode::Max(children) if children.len() == 2));
+}
+
+#[test]
+#[should_panic(expected = "expressions belong to different arenas")]
+fn extrema_macro_rejects_foreign_arenas() {
+    let m = Model::new("local_extrema");
+    let other = Model::new("foreign_extrema");
+    variable!(m, x);
+    variable!(other, y);
+    let _ = min!(if i == 0 { x } else { y } for i in 0..2);
+}
+
+#[test]
+#[should_panic(expected = "min! on empty domain")]
+fn min_macro_empty_domain_has_specific_diagnostic() {
+    let m = Model::new("empty_min");
+    variable!(m, x);
+    let _ = min!(x for _i in 0..0);
+}
+
+#[test]
+#[should_panic(expected = "max! with an `if` filter produced no terms")]
+fn max_macro_empty_filter_has_specific_diagnostic() {
+    let m = Model::new("empty_max_filter");
+    variable!(m, x);
+    let _ = max!(x for i in 0..3 if i > 10);
+}

--- a/crates/oximo-expr/README.md
+++ b/crates/oximo-expr/README.md
@@ -19,6 +19,7 @@ This crate is the fundamental layer. End users depend on `oximo-core`, which re-
 | `ExprArenaCell` | Synchronized owner used by expression handles           |
 | `ExprId`        | Newtype `u32` index into an arena                       |
 | `ExprNode`      | Enum of all node kinds (see below)                      |
+| `UnaryOp`       | Public enum of unary scalar operations                  |
 | `Expr<'a>`      | Lightweight handle: `id` + borrow of the arena. `Copy`. |
 | `VarId`         | Opaque variable index                                   |
 | `ParamId`       | Opaque parameter index                                  |
@@ -32,11 +33,11 @@ Var(VarId)
 Param(ParamId)
 Add(Children) // generic n-ary add
 Mul(Children) // generic n-ary mul
-Neg(ExprId)
+Unary(UnaryOp, ExprId)
 Pow(ExprId, ExprId)
 Div(ExprId, ExprId) // numerator / denominator
-Sin(ExprId) / Cos(ExprId) / Exp(ExprId) / Log(ExprId)
-Abs(ExprId)
+Atan2(ExprId, ExprId) // y, x order
+Min(Children) / Max(Children)
 Linear { coeffs: Vec<(VarId, f64)>, constant: f64 } // LP fast-path
 ```
 
@@ -60,11 +61,25 @@ let e = x / 2.0; // constant denominator: stays linear (x*0.5)
 expr.pow(exponent) // Expr ^ Expr
 expr.powi(n: i32)  // integer exponent shorthand
 expr.powf(n: f64)  // float exponent shorthand
+expr.neg()         // explicit UnaryOp::Neg (the `-expr` operator keeps affine lowering)
 expr.sin()
 expr.cos()
+expr.tan()
 expr.exp()
-expr.log()
+expr.exp2()
+expr.expm1() // alias: exp_m1()
+expr.log()   // alias: ln()
+expr.log1p() // alias: ln_1p()
+expr.log2()
+expr.log10()
 expr.abs()
+expr.sqrt()
+expr.cbrt()
+expr.asin() / expr.acos() / expr.atan()
+expr.sinh() / expr.cosh() / expr.tanh()
+expr.asinh() / expr.acosh() / expr.atanh()
+expr.atan2(x) // self is y
+expr.min(other) / expr.max(other) // flattened n-ary nodes
 expr/expr
 ```
 

--- a/crates/oximo-expr/benches/extraction.rs
+++ b/crates/oximo-expr/benches/extraction.rs
@@ -22,7 +22,7 @@ fn main() {
     }
     let mut root = arena.push(ExprNode::Mul(smallvec![param, vars[0]]));
     for _ in 0..256 {
-        root = arena.push(ExprNode::Neg(root));
+        root = arena.push(ExprNode::Unary(oximo_expr::UnaryOp::Neg, root));
     }
     support::measure("linear_deep/256", || extract_linear(&arena, root).unwrap());
     support::measure("quadratic_deep/256", || extract_quadratic(&arena, root).unwrap());

--- a/crates/oximo-expr/src/arena.rs
+++ b/crates/oximo-expr/src/arena.rs
@@ -39,6 +39,113 @@ impl ParamId {
 
 pub type Children = SmallVec<[ExprId; 4]>;
 
+/// Unary scalar functions represented by [`ExprNode::Unary`].
+///
+/// This enum is public so expression consumers can exhaustively describe the
+/// nonlinear vocabulary they support. Adding a variant is therefore a
+/// deliberate source-breaking extension for exhaustive matches.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum UnaryOp {
+    Neg,
+    Abs,
+    Sqrt,
+    Cbrt,
+    Exp,
+    Exp2,
+    Expm1,
+    Log,
+    Log2,
+    Log10,
+    Log1p,
+    Sin,
+    Cos,
+    Tan,
+    Asin,
+    Acos,
+    Atan,
+    Sinh,
+    Cosh,
+    Tanh,
+    Asinh,
+    Acosh,
+    Atanh,
+}
+
+impl UnaryOp {
+    /// Canonical modeling-language spelling used in rendering and diagnostics.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Neg => "neg",
+            Self::Abs => "abs",
+            Self::Sqrt => "sqrt",
+            Self::Cbrt => "cbrt",
+            Self::Exp => "exp",
+            Self::Exp2 => "exp2",
+            Self::Expm1 => "expm1",
+            Self::Log => "log",
+            Self::Log2 => "log2",
+            Self::Log10 => "log10",
+            Self::Log1p => "log1p",
+            Self::Sin => "sin",
+            Self::Cos => "cos",
+            Self::Tan => "tan",
+            Self::Asin => "asin",
+            Self::Acos => "acos",
+            Self::Atan => "atan",
+            Self::Sinh => "sinh",
+            Self::Cosh => "cosh",
+            Self::Tanh => "tanh",
+            Self::Asinh => "asinh",
+            Self::Acosh => "acosh",
+            Self::Atanh => "atanh",
+        }
+    }
+
+    /// Apply this operation with Rust's IEEE-754 `f64` semantics.
+    #[must_use]
+    #[inline]
+    pub fn apply(self, value: f64) -> f64 {
+        match self {
+            Self::Neg => -value,
+            Self::Abs => value.abs(),
+            Self::Sqrt => value.sqrt(),
+            Self::Cbrt => value.cbrt(),
+            Self::Exp => value.exp(),
+            Self::Exp2 => value.exp2(),
+            Self::Expm1 => value.exp_m1(),
+            Self::Log => value.ln(),
+            Self::Log2 => value.log2(),
+            Self::Log10 => value.log10(),
+            Self::Log1p => value.ln_1p(),
+            Self::Sin => value.sin(),
+            Self::Cos => value.cos(),
+            Self::Tan => value.tan(),
+            Self::Asin => value.asin(),
+            Self::Acos => value.acos(),
+            Self::Atan => value.atan(),
+            Self::Sinh => value.sinh(),
+            Self::Cosh => value.cosh(),
+            Self::Tanh => value.tanh(),
+            Self::Asinh => value.asinh(),
+            Self::Acosh => value.acosh(),
+            Self::Atanh => value.atanh(),
+        }
+    }
+
+    /// Whether this operation is nonsmooth on its ordinary real domain.
+    #[must_use]
+    pub const fn is_nonsmooth(self) -> bool {
+        matches!(self, Self::Abs)
+    }
+}
+
+impl std::fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 /// Here we use a linear fast-path: `sum(coeff * var) + constant`.
 /// Built by the operator overloads when all children are linear,
 /// so LP/MILP construction never walks an `Add(Mul(Const, Var), ...)` tree.
@@ -50,15 +157,20 @@ pub enum ExprNode {
     Param(ParamId),
     Add(Children),
     Mul(Children),
-    Neg(ExprId),
+    /// Unary scalar operation.
+    Unary(UnaryOp, ExprId),
     Pow(ExprId, ExprId),
     Div(ExprId, ExprId),
-    Sin(ExprId),
-    Cos(ExprId),
-    Exp(ExprId),
-    Log(ExprId),
-    Abs(ExprId),
-    Linear { coeffs: Vec<(VarId, f64)>, constant: f64 },
+    /// Two-argument arctangent in `y.atan2(x)` order.
+    Atan2(ExprId, ExprId),
+    /// N-ary minimum.
+    Min(Children),
+    /// N-ary maximum.
+    Max(Children),
+    Linear {
+        coeffs: Vec<(VarId, f64)>,
+        constant: f64,
+    },
 }
 
 #[derive(Clone, Debug, Default)]
@@ -674,18 +786,16 @@ impl ExprArenaBatchGuard<'_> {
 
 fn validate_node(node: &ExprNode, remap: ExprIdRemap) {
     match node {
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             for child in children {
                 remap.validate(*child);
             }
         }
-        ExprNode::Neg(child)
-        | ExprNode::Sin(child)
-        | ExprNode::Cos(child)
-        | ExprNode::Exp(child)
-        | ExprNode::Log(child)
-        | ExprNode::Abs(child) => remap.validate(*child),
-        ExprNode::Pow(left, right) | ExprNode::Div(left, right) => {
+        ExprNode::Unary(_, child) => remap.validate(*child),
+        ExprNode::Pow(left, right) | ExprNode::Div(left, right) | ExprNode::Atan2(left, right) => {
             remap.validate(*left);
             remap.validate(*right);
         }
@@ -701,18 +811,16 @@ impl Drop for ExprArenaBatchGuard<'_> {
 
 fn remap_node(node: &mut ExprNode, remap: ExprIdRemap) {
     match node {
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             for child in children {
                 *child = remap.apply(*child);
             }
         }
-        ExprNode::Neg(child)
-        | ExprNode::Sin(child)
-        | ExprNode::Cos(child)
-        | ExprNode::Exp(child)
-        | ExprNode::Log(child)
-        | ExprNode::Abs(child) => *child = remap.apply(*child),
-        ExprNode::Pow(left, right) | ExprNode::Div(left, right) => {
+        ExprNode::Unary(_, child) => *child = remap.apply(*child),
+        ExprNode::Pow(left, right) | ExprNode::Div(left, right) | ExprNode::Atan2(left, right) => {
             *left = remap.apply(*left);
             *right = remap.apply(*right);
         }
@@ -799,7 +907,7 @@ mod tests {
             cell.__with_fork(snapshot.clone(), || Expr::constant(&cell, 1.0)),
             cell.__with_fork(snapshot, || Expr::constant(&cell, 2.0)),
         ];
-        forks[1].nodes.push(ExprNode::Neg(ExprId(u32::MAX)));
+        forks[1].nodes.push(ExprNode::Unary(UnaryOp::Neg, ExprId(u32::MAX)));
         assert!(catch_unwind(AssertUnwindSafe(|| batch.merge(&mut forks))).is_err());
         assert_eq!(batch.arena.len(), 0);
         assert_eq!(forks[0].nodes.len(), 1);

--- a/crates/oximo-expr/src/classify.rs
+++ b/crates/oximo-expr/src/classify.rs
@@ -1,4 +1,4 @@
-use crate::arena::{ArenaAccess, ExprArena, ExprId, ExprNode};
+use crate::arena::{ArenaAccess, ExprArena, ExprId, ExprNode, UnaryOp};
 
 /// Highest-degree polynomial class an expression belongs to, ignoring constant
 /// folding. Used by backends to pick between linear, quadratic, and general
@@ -57,7 +57,7 @@ fn recursive_degree(arena: &(impl ArenaAccess + ?Sized), id: ExprId) -> Degree {
     match arena.get(id) {
         ExprNode::Const(_) | ExprNode::Param(_) => Degree::Zero,
         ExprNode::Var(_) | ExprNode::Linear { .. } => Degree::One,
-        ExprNode::Neg(inner) => recursive_degree(arena, *inner),
+        ExprNode::Unary(UnaryOp::Neg, inner) => recursive_degree(arena, *inner),
         ExprNode::Add(children) => {
             let mut d = Degree::Zero;
             for c in children {
@@ -98,11 +98,10 @@ fn recursive_degree(arena: &(impl ArenaAccess + ?Sized), id: ExprId) -> Degree {
         // `Div` node is created, so any other `Div` has a non-constant
         // denominator.
         ExprNode::Div(_, _)
-        | ExprNode::Sin(_)
-        | ExprNode::Cos(_)
-        | ExprNode::Exp(_)
-        | ExprNode::Log(_)
-        | ExprNode::Abs(_) => Degree::Higher,
+        | ExprNode::Atan2(_, _)
+        | ExprNode::Min(_)
+        | ExprNode::Max(_)
+        | ExprNode::Unary(_, _) => Degree::Higher,
     }
 }
 
@@ -130,7 +129,7 @@ impl<'a, A: ArenaAccess + ?Sized> crate::fold::Folder for DegreeFolder<'a, A> {
             ExprNode::Var(_) | ExprNode::Linear { .. } => return Break(Some(Degree::One)),
             ExprNode::Add(c) => (c.as_slice(), DegreeOp::Add),
             ExprNode::Mul(c) => (c.as_slice(), DegreeOp::Mul),
-            ExprNode::Neg(c) => (std::slice::from_ref(c), DegreeOp::Add),
+            ExprNode::Unary(UnaryOp::Neg, c) => (std::slice::from_ref(c), DegreeOp::Add),
             ExprNode::Pow(base, exp) => {
                 let ExprNode::Const(e) = self.0.get(*exp) else {
                     return Break(Some(Degree::Higher));
@@ -174,7 +173,7 @@ impl<'a, A: ArenaAccess + ?Sized> crate::fold::Folder for DegreeFolder<'a, A> {
 }
 
 fn degree(arena: &(impl ArenaAccess + ?Sized), mut id: ExprId) -> Degree {
-    while let ExprNode::Neg(child) = arena.get(id) {
+    while let ExprNode::Unary(UnaryOp::Neg, child) = arena.get(id) {
         id = *child;
     }
     crate::fold::fold(arena, id, DegreeFolder(arena)).expect("degree classification is total")
@@ -262,7 +261,7 @@ mod tests {
     fn nonlinear_sin() {
         let mut a = ExprArena::new();
         let x = var(&mut a, 0);
-        let s = a.push(ExprNode::Sin(x));
+        let s = a.push(ExprNode::Unary(UnaryOp::Sin, x));
         assert_eq!(classify(&a, s), ExprClass::Nonlinear);
     }
 
@@ -270,7 +269,7 @@ mod tests {
     fn nonlinear_abs() {
         let mut a = ExprArena::new();
         let x = var(&mut a, 0);
-        let s = a.push(ExprNode::Abs(x));
+        let s = a.push(ExprNode::Unary(UnaryOp::Abs, x));
         assert_eq!(classify(&a, s), ExprClass::Nonlinear);
     }
 

--- a/crates/oximo-expr/src/eval.rs
+++ b/crates/oximo-expr/src/eval.rs
@@ -44,14 +44,16 @@ pub fn evaluate<C: EvalContext>(arena: &ExprArena, id: ExprId, ctx: &C) -> Resul
         ExprNode::Mul(children) => children
             .iter()
             .try_fold(1.0, |acc, c| Ok::<_, EvalError>(acc * evaluate(arena, *c, ctx)?))?,
-        ExprNode::Neg(inner) => -evaluate(arena, *inner, ctx)?,
+        ExprNode::Unary(op, inner) => op.apply(evaluate(arena, *inner, ctx)?),
         ExprNode::Pow(base, exp) => evaluate(arena, *base, ctx)?.powf(evaluate(arena, *exp, ctx)?),
         ExprNode::Div(num, den) => evaluate(arena, *num, ctx)? / evaluate(arena, *den, ctx)?,
-        ExprNode::Sin(inner) => evaluate(arena, *inner, ctx)?.sin(),
-        ExprNode::Cos(inner) => evaluate(arena, *inner, ctx)?.cos(),
-        ExprNode::Exp(inner) => evaluate(arena, *inner, ctx)?.exp(),
-        ExprNode::Log(inner) => evaluate(arena, *inner, ctx)?.ln(),
-        ExprNode::Abs(inner) => evaluate(arena, *inner, ctx)?.abs(),
+        ExprNode::Atan2(y, x) => evaluate(arena, *y, ctx)?.atan2(evaluate(arena, *x, ctx)?),
+        ExprNode::Min(children) => children.iter().try_fold(f64::INFINITY, |acc, child| {
+            Ok::<_, EvalError>(acc.min(evaluate(arena, *child, ctx)?))
+        })?,
+        ExprNode::Max(children) => children.iter().try_fold(f64::NEG_INFINITY, |acc, child| {
+            Ok::<_, EvalError>(acc.max(evaluate(arena, *child, ctx)?))
+        })?,
         ExprNode::Linear { coeffs, constant } => {
             let mut acc = *constant;
             for (v, c) in coeffs {

--- a/crates/oximo-expr/src/fold.rs
+++ b/crates/oximo-expr/src/fold.rs
@@ -23,14 +23,19 @@ fn shared_nodes(arena: &(impl ArenaAccess + ?Sized), root: ExprId) -> FxHashSet<
     stack.push(root);
     while let Some(id) = stack.pop() {
         let children: &[ExprId] = match arena.get(id) {
-            ExprNode::Add(c) | ExprNode::Mul(c) => c,
-            ExprNode::Neg(c) | ExprNode::Pow(c, _) => std::slice::from_ref(c),
+            ExprNode::Add(c) | ExprNode::Mul(c) | ExprNode::Min(c) | ExprNode::Max(c) => c,
+            ExprNode::Unary(_, c) | ExprNode::Pow(c, _) => std::slice::from_ref(c),
             _ => continue,
         };
         for &child in children {
             if !matches!(
                 arena.get(child),
-                ExprNode::Add(_) | ExprNode::Mul(_) | ExprNode::Neg(_) | ExprNode::Pow(_, _)
+                ExprNode::Add(_)
+                    | ExprNode::Mul(_)
+                    | ExprNode::Min(_)
+                    | ExprNode::Max(_)
+                    | ExprNode::Unary(_, _)
+                    | ExprNode::Pow(_, _)
             ) {
                 continue;
             }
@@ -92,7 +97,7 @@ pub(crate) fn fold<F: Folder>(
 
 #[cfg(test)]
 pub(crate) fn test_arena() -> (crate::ExprArena, Vec<ExprId>) {
-    use crate::VarId;
+    use crate::{UnaryOp, VarId};
     use smallvec::smallvec;
     let mut arena = crate::ExprArena::new();
     let mut ids = vec![];
@@ -118,10 +123,10 @@ pub(crate) fn test_arena() -> (crate::ExprArena, Vec<ExprId>) {
             let node = match i % 8 {
                 0 | 1 => ExprNode::Add(smallvec![a, b, a]),
                 2 => ExprNode::Mul(smallvec![a, b]),
-                3 => ExprNode::Neg(a),
+                3 => ExprNode::Unary(UnaryOp::Neg, a),
                 4 => ExprNode::Pow(a, ids[(i / 8) % 5]),
                 5 => ExprNode::Mul(smallvec![ids[6], a, ids[8]]),
-                6 => ExprNode::Sin(a),
+                6 => ExprNode::Unary(UnaryOp::Sin, a),
                 _ => ExprNode::Add(smallvec![a, ids[6], ids[7], b]),
             };
             ids.push(arena.push(node));
@@ -134,7 +139,7 @@ pub(crate) fn test_arena() -> (crate::ExprArena, Vec<ExprId>) {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ExprArena, ExprClass, ExprNode, VarId, classify, extract_linear, extract_quadratic,
+        ExprArena, ExprClass, ExprNode, UnaryOp, VarId, classify, extract_linear, extract_quadratic,
     };
     use smallvec::smallvec;
 
@@ -143,7 +148,7 @@ mod tests {
         let mut arena = ExprArena::new();
         let mut root = arena.push(ExprNode::Var(VarId(0)));
         for _ in 0..30_000 {
-            root = arena.push(ExprNode::Neg(root));
+            root = arena.push(ExprNode::Unary(UnaryOp::Neg, root));
         }
         assert_eq!(extract_linear(&arena, root).unwrap().coeffs.as_ref(), &[(VarId(0), 1.0)]);
         assert_eq!(extract_quadratic(&arena, root).unwrap().linear, vec![(VarId(0), 1.0)]);

--- a/crates/oximo-expr/src/handle.rs
+++ b/crates/oximo-expr/src/handle.rs
@@ -1,4 +1,4 @@
-use crate::arena::{ExprArenaCell, ExprId, ExprNode, ParamId, VarId};
+use crate::arena::{Children, ExprArenaCell, ExprId, ExprNode, ParamId, UnaryOp, VarId};
 use crate::classify::{ExprClass, classify_access};
 
 /// Lightweight handle to a node in an [`ExprArenaCell`].
@@ -90,29 +90,145 @@ impl<'a> Expr<'a> {
         Self::new(id, self.arena)
     }
 
-    pub fn sin(self) -> Self {
-        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Sin(self.id)));
+    fn unary(self, op: UnaryOp) -> Self {
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Unary(op, self.id)));
         Self::new(id, self.arena)
     }
 
-    pub fn cos(self) -> Self {
-        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Cos(self.id)));
-        Self::new(id, self.arena)
-    }
-
-    pub fn exp(self) -> Self {
-        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Exp(self.id)));
-        Self::new(id, self.arena)
-    }
-
-    pub fn log(self) -> Self {
-        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Log(self.id)));
-        Self::new(id, self.arena)
+    /// Unary negation as an explicit expression node. The `-expr` operator
+    /// keeps its affine fast path. Use this method when the public
+    /// [`UnaryOp`] node is required.
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "explicit node constructor complements Neg::neg"
+    )]
+    pub fn neg(self) -> Self {
+        self.unary(UnaryOp::Neg)
     }
 
     pub fn abs(self) -> Self {
-        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Abs(self.id)));
+        self.unary(UnaryOp::Abs)
+    }
+    pub fn sqrt(self) -> Self {
+        self.unary(UnaryOp::Sqrt)
+    }
+    pub fn cbrt(self) -> Self {
+        self.unary(UnaryOp::Cbrt)
+    }
+    pub fn exp(self) -> Self {
+        self.unary(UnaryOp::Exp)
+    }
+    pub fn exp2(self) -> Self {
+        self.unary(UnaryOp::Exp2)
+    }
+    pub fn expm1(self) -> Self {
+        self.unary(UnaryOp::Expm1)
+    }
+    /// Alias for [`Expr::expm1`], matching Rust's `f64::exp_m1` spelling.
+    pub fn exp_m1(self) -> Self {
+        self.expm1()
+    }
+    pub fn log(self) -> Self {
+        self.unary(UnaryOp::Log)
+    }
+    /// Alias for [`Expr::log`], matching Rust's `f64::ln` spelling.
+    pub fn ln(self) -> Self {
+        self.log()
+    }
+    pub fn log2(self) -> Self {
+        self.unary(UnaryOp::Log2)
+    }
+    pub fn log10(self) -> Self {
+        self.unary(UnaryOp::Log10)
+    }
+    pub fn log1p(self) -> Self {
+        self.unary(UnaryOp::Log1p)
+    }
+    /// Alias for [`Expr::log1p`], matching Rust's `f64::ln_1p` spelling.
+    pub fn ln_1p(self) -> Self {
+        self.log1p()
+    }
+    pub fn sin(self) -> Self {
+        self.unary(UnaryOp::Sin)
+    }
+    pub fn cos(self) -> Self {
+        self.unary(UnaryOp::Cos)
+    }
+    pub fn tan(self) -> Self {
+        self.unary(UnaryOp::Tan)
+    }
+    pub fn asin(self) -> Self {
+        self.unary(UnaryOp::Asin)
+    }
+    pub fn acos(self) -> Self {
+        self.unary(UnaryOp::Acos)
+    }
+    pub fn atan(self) -> Self {
+        self.unary(UnaryOp::Atan)
+    }
+    pub fn sinh(self) -> Self {
+        self.unary(UnaryOp::Sinh)
+    }
+    pub fn cosh(self) -> Self {
+        self.unary(UnaryOp::Cosh)
+    }
+    pub fn tanh(self) -> Self {
+        self.unary(UnaryOp::Tanh)
+    }
+    pub fn asinh(self) -> Self {
+        self.unary(UnaryOp::Asinh)
+    }
+    pub fn acosh(self) -> Self {
+        self.unary(UnaryOp::Acosh)
+    }
+    pub fn atanh(self) -> Self {
+        self.unary(UnaryOp::Atanh)
+    }
+
+    /// Two-argument arctangent in Rust's `y.atan2(x)` argument order.
+    pub fn atan2(self, x: Self) -> Self {
+        self.assert_same_arena(x);
+        let id = self.arena.with_mut(|arena| arena.push(ExprNode::Atan2(self.id, x.id)));
         Self::new(id, self.arena)
+    }
+
+    fn extrema(self, other: Self, is_min: bool) -> Self {
+        self.assert_same_arena(other);
+        let id = self.arena.with_mut(|arena| {
+            let mut children = Children::new();
+            let left = match arena.get(self.id) {
+                ExprNode::Min(existing) if is_min => Some(existing.as_slice()),
+                ExprNode::Max(existing) if !is_min => Some(existing.as_slice()),
+                _ => None,
+            };
+            if let Some(existing) = left {
+                children.extend_from_slice(existing);
+            } else {
+                children.push(self.id);
+            }
+            let right = match arena.get(other.id) {
+                ExprNode::Min(existing) if is_min => Some(existing.as_slice()),
+                ExprNode::Max(existing) if !is_min => Some(existing.as_slice()),
+                _ => None,
+            };
+            if let Some(existing) = right {
+                children.extend_from_slice(existing);
+            } else {
+                children.push(other.id);
+            }
+            arena.push(if is_min { ExprNode::Min(children) } else { ExprNode::Max(children) })
+        });
+        Self::new(id, self.arena)
+    }
+
+    /// Pairwise minimum, flattening nested minima into deterministic n-ary nodes.
+    pub fn min(self, other: Self) -> Self {
+        self.extrema(other, true)
+    }
+
+    /// Pairwise maximum, flattening nested maxima into deterministic n-ary nodes.
+    pub fn max(self, other: Self) -> Self {
+        self.extrema(other, false)
     }
 
     #[doc(hidden)]

--- a/crates/oximo-expr/src/lib.rs
+++ b/crates/oximo-expr/src/lib.rs
@@ -14,8 +14,9 @@ mod simplify;
 mod visit;
 
 pub use arena::{
-    ExprArena, ExprArenaBatchGuard, ExprArenaCell, ExprArenaSnapshot, ExprArenaWriteGuard, ExprId,
-    ExprIdRemap, ExprNode, ForkOutput, FrozenExprArena, ParamId, VarId,
+    Children, ExprArena, ExprArenaBatchGuard, ExprArenaCell, ExprArenaSnapshot,
+    ExprArenaWriteGuard, ExprId, ExprIdRemap, ExprNode, ForkOutput, FrozenExprArena, ParamId,
+    UnaryOp, VarId,
 };
 pub use classify::{ExprClass, classify};
 pub use eval::{EvalContext, EvalError, evaluate};

--- a/crates/oximo-expr/src/linear.rs
+++ b/crates/oximo-expr/src/linear.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use smallvec::smallvec;
 
-use crate::arena::{ArenaAccess, Children, ExprArena, ExprId, ExprNode, VarId};
+use crate::arena::{ArenaAccess, Children, ExprArena, ExprId, ExprNode, UnaryOp, VarId};
 
 /// Coefficients of a linear expression: `sum(coeff * var) + constant`.
 ///
@@ -93,7 +93,7 @@ fn recursive_linear<'a, A: ArenaAccess + ?Sized>(
             Some(LinearTerms { coeffs: Cow::Owned(vec![(*v, 1.0)]), constant: 0.0 })
         }
         ExprNode::Linear { coeffs, constant } => Some(LinearTerms::borrowed(coeffs, *constant)),
-        ExprNode::Neg(inner) => {
+        ExprNode::Unary(UnaryOp::Neg, inner) => {
             let inner = *inner;
             recursive_linear(arena, inner, resolve_params).map(|t| {
                 let mut coeffs = t.coeffs.into_owned();
@@ -173,7 +173,7 @@ impl<'a, A: ArenaAccess + ?Sized> crate::fold::Folder for LinearFolder<'a, A> {
                     constant: 0.0,
                 });
             }
-            ExprNode::Neg(child) => {
+            ExprNode::Unary(UnaryOp::Neg, child) => {
                 return Continue(LinearState::Scale {
                     child: Some(*child),
                     value: None,
@@ -268,7 +268,7 @@ fn as_linear<'a, A: ArenaAccess + ?Sized>(
     resolve_params: bool,
 ) -> Option<LinearTerms<'a>> {
     let mut negations = 0;
-    while let ExprNode::Neg(child) = arena.get(id) {
+    while let ExprNode::Unary(UnaryOp::Neg, child) = arena.get(id) {
         id = *child;
         negations += 1;
     }
@@ -402,7 +402,7 @@ pub(crate) fn neg_into(arena: &mut (impl ArenaAccess + ?Sized), rhs: ExprId) -> 
         }
         return push_linear(arena, LinearTerms { coeffs: Cow::Owned(coeffs), constant });
     }
-    arena.push(ExprNode::Neg(rhs))
+    arena.push(ExprNode::Unary(UnaryOp::Neg, rhs))
 }
 
 /// Extract the linear terms of `id`, if any. Used by solver backends to extract
@@ -459,7 +459,7 @@ pub fn split_linear<'a>(arena: &'a ExprArena, id: ExprId) -> (LinearTerms<'a>, V
                     sign_stack.push((c, sign));
                 }
             }
-            ExprNode::Neg(inner) => sign_stack.push((*inner, -sign)),
+            ExprNode::Unary(UnaryOp::Neg, inner) => sign_stack.push((*inner, -sign)),
             _ => {
                 if let Some(t) = as_linear(arena, cur, true) {
                     for &(v, c) in t.coeffs.iter() {
@@ -575,7 +575,7 @@ mod tests {
         assert!(residual.is_empty());
 
         let y = arena.push(ExprNode::Var(VarId(1)));
-        let nonlinear = arena.push(ExprNode::Sin(y));
+        let nonlinear = arena.push(ExprNode::Unary(UnaryOp::Sin, y));
         let mixed = arena.push(ExprNode::Add(smallvec::smallvec![linear, nonlinear]));
         let (split, residual) = split_linear(&arena, mixed);
         assert!(matches!(split.coeffs, Cow::Owned(_)));
@@ -678,7 +678,7 @@ mod tests {
         let pow = arena.push(ExprNode::Pow(x, two));
         assert_eq!(describe_nonlinear_term(&arena, pow, &names).as_deref(), Some("x^2"));
 
-        let s = arena.push(ExprNode::Sin(x));
+        let s = arena.push(ExprNode::Unary(UnaryOp::Sin, x));
         assert_eq!(describe_nonlinear_term(&arena, s, &names).as_deref(), Some("sin(x)"));
 
         let div = arena.push(ExprNode::Div(x, y));

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
-use crate::arena::{Children, ExprId};
+use crate::arena::{Children, ExprId, ExprNode};
 use crate::handle::Expr;
 use crate::linear::{add_into, add_n, div_into, mul_into, neg_into, sub_into};
 
@@ -198,6 +198,44 @@ impl<'a> Expr<'a> {
         assert!(same_arena, "expressions belong to different arenas");
         let id = first.arena.with_mut(|arena| add_n(arena, ids));
         Some(Self::new(id, first.arena))
+    }
+
+    fn extrema_terms(mut iter: impl Iterator<Item = Self>, is_min: bool) -> Option<Self> {
+        let first = iter.next()?;
+        let mut same_arena = true;
+        let mut ids = Children::new();
+        let mut append = |expr: Self| {
+            same_arena &= std::ptr::eq(first.arena, expr.arena);
+            expr.arena.with_ref(|arena| match arena.get(expr.id) {
+                ExprNode::Min(children) if is_min => ids.extend_from_slice(children),
+                ExprNode::Max(children) if !is_min => ids.extend_from_slice(children),
+                _ => ids.push(expr.id),
+            });
+        };
+        append(first);
+        for expr in iter {
+            append(expr);
+        }
+        assert!(same_arena, "expressions belong to different arenas");
+        if ids.len() == 1 {
+            return Some(first);
+        }
+        let id = first.arena.with_mut(|arena| {
+            arena.push(if is_min { ExprNode::Min(ids) } else { ExprNode::Max(ids) })
+        });
+        Some(Self::new(id, first.arena))
+    }
+
+    /// Macro support for constructing a flat n-ary minimum.
+    #[doc(hidden)]
+    pub fn __min_terms(iter: impl Iterator<Item = Self>) -> Option<Self> {
+        Self::extrema_terms(iter, true)
+    }
+
+    /// Macro support for constructing a flat n-ary maximum.
+    #[doc(hidden)]
+    pub fn __max_terms(iter: impl Iterator<Item = Self>) -> Option<Self> {
+        Self::extrema_terms(iter, false)
     }
 }
 

--- a/crates/oximo-expr/src/ops.rs
+++ b/crates/oximo-expr/src/ops.rs
@@ -218,7 +218,7 @@ impl<'a> Expr<'a> {
         }
         assert!(same_arena, "expressions belong to different arenas");
         if ids.len() == 1 {
-            return Some(first);
+            return Some(Self::new(ids[0], first.arena));
         }
         let id = first.arena.with_mut(|arena| {
             arena.push(if is_min { ExprNode::Min(ids) } else { ExprNode::Max(ids) })

--- a/crates/oximo-expr/src/quadratic.rs
+++ b/crates/oximo-expr/src/quadratic.rs
@@ -1,6 +1,6 @@
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
-use crate::arena::{ExprArena, ExprId, ExprNode, VarId};
+use crate::arena::{ExprArena, ExprId, ExprNode, UnaryOp, VarId};
 
 /// Quadratic decomposition of an expression: its Hessian, gradient-linear
 /// part, and constant.
@@ -123,7 +123,7 @@ fn recursive_poly(arena: &ExprArena, id: ExprId) -> Option<Poly> {
             }
             Some(Poly { quad: FxHashMap::default(), linear, constant: *constant })
         }
-        ExprNode::Neg(inner) => recursive_poly(arena, *inner).map(Poly::neg),
+        ExprNode::Unary(UnaryOp::Neg, inner) => recursive_poly(arena, *inner).map(Poly::neg),
         ExprNode::Add(children) => {
             let mut acc = Poly::default();
             for child in children {
@@ -167,11 +167,10 @@ fn recursive_poly(arena: &ExprArena, id: ExprId) -> Option<Poly> {
         }
         ExprNode::Param(p) => Some(Poly::constant(arena.param_value(*p))),
         ExprNode::Div(_, _)
-        | ExprNode::Sin(_)
-        | ExprNode::Cos(_)
-        | ExprNode::Exp(_)
-        | ExprNode::Log(_)
-        | ExprNode::Abs(_) => None,
+        | ExprNode::Atan2(_, _)
+        | ExprNode::Min(_)
+        | ExprNode::Max(_)
+        | ExprNode::Unary(_, _) => None,
     }
 }
 
@@ -208,7 +207,9 @@ impl<'a> crate::fold::Folder for PolyFolder<'a> {
             }
             ExprNode::Add(c) => (c.as_slice(), PolyOp::Add, Poly::default()),
             ExprNode::Mul(c) => (c.as_slice(), PolyOp::Mul, Poly::constant(1.0)),
-            ExprNode::Neg(c) => (std::slice::from_ref(c), PolyOp::Neg, Poly::default()),
+            ExprNode::Unary(UnaryOp::Neg, c) => {
+                (std::slice::from_ref(c), PolyOp::Neg, Poly::default())
+            }
             ExprNode::Pow(base, exp) => {
                 let ExprNode::Const(e) = self.0.get(*exp) else { return Break(None) };
                 if (*e - e.round()).abs() >= f64::EPSILON || *e < 0.0 {
@@ -280,7 +281,7 @@ impl<'a> crate::fold::Folder for PolyFolder<'a> {
 
 fn as_poly(arena: &ExprArena, mut id: ExprId) -> Option<Poly> {
     let mut negations = 0;
-    while let ExprNode::Neg(child) = arena.get(id) {
+    while let ExprNode::Unary(UnaryOp::Neg, child) = arena.get(id) {
         id = *child;
         negations += 1;
     }
@@ -448,7 +449,7 @@ mod tests {
         let two = a.push(ExprNode::Const(2.0));
         let sq = a.push(ExprNode::Pow(x, two));
         let inner = a.push(ExprNode::Add(smallvec![sq, x]));
-        let neg = a.push(ExprNode::Neg(inner));
+        let neg = a.push(ExprNode::Unary(UnaryOp::Neg, inner));
         let q = extract_quadratic(&a, neg).unwrap();
         assert_eq!(q.hessian, vec![(v(0), v(0), -2.0)]);
         assert_eq!(q.linear, vec![(v(0), -1.0)]);
@@ -477,7 +478,7 @@ mod tests {
     fn transcendental_is_none() {
         let mut a = ExprArena::new();
         let x = var(&mut a, 0);
-        let s = a.push(ExprNode::Sin(x));
+        let s = a.push(ExprNode::Unary(UnaryOp::Sin, x));
         assert!(extract_quadratic(&a, s).is_none());
     }
 

--- a/crates/oximo-expr/src/render.rs
+++ b/crates/oximo-expr/src/render.rs
@@ -2,7 +2,7 @@
 //! Used by the public display adapters in `oximo-core` and by
 //! the nonlinear-term error messages ([`describe_nonlinear_term`](crate::describe_nonlinear_term)).
 
-use crate::arena::{ExprArena, ExprId, ExprNode, VarId};
+use crate::arena::{ExprArena, ExprId, ExprNode, UnaryOp, VarId};
 use crate::linear::{LinearTerms, split_linear};
 
 // Precedence levels for parenthesizing `render_node` output.
@@ -99,14 +99,14 @@ pub(crate) fn render_node(
         ExprNode::Const(c) => (fmt_num(*c), PREC_UNARY),
         ExprNode::Var(v) => (resolve(*v), PREC_UNARY),
         ExprNode::Param(p) => (fmt_num(arena.param_value(*p)), PREC_UNARY),
-        ExprNode::Neg(x) => {
+        ExprNode::Unary(UnaryOp::Neg, x) => {
             (format!("-{}", render_node(arena, *x, resolve, PREC_UNARY)), PREC_UNARY)
         }
         ExprNode::Add(children) => {
             let mut parts: Vec<Part> = Vec::with_capacity(children.len());
             for c in children.iter().copied() {
                 match arena.get(c) {
-                    ExprNode::Neg(inner) => {
+                    ExprNode::Unary(UnaryOp::Neg, inner) => {
                         parts.push((true, render_node(arena, *inner, resolve, PREC_UNARY)));
                     }
                     ExprNode::Const(v) if *v < 0.0 => parts.push((true, fmt_num(-v))),
@@ -136,11 +136,21 @@ pub(crate) fn render_node(
             let d = render_node(arena, *den, resolve, PREC_MUL);
             (format!("{n} / {d}"), PREC_MUL)
         }
-        ExprNode::Sin(x) => (fmt_call("sin", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Cos(x) => (fmt_call("cos", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Exp(x) => (fmt_call("exp", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Log(x) => (fmt_call("log", arena, *x, resolve), PREC_UNARY),
-        ExprNode::Abs(x) => (fmt_call("abs", arena, *x, resolve), PREC_UNARY),
+        ExprNode::Unary(op, x) => (fmt_call(op.name(), arena, *x, resolve), PREC_UNARY),
+        ExprNode::Atan2(y, x) => {
+            let y = render_node(arena, *y, resolve, PREC_ADD);
+            let x = render_node(arena, *x, resolve, PREC_ADD);
+            (format!("atan2({y}, {x})"), PREC_UNARY)
+        }
+        ExprNode::Min(children) | ExprNode::Max(children) => {
+            let name = if matches!(arena.get(id), ExprNode::Min(_)) { "min" } else { "max" };
+            let args = children
+                .iter()
+                .map(|child| render_node(arena, *child, resolve, PREC_ADD))
+                .collect::<Vec<_>>()
+                .join(", ");
+            (format!("{name}({args})"), PREC_UNARY)
+        }
         ExprNode::Linear { coeffs, constant } => {
             let parts = linear_parts_from_slice(coeffs, *constant, resolve);
             // A multi-term or negative-leading sum needs parens inside a product.
@@ -238,8 +248,8 @@ mod tests {
     fn expr_negated_residual() {
         let mut arena = ExprArena::new();
         let x = arena.push(ExprNode::Var(VarId(0)));
-        let s = arena.push(ExprNode::Sin(x));
-        let neg = arena.push(ExprNode::Neg(s));
+        let s = arena.push(ExprNode::Unary(UnaryOp::Sin, x));
+        let neg = arena.push(ExprNode::Unary(UnaryOp::Neg, s));
         assert_eq!(render_expr(&arena, neg, &names), "-sin(x)");
 
         let y = arena.push(ExprNode::Var(VarId(1)));
@@ -276,7 +286,7 @@ mod tests {
         let prod = arena.push(ExprNode::Mul(smallvec::smallvec![x, y]));
         let neg_z = arena.push(ExprNode::Linear { coeffs: vec![(VarId(2), -1.0)], constant: 0.0 });
         let sum = arena.push(ExprNode::Add(smallvec::smallvec![prod, neg_z]));
-        let s = arena.push(ExprNode::Sin(sum));
+        let s = arena.push(ExprNode::Unary(UnaryOp::Sin, sum));
         assert_eq!(render_expr(&arena, s, &names), "sin(x * y - z)");
     }
 
@@ -287,7 +297,7 @@ mod tests {
         let pid = arena.new_param(-3.0);
         let p = arena.param(pid);
         let sum = arena.push(ExprNode::Add(smallvec::smallvec![x, p]));
-        let s = arena.push(ExprNode::Sin(sum));
+        let s = arena.push(ExprNode::Unary(UnaryOp::Sin, sum));
         assert_eq!(render_expr(&arena, s, &names), "sin(x - 3)");
 
         arena.set_param_value(pid, 3.0);

--- a/crates/oximo-expr/src/simplify.rs
+++ b/crates/oximo-expr/src/simplify.rs
@@ -3,15 +3,15 @@ use crate::arena::{ExprArena, ExprId, ExprNode};
 /// Apply local algebraic simplifications to the subtree rooted at `id`,
 /// returning a (possibly fresh) `ExprId` that is observationally equivalent.
 ///
-/// Current rules: constant folding for unary nodes and `Pow`. The linear
-/// fast-path is already canonical, so we leave `Linear` and n-ary `Add`/`Mul`
-/// alone.
+/// Current rules: constant folding for unary nodes, `Pow`, `Div`, `Atan2`, and
+/// all-constant `Min`/`Max` nodes. The linear fast-path is already canonical,
+/// so we leave `Linear` and n-ary `Add`/`Mul` alone.
 ///
 /// TODO: Extend this once we add a CSE pass.
 pub fn simplify(arena: &mut ExprArena, id: ExprId) -> ExprId {
     let folded = match arena.get(id).clone() {
-        ExprNode::Neg(inner) => match arena.get(inner) {
-            ExprNode::Const(c) => Some(ExprNode::Const(-*c)),
+        ExprNode::Unary(op, inner) => match arena.get(inner) {
+            ExprNode::Const(c) => Some(ExprNode::Const(op.apply(*c))),
             _ => None,
         },
         ExprNode::Pow(base, exp) => match (arena.get(base), arena.get(exp)) {
@@ -22,24 +22,23 @@ pub fn simplify(arena: &mut ExprArena, id: ExprId) -> ExprId {
             (ExprNode::Const(n), ExprNode::Const(d)) => Some(ExprNode::Const(n / d)),
             _ => None,
         },
-        ExprNode::Sin(inner)
-        | ExprNode::Cos(inner)
-        | ExprNode::Exp(inner)
-        | ExprNode::Log(inner)
-        | ExprNode::Abs(inner) => {
-            let node = arena.get(id).clone();
-            if let ExprNode::Const(c) = arena.get(inner) {
-                Some(ExprNode::Const(match node {
-                    ExprNode::Sin(_) => c.sin(),
-                    ExprNode::Cos(_) => c.cos(),
-                    ExprNode::Exp(_) => c.exp(),
-                    ExprNode::Log(_) => c.ln(),
-                    ExprNode::Abs(_) => c.abs(),
-                    _ => unreachable!(),
-                }))
-            } else {
-                None
-            }
+        ExprNode::Atan2(y, x) => match (arena.get(y), arena.get(x)) {
+            (ExprNode::Const(y), ExprNode::Const(x)) => Some(ExprNode::Const(y.atan2(*x))),
+            _ => None,
+        },
+        ExprNode::Min(children) | ExprNode::Max(children) => {
+            let is_min = matches!(arena.get(id), ExprNode::Min(_));
+            let mut values = children.iter().map(|child| match arena.get(*child) {
+                ExprNode::Const(value) => Some(*value),
+                _ => None,
+            });
+            values.next().flatten().and_then(|first| {
+                values
+                    .try_fold(first, |acc, value| {
+                        value.map(|v| if is_min { acc.min(v) } else { acc.max(v) })
+                    })
+                    .map(ExprNode::Const)
+            })
         }
         _ => None,
     };
@@ -52,13 +51,13 @@ pub fn simplify(arena: &mut ExprArena, id: ExprId) -> ExprId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arena::{ExprArena, ExprNode};
+    use crate::arena::{ExprArena, ExprNode, UnaryOp};
 
     #[test]
     fn folds_abs_of_const() {
         let mut a = ExprArena::new();
         let c = a.push(ExprNode::Const(-5.0));
-        let abs = a.push(ExprNode::Abs(c));
+        let abs = a.push(ExprNode::Unary(UnaryOp::Abs, c));
         let folded = simplify(&mut a, abs);
         assert!(matches!(a.get(folded), ExprNode::Const(v) if (*v - 5.0).abs() < f64::EPSILON));
     }

--- a/crates/oximo-expr/src/visit.rs
+++ b/crates/oximo-expr/src/visit.rs
@@ -11,21 +11,19 @@ pub fn walk<V: Visitor>(arena: &ExprArena, id: ExprId, visitor: &mut V) {
     let node = arena.get(id);
     visitor.visit(arena, id, node);
     match node {
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             for &child in children {
                 walk(arena, child, visitor);
             }
         }
-        ExprNode::Neg(inner)
-        | ExprNode::Sin(inner)
-        | ExprNode::Cos(inner)
-        | ExprNode::Exp(inner)
-        | ExprNode::Log(inner)
-        | ExprNode::Abs(inner) => {
+        ExprNode::Unary(_, inner) => {
             let inner = *inner;
             walk(arena, inner, visitor);
         }
-        ExprNode::Pow(base, exp) => {
+        ExprNode::Pow(base, exp) | ExprNode::Atan2(base, exp) => {
             let base = *base;
             let exp = *exp;
             walk(arena, base, visitor);

--- a/crates/oximo-expr/tests/arithmetic.rs
+++ b/crates/oximo-expr/tests/arithmetic.rs
@@ -186,7 +186,7 @@ fn abs_is_nonlinear() {
     let arena = ExprArenaCell::new(ExprArena::new());
     let x = make_var(&arena, 0);
     let e = x.abs();
-    assert!(matches!(arena.borrow().get(e.id), ExprNode::Abs(_)));
+    assert!(matches!(arena.borrow().get(e.id), ExprNode::Unary(oximo_expr::UnaryOp::Abs, _)));
     assert_eq!(classify(&arena.borrow(), e.id), ExprClass::Nonlinear);
     assert!(extract_linear(&arena.borrow(), e.id).is_none());
 }

--- a/crates/oximo-expr/tests/nonlinear.rs
+++ b/crates/oximo-expr/tests/nonlinear.rs
@@ -1,0 +1,140 @@
+#![expect(clippy::float_cmp)]
+
+use oximo_expr::{
+    Expr, ExprArena, ExprArenaCell, ExprClass, ExprNode, UnaryOp, VarId, classify, evaluate,
+    render_expr, simplify,
+};
+
+fn value(expr: Expr<'_>) -> f64 {
+    let values: &[f64] = &[];
+    evaluate(&expr.arena.borrow(), expr.id, &values).unwrap()
+}
+
+#[test]
+fn every_unary_method_uses_the_public_operation_enum() {
+    let arena = ExprArenaCell::new(ExprArena::new());
+    let x = Expr::constant(&arena, 1.25);
+    let expressions = [
+        (x.neg(), UnaryOp::Neg),
+        (x.abs(), UnaryOp::Abs),
+        (x.sqrt(), UnaryOp::Sqrt),
+        (x.cbrt(), UnaryOp::Cbrt),
+        (x.exp(), UnaryOp::Exp),
+        (x.exp2(), UnaryOp::Exp2),
+        (x.expm1(), UnaryOp::Expm1),
+        (x.log(), UnaryOp::Log),
+        (x.log2(), UnaryOp::Log2),
+        (x.log10(), UnaryOp::Log10),
+        (x.log1p(), UnaryOp::Log1p),
+        (x.sin(), UnaryOp::Sin),
+        (x.cos(), UnaryOp::Cos),
+        (x.tan(), UnaryOp::Tan),
+        ((x / 2.0).asin(), UnaryOp::Asin),
+        ((x / 2.0).acos(), UnaryOp::Acos),
+        (x.atan(), UnaryOp::Atan),
+        (x.sinh(), UnaryOp::Sinh),
+        (x.cosh(), UnaryOp::Cosh),
+        (x.tanh(), UnaryOp::Tanh),
+        (x.asinh(), UnaryOp::Asinh),
+        ((x + 1.0).acosh(), UnaryOp::Acosh),
+        ((x / 2.0).atanh(), UnaryOp::Atanh),
+    ];
+    let snapshot = arena.borrow();
+    for (expr, expected) in expressions {
+        assert!(matches!(snapshot.get(expr.id), ExprNode::Unary(op, _) if *op == expected));
+        let expected_class =
+            if expected == UnaryOp::Neg { ExprClass::Linear } else { ExprClass::Nonlinear };
+        assert_eq!(classify(&snapshot, expr.id), expected_class);
+    }
+}
+
+#[test]
+fn rust_spelling_aliases_produce_the_same_operations() {
+    let arena = ExprArenaCell::new(ExprArena::new());
+    let x = Expr::constant(&arena, 0.25);
+    for (modeling, rust, expected) in [
+        (x.log(), x.ln(), UnaryOp::Log),
+        (x.log1p(), x.ln_1p(), UnaryOp::Log1p),
+        (x.expm1(), x.exp_m1(), UnaryOp::Expm1),
+    ] {
+        let snapshot = arena.borrow();
+        assert!(matches!(snapshot.get(modeling.id), ExprNode::Unary(op, _) if *op == expected));
+        assert!(matches!(snapshot.get(rust.id), ExprNode::Unary(op, _) if *op == expected));
+    }
+}
+
+#[test]
+fn unary_values_and_constant_folding_follow_f64() {
+    let mut arena = ExprArena::new();
+    for op in [
+        UnaryOp::Neg,
+        UnaryOp::Abs,
+        UnaryOp::Sqrt,
+        UnaryOp::Cbrt,
+        UnaryOp::Exp,
+        UnaryOp::Exp2,
+        UnaryOp::Expm1,
+        UnaryOp::Log,
+        UnaryOp::Log2,
+        UnaryOp::Log10,
+        UnaryOp::Log1p,
+        UnaryOp::Sin,
+        UnaryOp::Cos,
+        UnaryOp::Tan,
+        UnaryOp::Asin,
+        UnaryOp::Acos,
+        UnaryOp::Atan,
+        UnaryOp::Sinh,
+        UnaryOp::Cosh,
+        UnaryOp::Tanh,
+        UnaryOp::Asinh,
+        UnaryOp::Acosh,
+        UnaryOp::Atanh,
+    ] {
+        let input = arena.constant(0.5);
+        let node = arena.push(ExprNode::Unary(op, input));
+        let folded = simplify(&mut arena, node);
+        let ExprNode::Const(actual) = arena.get(folded) else { panic!("not folded") };
+        assert_eq!(actual.to_bits(), op.apply(0.5).to_bits(), "{op}");
+    }
+}
+
+#[test]
+fn invalid_domains_are_deferred_to_ieee_evaluation() {
+    let arena = ExprArenaCell::new(ExprArena::new());
+    assert!(value(Expr::constant(&arena, -1.0).sqrt()).is_nan());
+    assert!(value(Expr::constant(&arena, -1.0).log()).is_nan());
+    assert!(value(Expr::constant(&arena, 0.5).acosh()).is_nan());
+    assert!(value(Expr::constant(&arena, 2.0).atanh()).is_nan());
+    assert_eq!(value(Expr::constant(&arena, -8.0).cbrt()), -2.0);
+}
+
+#[test]
+fn atan2_uses_y_then_x_and_preserves_quadrants() {
+    let arena = ExprArenaCell::new(ExprArena::new());
+    let cases = [(1.0, 1.0), (1.0, -1.0), (-1.0, -1.0), (-1.0, 1.0)];
+    for (y, x) in cases {
+        let expr = Expr::constant(&arena, y).atan2(Expr::constant(&arena, x));
+        assert_eq!(value(expr).to_bits(), y.atan2(x).to_bits());
+    }
+}
+
+#[test]
+fn pairwise_min_and_max_flatten_both_sides_in_stable_order() {
+    let arena = ExprArenaCell::new(ExprArena::new());
+    let a = Expr::from_var(&arena, VarId(0));
+    let b = Expr::from_var(&arena, VarId(1));
+    let c = Expr::from_var(&arena, VarId(2));
+    let d = Expr::from_var(&arena, VarId(3));
+    let minimum = a.min(b).min(c.min(d));
+    let maximum = a.max(b).max(c.max(d));
+    let snapshot = arena.borrow();
+    assert!(
+        matches!(snapshot.get(minimum.id), ExprNode::Min(children) if children.as_slice() == [a.id, b.id, c.id, d.id])
+    );
+    assert!(
+        matches!(snapshot.get(maximum.id), ExprNode::Max(children) if children.as_slice() == [a.id, b.id, c.id, d.id])
+    );
+    assert_eq!(render_expr(&snapshot, minimum.id, &|v| format!("x{}", v.0)), "min(x0, x1, x2, x3)");
+    assert_eq!(render_expr(&snapshot, maximum.id, &|v| format!("x{}", v.0)), "max(x0, x1, x2, x3)");
+}

--- a/crates/oximo-expr/tests/nonlinear.rs
+++ b/crates/oximo-expr/tests/nonlinear.rs
@@ -138,3 +138,29 @@ fn pairwise_min_and_max_flatten_both_sides_in_stable_order() {
     assert_eq!(render_expr(&snapshot, minimum.id, &|v| format!("x{}", v.0)), "min(x0, x1, x2, x3)");
     assert_eq!(render_expr(&snapshot, maximum.id, &|v| format!("x{}", v.0)), "max(x0, x1, x2, x3)");
 }
+
+#[test]
+fn extrema_term_helpers_return_the_only_flattened_child() {
+    let arena = ExprArenaCell::new(ExprArena::new());
+    let (empty_min, empty_max, child) = {
+        let mut nodes = arena.borrow_mut();
+        (
+            nodes.push(ExprNode::Min(Default::default())),
+            nodes.push(ExprNode::Max(Default::default())),
+            nodes.push(ExprNode::Const(7.0)),
+        )
+    };
+    let empty_min = Expr::new(empty_min, &arena);
+    let empty_max = Expr::new(empty_max, &arena);
+    let child = Expr::new(child, &arena);
+
+    let minimum = Expr::__min_terms([empty_min, child].into_iter()).unwrap();
+    let maximum = Expr::__max_terms([empty_max, child].into_iter()).unwrap();
+
+    assert_eq!(minimum.id, child.id);
+    assert_eq!(maximum.id, child.id);
+    assert_eq!(value(minimum), 7.0);
+    assert_eq!(value(maximum), 7.0);
+    assert_eq!(Expr::__min_terms([child].into_iter()).unwrap().id, child.id);
+    assert_eq!(Expr::__max_terms([child].into_iter()).unwrap().id, child.id);
+}

--- a/crates/oximo-expr/tests/nonlinear.rs
+++ b/crates/oximo-expr/tests/nonlinear.rs
@@ -1,8 +1,8 @@
 #![expect(clippy::float_cmp)]
 
 use oximo_expr::{
-    Expr, ExprArena, ExprArenaCell, ExprClass, ExprNode, UnaryOp, VarId, classify, evaluate,
-    render_expr, simplify,
+    Children, Expr, ExprArena, ExprArenaCell, ExprClass, ExprNode, UnaryOp, VarId, classify,
+    evaluate, render_expr, simplify,
 };
 
 fn value(expr: Expr<'_>) -> f64 {
@@ -145,8 +145,8 @@ fn extrema_term_helpers_return_the_only_flattened_child() {
     let (empty_min, empty_max, child) = {
         let mut nodes = arena.borrow_mut();
         (
-            nodes.push(ExprNode::Min(Default::default())),
-            nodes.push(ExprNode::Max(Default::default())),
+            nodes.push(ExprNode::Min(Children::new())),
+            nodes.push(ExprNode::Max(Children::new())),
             nodes.push(ExprNode::Const(7.0)),
         )
     };

--- a/crates/oximo-gams/README.md
+++ b/crates/oximo-gams/README.md
@@ -2,7 +2,7 @@
 
 GAMS backend for [oximo](https://github.com/oximo-rs/oximo).
 
-Writes an oximo `Model` to a temporary `.gms` file, invokes the GAMS executable via `std::process::Command`, and parses the solution from a PUT-generated text file. Supports `LP`, `MILP`, `QP`, `MIQP`, `QCP`, `MIQCP`, `SOCP`, `MISOCP`, `NLP`, and `MINLP` model kinds, including native `SOS1` and `SOS2` constraints.
+Writes an oximo `Model` to a temporary `.gms` file, invokes the GAMS executable via `std::process::Command`, and parses the solution from a PUT-generated text file. Supports `LP`, `MILP`, `QP`, `MIQP`, `QCP`, `MIQCP`, `SOCP`, `MISOCP`, `NLP`, `DNLP`, and `MINLP` solve types, including native `SOS1` and `SOS2` constraints.
 
 The sub-solver is determined by the GAMS installation (default) or set explicitly via `GamsOptions::solver`. Any solver available in your GAMS distribution can be targeted, see [Sub-solver selection](#sub-solver-selection) below.
 
@@ -101,8 +101,18 @@ let opts = GamsOptions::default()
 ## Sub-solver selection
 
 Pass a `GamsSolverConfig` to `.solver(...)` to select a GAMS sub-solver. This emits
-`option {LP|MIP|NLP|MINLP|QCP|MIQCP} = <NAME>;` in the generated `.gms` file, scoped to
-the solve type resolved from `Model::kind()` (`QP` -> `QCP`, `MIQP` -> `MIQCP`).
+`option {LP|MIP|NLP|DNLP|MINLP|QCP|MIQCP} = <NAME>;` in the generated `.gms` file,
+scoped to the solve type resolved from the model (`QP` -> `QCP`, `MIQP` -> `MIQCP`,
+and continuous variable-dependent `abs`/`min`/`max` -> `DNLP`).
+
+### Nonlinear expressions
+
+GAMS receives exact native expressions for `sqrt`, `exp2` (as `2 ** x`), the
+trigonometric and inverse-trigonometric functions, `sinh`/`cosh`/`tanh`,
+`log2`, `log10`, `atan2`, `min`, and `max`. Continuous variable-dependent
+`abs`, `min`, and `max` route to `DNLP`, while mixed-integer models remain `MINLP`.
+`cbrt`, `expm1`, `log1p`, and inverse-hyperbolic functions return a typed
+unsupported-operator error.
 
 ```rust
 use oximo_gams::{GamsOptions, GamsSolver, GamsSolverConfig};

--- a/crates/oximo-gams/src/solver_options.rs
+++ b/crates/oximo-gams/src/solver_options.rs
@@ -149,28 +149,30 @@ impl GamsSolverConfig {
     }
 }
 
-/// GAMS solve types a named solver supports, restricted to the six oximo can
-/// emit: `LP` / `MIP` / `NLP` / `MINLP` / `QCP` / `MIQCP`. `None` means the
+/// GAMS solve types a named solver supports, restricted to the seven oximo can
+/// emit: `LP` / `MIP` / `NLP` / `DNLP` / `MINLP` / `QCP` / `MIQCP`. `None` means the
 /// name is unrecognized and cannot be validated.
 ///
 /// Transcribed from the GAMS solver/model-type matrix (other model types
-/// (`MCP`, `MPEC`, `CNS`, `DNLP`, `EMP`, stochastic) are omitted because oximo
+/// (`MCP`, `MPEC`, `CNS`, `EMP`, stochastic) are omitted because oximo
 /// never emits them):
 /// - "GAMS Solver Manuals," GAMS Development Corporation.
 ///   <https://www.gams.com/latest/docs/S_MAIN.html#SOLVERS_MODEL_TYPES> (accessed May 14, 2026).
 fn supported_solve_types(gams_name: &str) -> Option<&'static [&'static str]> {
     Some(match gams_name {
         "ALPHAECP" | "DICOPT" | "SBB" | "SHOT" => &["MINLP", "MIQCP"],
-        "CONOPT" | "CONOPT3" | "CONOPT4" | "IPOPT" | "MINOS" | "SNOPT" => &["LP", "NLP", "QCP"],
+        "CONOPT" | "CONOPT3" | "CONOPT4" | "IPOPT" | "MINOS" | "SNOPT" => {
+            &["LP", "NLP", "DNLP", "QCP"]
+        }
         "DECIS" | "SOPLEX" | "QUADMINOS" => &["LP"],
         "CBC" | "GLPK" | "HIGHS" => &["LP", "MIP"],
         "ODHCPLEX" => &["MIP", "MIQCP"],
         "COPT" | "CPLEX" => &["LP", "MIP", "QCP", "MIQCP"],
-        "ANTIGONE" => &["NLP", "MINLP", "QCP", "MIQCP"],
-        "KNITRO" => &["LP", "NLP", "MINLP", "QCP", "MIQCP"],
-        "SCIP" => &["MIP", "NLP", "MINLP", "QCP", "MIQCP"],
+        "ANTIGONE" => &["NLP", "DNLP", "MINLP", "QCP", "MIQCP"],
+        "KNITRO" => &["LP", "NLP", "DNLP", "MINLP", "QCP", "MIQCP"],
+        "SCIP" => &["MIP", "NLP", "DNLP", "MINLP", "QCP", "MIQCP"],
         "BARON" | "GUROBI" | "GUSS" | "KESTREL" | "LINDO" | "LINDOGLOBAL" | "MOSEK" | "XPRESS" => {
-            &["LP", "MIP", "NLP", "MINLP", "QCP", "MIQCP"]
+            &["LP", "MIP", "NLP", "DNLP", "MINLP", "QCP", "MIQCP"]
         }
         // JAMS (EMP), MILES (MCP), NLPEC (MCP/MPEC), PATH (MCP/MPEC/CNS),
         // RESHOP (EMP) support none of the model types oximo emits.

--- a/crates/oximo-gams/src/translate.rs
+++ b/crates/oximo-gams/src/translate.rs
@@ -14,7 +14,7 @@ use oximo_core::{
     Constraint, ConstraintId, Domain, Model, ModelKind, Objective, ObjectiveSense, Sense,
     SocConstraint, SocConstraintId, SosConstraint, SosMember, SosType, VarId, Variable,
 };
-use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms};
+use oximo_expr::{ExprArena, ExprId, ExprNode, LinearTerms, UnaryOp};
 use oximo_solver::{
     DualStatus, PrimalStatus, SolutionPoint, SolverError, SolverResult, TerminationStatus,
 };
@@ -45,7 +45,9 @@ pub fn solve(
 ) -> Result<SolverResult, SolverError> {
     let prepared = LoweringContext::new(model)?;
     let kind = prepared.kind();
-    validate_solver(opts, kind)?;
+    let nonsmooth = analyze_gams_expressions(&prepared)?;
+    let solve_type = gams_solve_type_for(kind, nonsmooth);
+    validate_solver_type(opts, kind, solve_type)?;
     let vars = prepared.variables();
     let model_constraints = prepared.constraints();
     let constraints = model_constraints.algebraic();
@@ -62,7 +64,7 @@ pub fn solve(
     let mut gms = String::with_capacity(4096);
     let solver_opt = build_model_section(
         &mut gms,
-        kind,
+        solve_type,
         &prepared,
         vars,
         constraints,
@@ -655,7 +657,7 @@ fn solve_status_label(status: i32) -> &'static str {
 #[expect(clippy::too_many_arguments)]
 fn build_model_section(
     gms: &mut String,
-    kind: ModelKind,
+    solve_type: &str,
     prepared: &PreparedExpressions,
     vars: &[Variable],
     constraints: &[Constraint],
@@ -665,7 +667,6 @@ fn build_model_section(
     sense_kw: &str,
     opts: &GamsOptions,
 ) -> Option<(String, String)> {
-    let solve_type = gams_solve_type(kind);
     let solver_opt = build_solver_opt(opts);
 
     write_preamble(gms);
@@ -690,14 +691,21 @@ pub(crate) fn gams_solve_type(kind: ModelKind) -> &'static str {
     }
 }
 
+fn gams_solve_type_for(kind: ModelKind, nonsmooth: bool) -> &'static str {
+    if nonsmooth && kind == ModelKind::NLP { "DNLP" } else { gams_solve_type(kind) }
+}
+
 /// Reject an explicitly selected sub-solver that cannot handle `kind` before
 /// invoking GAMS, so the caller gets a clear error naming the solver and model
 /// type instead of a downstream GAMS compilation failure.
-fn validate_solver(opts: &GamsOptions, kind: ModelKind) -> Result<(), SolverError> {
+fn validate_solver_type(
+    opts: &GamsOptions,
+    kind: ModelKind,
+    solve_type: &str,
+) -> Result<(), SolverError> {
     if let Some(cfg) = &opts.solver
-        && !cfg.supports(kind)
+        && !crate::solver_options::solver_supports_type(cfg.gams_name(), solve_type)
     {
-        let solve_type = gams_solve_type(kind);
         return Err(SolverError::Backend(format!(
             "GAMS solver {} does not support {solve_type} models (model kind {kind:?}); \
             select a solver that supports {solve_type}",
@@ -705,6 +713,88 @@ fn validate_solver(opts: &GamsOptions, kind: ModelKind) -> Result<(), SolverErro
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+fn validate_solver(opts: &GamsOptions, kind: ModelKind) -> Result<(), SolverError> {
+    validate_solver_type(opts, kind, gams_solve_type(kind))
+}
+
+/// Validate GAMS's expression-local vocabulary and detect active,
+/// variable-dependent nonsmooth primitives that require DNLP routing.
+fn analyze_gams_expressions(prepared: &LoweringContext<'_>) -> Result<bool, SolverError> {
+    let arena = prepared.arena();
+    let mut depends_on_var = vec![false; arena.len()];
+    for (index, node) in arena.nodes().iter().enumerate() {
+        let dep = |id: ExprId| depends_on_var[id.index()];
+        depends_on_var[index] = match node {
+            ExprNode::Const(_) | ExprNode::Param(_) => false,
+            ExprNode::Var(_) => true,
+            ExprNode::Linear { coeffs, .. } => !coeffs.is_empty(),
+            ExprNode::Unary(_, child) => dep(*child),
+            ExprNode::Pow(a, b) | ExprNode::Div(a, b) | ExprNode::Atan2(a, b) => dep(*a) || dep(*b),
+            ExprNode::Add(children)
+            | ExprNode::Mul(children)
+            | ExprNode::Min(children)
+            | ExprNode::Max(children) => children.iter().any(|child| dep(*child)),
+        };
+    }
+
+    let mut roots = Vec::new();
+    if let Some(objective) = prepared.objective() {
+        roots.push(objective.expr);
+    }
+    roots.extend(
+        prepared
+            .constraints()
+            .algebraic()
+            .iter()
+            .filter(|constraint| constraint.active)
+            .map(|constraint| constraint.lhs),
+    );
+    let mut seen = vec![false; arena.len()];
+    let mut nonsmooth = false;
+    while let Some(id) = roots.pop() {
+        if std::mem::replace(&mut seen[id.index()], true) {
+            continue;
+        }
+        match arena.get(id) {
+            ExprNode::Unary(op, child) => {
+                if matches!(
+                    op,
+                    UnaryOp::Cbrt
+                        | UnaryOp::Expm1
+                        | UnaryOp::Log1p
+                        | UnaryOp::Asinh
+                        | UnaryOp::Acosh
+                        | UnaryOp::Atanh
+                ) {
+                    return Err(SolverError::UnsupportedNonlinearOperator {
+                        backend: "GAMS",
+                        operator: op.name(),
+                    });
+                }
+                nonsmooth |= *op == UnaryOp::Abs && depends_on_var[id.index()];
+                roots.push(*child);
+            }
+            ExprNode::Min(children) | ExprNode::Max(children) => {
+                nonsmooth |= depends_on_var[id.index()];
+                roots.extend(children.iter().copied());
+            }
+            ExprNode::Add(children) | ExprNode::Mul(children) => {
+                roots.extend(children.iter().copied());
+            }
+            ExprNode::Pow(a, b) | ExprNode::Div(a, b) | ExprNode::Atan2(a, b) => {
+                roots.push(*a);
+                roots.push(*b);
+            }
+            ExprNode::Const(_)
+            | ExprNode::Var(_)
+            | ExprNode::Param(_)
+            | ExprNode::Linear { .. } => {}
+        }
+    }
+    Ok(nonsmooth)
 }
 
 fn build_solver_opt(opts: &GamsOptions) -> Option<(String, String)> {
@@ -1082,7 +1172,7 @@ fn write_gams_expr(gms: &mut String, arena: &ExprArena, id: ExprId, leading_spac
             write_linear(gms, &t, true);
             write!(gms, " )").unwrap();
         }
-        ExprNode::Neg(inner) => {
+        ExprNode::Unary(UnaryOp::Neg, inner) => {
             write!(gms, "(-").unwrap();
             write_gams_expr(gms, arena, *inner, true);
             write!(gms, ")").unwrap();
@@ -1136,32 +1226,63 @@ fn write_gams_expr(gms: &mut String, arena: &ExprArena, id: ExprId, leading_spac
             write_gams_expr(gms, arena, *den, true);
             write!(gms, ")").unwrap();
         }
-        ExprNode::Sin(a) => {
-            write!(gms, "sin(").unwrap();
-            write_gams_expr(gms, arena, *a, false);
+        ExprNode::Unary(op, a) => write_gams_unary(gms, arena, *op, *a),
+        ExprNode::Atan2(y, x) => {
+            write!(gms, "arctan2(").unwrap();
+            write_gams_expr(gms, arena, *y, false);
+            write!(gms, ", ").unwrap();
+            write_gams_expr(gms, arena, *x, false);
             write!(gms, ")").unwrap();
         }
-        ExprNode::Cos(a) => {
-            write!(gms, "cos(").unwrap();
-            write_gams_expr(gms, arena, *a, false);
-            write!(gms, ")").unwrap();
-        }
-        ExprNode::Exp(a) => {
-            write!(gms, "exp(").unwrap();
-            write_gams_expr(gms, arena, *a, false);
-            write!(gms, ")").unwrap();
-        }
-        ExprNode::Log(a) => {
-            write!(gms, "log(").unwrap();
-            write_gams_expr(gms, arena, *a, false);
-            write!(gms, ")").unwrap();
-        }
-        ExprNode::Abs(a) => {
-            write!(gms, "abs(").unwrap();
-            write_gams_expr(gms, arena, *a, false);
+        ExprNode::Min(children) | ExprNode::Max(children) => {
+            let name = if matches!(arena.get(id), ExprNode::Min(_)) { "min" } else { "max" };
+            write!(gms, "{name}(").unwrap();
+            for (index, child) in children.iter().enumerate() {
+                if index > 0 {
+                    write!(gms, ", ").unwrap();
+                }
+                write_gams_expr(gms, arena, *child, false);
+            }
             write!(gms, ")").unwrap();
         }
     }
+}
+
+#[inline]
+fn write_gams_unary(gms: &mut String, arena: &ExprArena, op: UnaryOp, child: ExprId) {
+    if op == UnaryOp::Exp2 {
+        write!(gms, "(2 ** ").unwrap();
+        write_gams_expr(gms, arena, child, false);
+        write!(gms, ")").unwrap();
+        return;
+    }
+    let name = match op {
+        UnaryOp::Abs => "abs",
+        UnaryOp::Sqrt => "sqrt",
+        UnaryOp::Exp => "exp",
+        UnaryOp::Log => "log",
+        UnaryOp::Log2 => "log2",
+        UnaryOp::Log10 => "log10",
+        UnaryOp::Sin => "sin",
+        UnaryOp::Cos => "cos",
+        UnaryOp::Tan => "tan",
+        UnaryOp::Asin => "arcsin",
+        UnaryOp::Acos => "arccos",
+        UnaryOp::Atan => "arctan",
+        UnaryOp::Sinh => "sinh",
+        UnaryOp::Cosh => "cosh",
+        UnaryOp::Tanh => "tanh",
+        UnaryOp::Neg | UnaryOp::Exp2 => unreachable!(),
+        UnaryOp::Cbrt
+        | UnaryOp::Expm1
+        | UnaryOp::Log1p
+        | UnaryOp::Asinh
+        | UnaryOp::Acosh
+        | UnaryOp::Atanh => unreachable!("GAMS expression validation rejects {op}"),
+    };
+    write!(gms, "{name}(").unwrap();
+    write_gams_expr(gms, arena, child, false);
+    write!(gms, ")").unwrap();
 }
 
 /// Format an `f64` for use in a GAMS file.
@@ -1338,10 +1459,13 @@ mod tests {
             ObjectiveSense::Maximize => "maximizing",
         };
         let mut gms = String::new();
+        let prepared = LoweringContext::new(model).unwrap();
+        let solve_type =
+            gams_solve_type_for(model.kind(), analyze_gams_expressions(&prepared).unwrap());
         build_model_section(
             &mut gms,
-            model.kind(),
-            &LoweringContext::new(model).unwrap(),
+            solve_type,
+            &prepared,
             &vars,
             constraints,
             &socs,
@@ -1554,7 +1678,7 @@ mod tests {
         variable!(m, -5.0 <= x <= 5.0);
         objective!(m, Min, x.abs());
         let gms = render(&m, &GamsOptions::default());
-        assert!(gms.contains("Solve oximo_m using NLP minimizing v_obj;"), "got:\n{gms}");
+        assert!(gms.contains("Solve oximo_m using DNLP minimizing v_obj;"), "got:\n{gms}");
         assert!(gms.contains("abs("), "expected abs(...) in objective:\n{gms}");
     }
 
@@ -1568,6 +1692,67 @@ mod tests {
         let gms = render(&m, &GamsOptions::default());
         assert!(gms.contains("Solve oximo_m using MINLP maximizing v_obj;"), "got:\n{gms}");
         assert!(gms.contains("log("), "expected log(...) in objective:\n{gms}");
+    }
+
+    #[test]
+    fn min_max_render_natively_and_mixed_integer_nonsmooth_stays_minlp() {
+        let m = Model::new("nonsmooth_minlp");
+        variable!(m, b, Bin);
+        variable!(m, -2.0 <= x <= 2.0);
+        objective!(m, Max, x.min(b - x).max(x + b));
+        let gms = render(&m, &GamsOptions::default());
+        assert!(gms.contains("min("), "{gms}");
+        assert!(gms.contains("max("), "{gms}");
+        assert!(gms.contains("Solve oximo_m using MINLP maximizing v_obj;"), "{gms}");
+    }
+
+    #[test]
+    fn added_smooth_functions_render_with_gams_spellings() {
+        let m = Model::new("gams_functions");
+        variable!(m, 0.5 <= x <= 0.9);
+        let e = x.sqrt()
+            + x.exp2()
+            + x.tan()
+            + x.asin()
+            + x.acos()
+            + x.atan()
+            + x.sinh()
+            + x.cosh()
+            + x.tanh()
+            + x.log2()
+            + x.log10()
+            + x.atan2(x + 1.0);
+        objective!(m, Min, e);
+        let gms = render(&m, &GamsOptions::default());
+        for spelling in [
+            "sqrt(", "2 ** ", "tan(", "arcsin(", "arccos(", "arctan(", "sinh(", "cosh(", "tanh(",
+            "log2(", "log10(", "arctan2(",
+        ] {
+            assert!(gms.contains(spelling), "missing {spelling}:\n{gms}");
+        }
+        assert!(gms.contains("using NLP"), "{gms}");
+    }
+
+    #[test]
+    fn unsupported_gams_unary_families_fail_with_typed_error() {
+        for name in ["cbrt", "expm1", "log1p", "asinh"] {
+            let m = Model::new(name);
+            variable!(m, x);
+            let expr = match name {
+                "cbrt" => x.cbrt(),
+                "expm1" => x.expm1(),
+                "log1p" => x.log1p(),
+                "asinh" => x.asinh(),
+                _ => unreachable!(),
+            };
+            objective!(m, Min, expr);
+            let prepared = LoweringContext::new(&m).unwrap();
+            assert!(matches!(
+                analyze_gams_expressions(&prepared),
+                Err(SolverError::UnsupportedNonlinearOperator { backend: "GAMS", operator })
+                    if operator == name
+            ));
+        }
     }
 
     #[test]
@@ -1740,6 +1925,21 @@ mod tests {
         // IPOPT does LP/NLP/QCP only, so the integer kinds must be rejected.
         assert!(validate_solver(&o, ModelKind::MILP).is_err());
         assert!(validate_solver(&o, ModelKind::MIQP).is_err());
+    }
+
+    #[test]
+    fn nonsmooth_nlp_routes_to_dnlp_and_checks_subsolver_capability() {
+        use crate::solver_options::{GamsCplexOptions, GamsIpoptOptions, GamsSolverConfig};
+        assert_eq!(gams_solve_type_for(ModelKind::NLP, true), "DNLP");
+        assert_eq!(gams_solve_type_for(ModelKind::NLP, false), "NLP");
+        assert_eq!(gams_solve_type_for(ModelKind::MINLP, true), "MINLP");
+
+        let ipopt =
+            GamsOptions::default().solver(GamsSolverConfig::Ipopt(GamsIpoptOptions::default()));
+        assert!(validate_solver_type(&ipopt, ModelKind::NLP, "DNLP").is_ok());
+        let cplex =
+            GamsOptions::default().solver(GamsSolverConfig::Cplex(GamsCplexOptions::default()));
+        assert!(validate_solver_type(&cplex, ModelKind::NLP, "DNLP").is_err());
     }
 
     #[test]

--- a/crates/oximo-gurobi/src/nonlinear.rs
+++ b/crates/oximo-gurobi/src/nonlinear.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use gurobi_rs::Opcode;
 use gurobi_rs::expr::{LinExpr, QuadExpr};
 use gurobi_rs::prelude::*;
-use oximo_expr::{ExprArena, ExprId, ExprNode, VarId};
+use oximo_expr::{ExprArena, ExprId, ExprNode, UnaryOp, VarId};
 use oximo_solver::SolverError;
 
 /// A value that can stay on Gurobi's direct linear/quadratic fast path, or a
@@ -235,7 +235,7 @@ fn try_quadratic(
             }
             LoweredExpr::Linear(e)
         }
-        ExprNode::Neg(inner) => {
+        ExprNode::Unary(UnaryOp::Neg, inner) => {
             let Some(inner) = try_quadratic(arena, *inner, ctx)? else {
                 return Ok(cache_quadratic_none(ctx, id));
             };
@@ -298,11 +298,9 @@ fn try_quadratic(
             };
             try_scale(num, 1.0 / den)
         }
-        ExprNode::Sin(_)
-        | ExprNode::Cos(_)
-        | ExprNode::Exp(_)
-        | ExprNode::Log(_)
-        | ExprNode::Abs(_) => return Ok(cache_quadratic_none(ctx, id)),
+        ExprNode::Unary(_, _) | ExprNode::Atan2(_, _) | ExprNode::Min(_) | ExprNode::Max(_) => {
+            return Ok(cache_quadratic_none(ctx, id));
+        }
     };
     ctx.quadratic_cache.insert(id, Some(value.clone()));
     Ok(Some(value))
@@ -315,18 +313,16 @@ fn cache_quadratic_none(ctx: &mut LoweringCtx<'_>, id: ExprId) -> Option<Lowered
 
 fn for_each_child(node: &ExprNode, f: &mut impl FnMut(ExprId)) {
     match node {
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             for child in children {
                 f(*child);
             }
         }
-        ExprNode::Neg(inner)
-        | ExprNode::Sin(inner)
-        | ExprNode::Cos(inner)
-        | ExprNode::Exp(inner)
-        | ExprNode::Log(inner)
-        | ExprNode::Abs(inner) => f(*inner),
-        ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) => {
+        ExprNode::Unary(_, inner) => f(*inner),
+        ExprNode::Pow(base, exp) | ExprNode::Div(base, exp) | ExprNode::Atan2(base, exp) => {
             f(*base);
             f(*exp);
         }
@@ -554,6 +550,91 @@ fn materialize_abs(
     Ok(result)
 }
 
+pub(crate) fn validate_supported(
+    arena: &ExprArena,
+    roots: impl IntoIterator<Item = ExprId>,
+) -> Result<(), SolverError> {
+    let mut seen = vec![false; arena.len()];
+    let mut stack: Vec<_> = roots.into_iter().collect();
+    while let Some(id) = stack.pop() {
+        if std::mem::replace(&mut seen[id.index()], true) {
+            continue;
+        }
+        match arena.get(id) {
+            ExprNode::Unary(op, child) => {
+                if !matches!(
+                    op,
+                    UnaryOp::Neg
+                        | UnaryOp::Abs
+                        | UnaryOp::Sqrt
+                        | UnaryOp::Exp
+                        | UnaryOp::Exp2
+                        | UnaryOp::Log
+                        | UnaryOp::Log2
+                        | UnaryOp::Log10
+                        | UnaryOp::Sin
+                        | UnaryOp::Cos
+                        | UnaryOp::Tan
+                        | UnaryOp::Tanh
+                ) {
+                    return Err(SolverError::UnsupportedNonlinearOperator {
+                        backend: "Gurobi",
+                        operator: op.name(),
+                    });
+                }
+                stack.push(*child);
+            }
+            ExprNode::Add(children)
+            | ExprNode::Mul(children)
+            | ExprNode::Min(children)
+            | ExprNode::Max(children) => stack.extend(children.iter().copied()),
+            ExprNode::Pow(a, b) | ExprNode::Div(a, b) => {
+                stack.push(*a);
+                stack.push(*b);
+            }
+            ExprNode::Atan2(_, _) => {
+                return Err(SolverError::UnsupportedNonlinearOperator {
+                    backend: "Gurobi",
+                    operator: "atan2",
+                });
+            }
+            ExprNode::Const(_)
+            | ExprNode::Var(_)
+            | ExprNode::Param(_)
+            | ExprNode::Linear { .. } => {}
+        }
+    }
+    Ok(())
+}
+
+fn materialize_extrema(
+    ctx: &mut LoweringCtx<'_>,
+    arena: &ExprArena,
+    children: &[ExprId],
+    is_min: bool,
+) -> Result<Var, SolverError> {
+    let mut arguments = Vec::with_capacity(children.len());
+    for child in children {
+        let argument = if let Some(value) = try_quadratic(arena, *child, ctx)? {
+            materialize_lowered(ctx, value)?
+        } else {
+            native_expr(ctx, arena, *child)?
+        };
+        arguments.push(argument);
+    }
+    let tag = if is_min { "min" } else { "max" };
+    let result = ctx.new_aux(tag, f64::NEG_INFINITY, f64::INFINITY).map_err(map_gurobi)?;
+    let name = ctx.next_name(&format!("{tag}_def"));
+    let generated = if is_min {
+        ctx.model.add_genconstr_min(&name, result, arguments, Some(gurobi_rs::INFINITY))
+    } else {
+        ctx.model.add_genconstr_max(&name, result, arguments, Some(-gurobi_rs::INFINITY))
+    }
+    .map_err(map_gurobi)?;
+    ctx.generated.push(GeneratedConstraint::General(generated));
+    Ok(result)
+}
+
 fn materialize_shared(
     ctx: &mut LoweringCtx<'_>,
     arena: &ExprArena,
@@ -566,7 +647,9 @@ fn materialize_shared(
         materialize_lowered(ctx, value)?
     } else {
         match arena.get(id) {
-            ExprNode::Abs(inner) => materialize_abs(ctx, arena, *inner)?,
+            ExprNode::Unary(UnaryOp::Abs, inner) => materialize_abs(ctx, arena, *inner)?,
+            ExprNode::Min(children) => materialize_extrema(ctx, arena, children, true)?,
+            ExprNode::Max(children) => materialize_extrema(ctx, arena, children, false)?,
             _ => native_expr(ctx, arena, id)?,
         }
     };
@@ -574,6 +657,7 @@ fn materialize_shared(
     Ok(result)
 }
 
+#[expect(clippy::too_many_lines)]
 fn append_tree(
     ctx: &mut LoweringCtx<'_>,
     arena: &ExprArena,
@@ -614,7 +698,7 @@ fn append_tree(
             }
             append_linear_parts(ctx, &terms, parent, tree)
         }
-        ExprNode::Neg(inner) => {
+        ExprNode::Unary(UnaryOp::Neg, inner) => {
             let op = tree.push(Opcode::Uminus, 0.0, parent)?;
             append_tree(ctx, arena, *inner, Some(op), tree)
         }
@@ -635,24 +719,61 @@ fn append_tree(
             append_tree(ctx, arena, *num, Some(op), tree)?;
             append_tree(ctx, arena, *den, Some(op), tree)
         }
-        ExprNode::Sin(inner)
-        | ExprNode::Cos(inner)
-        | ExprNode::Exp(inner)
-        | ExprNode::Log(inner) => {
-            let opcode = match arena.get(id) {
-                ExprNode::Sin(_) => Opcode::Sin,
-                ExprNode::Cos(_) => Opcode::Cos,
-                ExprNode::Exp(_) => Opcode::Exp,
-                ExprNode::Log(_) => Opcode::Log,
+        ExprNode::Unary(op, inner)
+            if matches!(
+                op,
+                UnaryOp::Sqrt
+                    | UnaryOp::Sin
+                    | UnaryOp::Cos
+                    | UnaryOp::Tan
+                    | UnaryOp::Exp
+                    | UnaryOp::Log
+                    | UnaryOp::Log2
+                    | UnaryOp::Log10
+                    | UnaryOp::Tanh
+            ) =>
+        {
+            let opcode = match op {
+                UnaryOp::Sqrt => Opcode::Sqrt,
+                UnaryOp::Sin => Opcode::Sin,
+                UnaryOp::Cos => Opcode::Cos,
+                UnaryOp::Tan => Opcode::Tan,
+                UnaryOp::Exp => Opcode::Exp,
+                UnaryOp::Log => Opcode::Log,
+                UnaryOp::Log2 => Opcode::Log2,
+                UnaryOp::Log10 => Opcode::Log10,
+                UnaryOp::Tanh => Opcode::Tanh,
                 _ => unreachable!(),
             };
             let op = tree.push(opcode, 0.0, parent)?;
             append_tree(ctx, arena, *inner, Some(op), tree)
         }
-        ExprNode::Abs(inner) => {
+        ExprNode::Unary(UnaryOp::Exp2, inner) => {
+            let op = tree.push(Opcode::Pow, 0.0, parent)?;
+            tree.push(Opcode::Constant, 2.0, Some(op))?;
+            append_tree(ctx, arena, *inner, Some(op), tree)
+        }
+        ExprNode::Unary(UnaryOp::Abs, inner) => {
             let result = materialize_abs(ctx, arena, *inner)?;
             let index = ctx.model.var_index(&result).map_err(map_gurobi)?;
             tree.push(Opcode::Variable, f64::from(index), parent)
+        }
+        ExprNode::Min(children) | ExprNode::Max(children) => {
+            let result = materialize_extrema(
+                ctx,
+                arena,
+                children,
+                matches!(arena.get(id), ExprNode::Min(_)),
+            )?;
+            let index = ctx.model.var_index(&result).map_err(map_gurobi)?;
+            tree.push(Opcode::Variable, f64::from(index), parent)
+        }
+        ExprNode::Unary(op, _) => Err(SolverError::UnsupportedNonlinearOperator {
+            backend: "Gurobi",
+            operator: op.name(),
+        }),
+        ExprNode::Atan2(_, _) => {
+            Err(SolverError::UnsupportedNonlinearOperator { backend: "Gurobi", operator: "atan2" })
         }
     }
 }

--- a/crates/oximo-gurobi/src/translate.rs
+++ b/crates/oximo-gurobi/src/translate.rs
@@ -17,7 +17,7 @@ use oximo_solver::{
 use rustc_hash::FxHashMap;
 
 use crate::GurobiOptions;
-use crate::nonlinear::{GeneratedConstraint, LoweredExpr, LoweringCtx, lower};
+use crate::nonlinear::{GeneratedConstraint, LoweredExpr, LoweringCtx, lower, validate_supported};
 use crate::options::apply as apply_options;
 
 pub(crate) fn map_gurobi_err(e: gurobi_rs::Error) -> SolverError {
@@ -38,6 +38,7 @@ pub(crate) fn map_gurobi_err(e: gurobi_rs::Error) -> SolverError {
 /// Panics if model variable or constraint indices overflow `u32`.
 pub fn solve(model: &Model, opts: &GurobiOptions) -> Result<SolverResult, SolverError> {
     let kind = model.kind();
+    validate_model_operators(model)?;
     let env = default_env()?;
     let mut built = build(model, opts, &env)?;
     run_and_collect(&mut built, kind)
@@ -68,6 +69,7 @@ pub(crate) struct Built {
 /// Returns a [`SolverError`] if the model contains nonlinear expressions Gurobi
 /// cannot represent or Gurobi reports an error during setup.
 pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Built, SolverError> {
+    validate_model_operators(model)?;
     let prepared = LoweringContext::new(model)?;
     let kind = prepared.kind();
     let nonlinear_kind = matches!(
@@ -134,6 +136,23 @@ pub(crate) fn build(model: &Model, opts: &GurobiOptions, env: &Env) -> Result<Bu
         obj_constant,
         has_semi,
     })
+}
+
+fn validate_model_operators(model: &Model) -> Result<(), SolverError> {
+    let arena = model.arena();
+    let mut roots = Vec::new();
+    if let Some(objective) = model.objective().as_ref() {
+        roots.push(objective.expr);
+    }
+    roots.extend(
+        model
+            .constraints()
+            .algebraic()
+            .iter()
+            .filter(|constraint| constraint.active)
+            .map(|constraint| constraint.lhs),
+    );
+    validate_supported(&arena, roots)
 }
 
 /// Optimize a built model and assemble the generic [`SolverResult`]. Shared by the

--- a/crates/oximo-gurobi/tests/nonlinear.rs
+++ b/crates/oximo-gurobi/tests/nonlinear.rs
@@ -168,3 +168,64 @@ fn nonlinear_iis_maps_generated_abs_definition() {
     let iis = Gurobi.compute_iis(&m, &GurobiOptions::default()).expect("compute nonlinear IIS");
     assert!(iis.constraints.contains(&conflict));
 }
+
+#[test]
+fn unsupported_operator_errors_before_environment_or_optimize() {
+    let m = Model::new("unsupported_asin");
+    variable!(m, -0.5 <= x <= 0.5);
+    objective!(m, Min, x.asin());
+    assert!(matches!(
+        Gurobi.solve(&m, &GurobiOptions::default()),
+        Err(oximo_solver::SolverError::UnsupportedNonlinearOperator {
+            backend: "Gurobi",
+            operator: "asin"
+        })
+    ));
+}
+
+#[test]
+fn newly_supported_native_unary_operators_solve_at_fixed_point() {
+    let point: f64 = 0.5;
+
+    macro_rules! check_unary {
+        ($method:ident, $expected:expr) => {{
+            let m = Model::new(concat!("native_", stringify!($method)));
+            variable!(m, -5.0 <= x <= 5.0);
+            m.fix(x, point);
+            objective!(m, Min, x.$method());
+
+            let result = Gurobi
+                .solve(&m, &GurobiOptions::default())
+                .unwrap_or_else(|error| panic!("{} solve failed: {error}", stringify!($method)));
+            assert_solved(&result);
+            let actual = result.objective().expect("objective");
+            assert!(
+                close(actual, $expected, 1e-6),
+                "{}({point}) = {actual}, expected {}",
+                stringify!($method),
+                $expected
+            );
+        }};
+    }
+
+    check_unary!(sqrt, point.sqrt());
+    check_unary!(exp2, point.exp2());
+    check_unary!(log2, point.log2());
+    check_unary!(log10, point.log10());
+    check_unary!(tan, point.tan());
+    check_unary!(tanh, point.tanh());
+}
+
+#[test]
+fn nested_min_max_use_native_general_constraints() {
+    let m = Model::new("nested_extrema");
+    variable!(m, -5.0 <= x <= 5.0);
+    variable!(m, -5.0 <= y <= 5.0);
+    m.fix(x, -2.0);
+    m.fix(y, 3.0);
+    objective!(m, Min, x.min(y).max(x + 1.0));
+
+    let result = Gurobi.solve(&m, &GurobiOptions::default()).expect("solve nested extrema");
+    assert_solved(&result);
+    assert!(close(result.objective().unwrap(), -1.0, 1e-8));
+}

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -125,15 +125,15 @@ let imported = oximo_io::read_lp(s.as_bytes())?;
 
 The standard format for sharing nonlinear and mixed-integer models. Unlike MPS/LP, it carries full nonlinear expressions, emitted as prefix (Polish) opcode trees.
 
-| Feature              | Behavior                                                                |
-| -------------------- | ----------------------------------------------------------------------- |
-| Nonlinear bodies     | Linear part goes to `J`/`G`; nonlinear residual to `C`/`O` opcode trees |
-| Supported operators  | `+ - * /`, negation, `pow`, `abs`, `sin`, `cos`, `exp`, `log` (natural) |
-| Output encoding      | ASCII (default) or binary, via `WriteOptions::format`                   |
-| Precision / comments | `precision` and `comments` knobs tune the ASCII output                  |
-| Variable ordering    | Standard ASL order: nonlinear-first (by appearance), then linear        |
-| Name sidecars        | `write_nl_files` also writes `.row` / `.col` name files                 |
-| Optional segments    | `F`/`S`/`V`/`d`/`r` segments supplied via `WriteOptions`                |
+| Feature              | Behavior                                                                    |
+| -------------------- | --------------------------------------------------------------------------- |
+| Nonlinear bodies     | Linear part goes to `J`/`G`; nonlinear residual to `C`/`O` opcode trees     |
+| Supported operators  | `+ - * /`, all documented AMPL unary/trig/hyperbolic opcodes, min/max, etc. |
+| Output encoding      | ASCII (default) or binary, via `WriteOptions::format`                       |
+| Precision / comments | `precision` and `comments` knobs tune the ASCII output                      |
+| Variable ordering    | Standard ASL order: nonlinear-first (by appearance), then linear            |
+| Name sidecars        | `write_nl_files` also writes `.row` / `.col` name files                     |
+| Optional segments    | `F`/`S`/`V`/`d`/`r` segments supplied via `WriteOptions`                    |
 
 ```rust,ignore
 use oximo::prelude::*;

--- a/crates/oximo-io/README.md
+++ b/crates/oximo-io/README.md
@@ -125,15 +125,15 @@ let imported = oximo_io::read_lp(s.as_bytes())?;
 
 The standard format for sharing nonlinear and mixed-integer models. Unlike MPS/LP, it carries full nonlinear expressions, emitted as prefix (Polish) opcode trees.
 
-| Feature              | Behavior                                                                    |
-| -------------------- | --------------------------------------------------------------------------- |
-| Nonlinear bodies     | Linear part goes to `J`/`G`; nonlinear residual to `C`/`O` opcode trees     |
-| Supported operators  | `+ - * /`, all documented AMPL unary/trig/hyperbolic opcodes, min/max, etc. |
-| Output encoding      | ASCII (default) or binary, via `WriteOptions::format`                       |
-| Precision / comments | `precision` and `comments` knobs tune the ASCII output                      |
-| Variable ordering    | Standard ASL order: nonlinear-first (by appearance), then linear            |
-| Name sidecars        | `write_nl_files` also writes `.row` / `.col` name files                     |
-| Optional segments    | `F`/`S`/`V`/`d`/`r` segments supplied via `WriteOptions`                    |
+| Feature              | Behavior                                                                        |
+| -------------------- | ------------------------------------------------------------------------------- |
+| Nonlinear bodies     | Linear part goes to `J`/`G`; nonlinear residual to `C`/`O` opcode trees         |
+| Supported operators  | `+ - * /`, powers, `atan2`, min/max, and supported `oximo-expr` unary functions |
+| Output encoding      | ASCII (default) or binary, via `WriteOptions::format`                           |
+| Precision / comments | `precision` and `comments` knobs tune the ASCII output                          |
+| Variable ordering    | Standard ASL order: nonlinear-first (by appearance), then linear                |
+| Name sidecars        | `write_nl_files` also writes `.row` / `.col` name files                         |
+| Optional segments    | `F`/`S`/`V`/`d`/`r` segments supplied via `WriteOptions`                        |
 
 ```rust,ignore
 use oximo::prelude::*;

--- a/crates/oximo-io/src/error.rs
+++ b/crates/oximo-io/src/error.rs
@@ -12,6 +12,8 @@ pub enum IoError {
     Conic,
     #[error("unsupported expression node in NL writer: {0}")]
     UnsupportedNode(&'static str),
+    #[error("AMPL .nl does not document an encoding for nonlinear operator {operator}")]
+    UnsupportedNonlinearOperator { operator: &'static str },
     #[error("variable domain {0} is not representable in NL")]
     UnsupportedDomain(&'static str),
     #[error("variable {0} is used in an expression but was not added to this model")]

--- a/crates/oximo-io/src/nl/analyze.rs
+++ b/crates/oximo-io/src/nl/analyze.rs
@@ -168,17 +168,15 @@ fn validate(arena: &ExprArena, id: ExprId, nonfinite_strings: bool) -> Result<()
             }
             Ok(())
         }
-        ExprNode::Neg(x)
-        | ExprNode::Sin(x)
-        | ExprNode::Cos(x)
-        | ExprNode::Exp(x)
-        | ExprNode::Log(x)
-        | ExprNode::Abs(x) => validate(arena, *x, nonfinite_strings),
-        ExprNode::Pow(b, e) => {
+        ExprNode::Unary(_, x) => validate(arena, *x, nonfinite_strings),
+        ExprNode::Pow(b, e) | ExprNode::Atan2(b, e) => {
             validate(arena, *b, nonfinite_strings)?;
             validate(arena, *e, nonfinite_strings)
         }
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             for c in children {
                 validate(arena, *c, nonfinite_strings)?;
             }
@@ -207,17 +205,15 @@ fn collect_vars(arena: &ExprArena, id: ExprId, out: &mut FxHashSet<VarId>) -> Re
             out.insert(*v);
             Ok(())
         }
-        ExprNode::Neg(x)
-        | ExprNode::Sin(x)
-        | ExprNode::Cos(x)
-        | ExprNode::Exp(x)
-        | ExprNode::Log(x)
-        | ExprNode::Abs(x) => collect_vars(arena, *x, out),
-        ExprNode::Pow(b, e) => {
+        ExprNode::Unary(_, x) => collect_vars(arena, *x, out),
+        ExprNode::Pow(b, e) | ExprNode::Atan2(b, e) => {
             collect_vars(arena, *b, out)?;
             collect_vars(arena, *e, out)
         }
-        ExprNode::Add(children) | ExprNode::Mul(children) => {
+        ExprNode::Add(children)
+        | ExprNode::Mul(children)
+        | ExprNode::Min(children)
+        | ExprNode::Max(children) => {
             for c in children {
                 collect_vars(arena, *c, out)?;
             }

--- a/crates/oximo-io/src/nl/emit_expr.rs
+++ b/crates/oximo-io/src/nl/emit_expr.rs
@@ -2,24 +2,25 @@
 //!
 //! Mapping (D. M. Gay, operator Tables 4 unary, 6 binary, 8 n-ary, 11 n-ary operators).
 //!
-//! | `ExprNode`        | NL opcode                             |
-//! |-------------------|---------------------------------------|
-//! | `Const(c)`        | `n<c>` (binary picks `s`/`l`/`n`)     |
-//! | `Var(v)`          | `v<permuted_idx>`                     |
-//! | `Neg(x)`          | `o16`                                 |
-//! | `Add(2)`          | `o0` (binary plus)                    |
-//! | `Add(>=3)`        | `o54 <N>` (n-ary sumlist)             |
-//! | `Mul(2)`          | `o2` (binary times)                   |
-//! | `Mul(>=3)`        | left-folded `o2` chain                |
-//! | `Pow(b, e)`       | `o5`                                  |
-//! | `Div(n, d)`       | `o3`                                  |
-//! | `Sin/Cos/Exp/Log` | `o41`, `o46`, `o44`, `o43`            |
-//! | `Abs`             | `o15`                                 |
-//! | `Linear`          | expanded to `o54 <N+1>` of `o2 n_c v` |
+//! | `ExprNode`        | NL opcode                                   |
+//! |-------------------|---------------------------------------------|
+//! | `Const(c)`        | `n<c>` (binary picks `s`/`l`/`n`)           |
+//! | `Var(v)`          | `v<permuted_idx>`                           |
+//! | `Unary(Neg, x)`   | `o16`                                       |
+//! | `Add(2)`          | `o0` (binary plus)                          |
+//! | `Add(>=3)`        | `o54 <N>` (n-ary sumlist)                   |
+//! | `Mul(2)`          | `o2` (binary times)                         |
+//! | `Mul(>=3)`        | left-folded `o2` chain                      |
+//! | `Pow(b, e)`       | `o5`                                        |
+//! | `Div(n, d)`       | `o3`                                        |
+//! | `Unary`           | documented unary opcodes (see `emit_unary`) |
+//! | `Atan2(y, x)`     | `o48`                                       |
+//! | `Min/Max`         | `o11`/`o12` with arity and children        |
+//! | `Linear`          | expanded to `o54 <N+1>` of `o2 n_c v`       |
 
 use std::io::Write;
 
-use oximo_expr::{ExprArena, ExprId, ExprNode, SignedExpr, VarId};
+use oximo_expr::{ExprArena, ExprId, ExprNode, SignedExpr, UnaryOp, VarId};
 use rustc_hash::FxHashMap;
 
 use super::writer::Writer;
@@ -82,10 +83,7 @@ pub(crate) fn emit_expr<W: Write>(
             w.var(idx)?;
         }
         ExprNode::Param(p) => w.num(arena.param_value(*p))?,
-        ExprNode::Neg(x) => {
-            w.op(16)?;
-            emit_expr(w, arena, var_index, *x)?;
-        }
+        ExprNode::Unary(op, x) => emit_unary(w, arena, var_index, *op, *x)?,
         ExprNode::Add(children) => emit_add(w, arena, var_index, children)?,
         ExprNode::Mul(children) => emit_mul(w, arena, var_index, children)?,
         ExprNode::Pow(b, e) => {
@@ -98,29 +96,72 @@ pub(crate) fn emit_expr<W: Write>(
             emit_expr(w, arena, var_index, *num)?;
             emit_expr(w, arena, var_index, *den)?;
         }
-        ExprNode::Sin(x) => {
-            w.op(41)?;
+        ExprNode::Atan2(y, x) => {
+            w.op(48)?;
+            emit_expr(w, arena, var_index, *y)?;
             emit_expr(w, arena, var_index, *x)?;
         }
-        ExprNode::Cos(x) => {
-            w.op(46)?;
-            emit_expr(w, arena, var_index, *x)?;
-        }
-        ExprNode::Exp(x) => {
-            w.op(44)?;
-            emit_expr(w, arena, var_index, *x)?;
-        }
-        ExprNode::Log(x) => {
-            w.op(43)?;
-            emit_expr(w, arena, var_index, *x)?;
-        }
-        ExprNode::Abs(x) => {
-            w.op(15)?;
-            emit_expr(w, arena, var_index, *x)?;
-        }
+        ExprNode::Min(children) => emit_extrema(w, arena, var_index, 11, children)?,
+        ExprNode::Max(children) => emit_extrema(w, arena, var_index, 12, children)?,
         ExprNode::Linear { coeffs, constant } => {
             emit_linear_inline(w, var_index, coeffs, *constant)?;
         }
+    }
+    Ok(())
+}
+
+fn emit_unary<W: Write>(
+    w: &mut Writer<'_, W>,
+    arena: &ExprArena,
+    var_index: &FxHashMap<VarId, u32>,
+    op: UnaryOp,
+    child: ExprId,
+) -> Result<(), IoError> {
+    if op == UnaryOp::Exp2 {
+        w.op(5)?;
+        w.num(2.0)?;
+        return emit_expr(w, arena, var_index, child);
+    }
+    let opcode = match op {
+        UnaryOp::Neg => 16,
+        UnaryOp::Abs => 15,
+        UnaryOp::Sqrt => 39,
+        UnaryOp::Exp => 44,
+        UnaryOp::Log => 43,
+        UnaryOp::Log10 => 42,
+        UnaryOp::Sin => 41,
+        UnaryOp::Cos => 46,
+        UnaryOp::Tan => 38,
+        UnaryOp::Asin => 51,
+        UnaryOp::Acos => 53,
+        UnaryOp::Atan => 49,
+        UnaryOp::Sinh => 40,
+        UnaryOp::Cosh => 45,
+        UnaryOp::Tanh => 37,
+        UnaryOp::Asinh => 50,
+        UnaryOp::Acosh => 52,
+        UnaryOp::Atanh => 47,
+        UnaryOp::Cbrt | UnaryOp::Expm1 | UnaryOp::Log2 | UnaryOp::Log1p => {
+            return Err(IoError::UnsupportedNonlinearOperator { operator: op.name() });
+        }
+        UnaryOp::Exp2 => unreachable!(),
+    };
+    w.op(opcode)?;
+    emit_expr(w, arena, var_index, child)
+}
+
+fn emit_extrema<W: Write>(
+    w: &mut Writer<'_, W>,
+    arena: &ExprArena,
+    var_index: &FxHashMap<VarId, u32>,
+    opcode: u32,
+    children: &[ExprId],
+) -> Result<(), IoError> {
+    w.op(opcode)?;
+    w.int(i64::try_from(children.len()).expect("arity"))?;
+    w.eor()?;
+    for child in children {
+        emit_expr(w, arena, var_index, *child)?;
     }
     Ok(())
 }

--- a/crates/oximo-io/src/nl/reader.rs
+++ b/crates/oximo-io/src/nl/reader.rs
@@ -54,7 +54,7 @@ enum Node {
     Var(usize),
     Unary(u32, Box<Node>),
     Binary(u32, Box<Node>, Box<Node>),
-    Sum(Vec<Node>),
+    Nary(u32, Vec<Node>),
 }
 
 /// Read an ASCII NL stream.
@@ -629,9 +629,9 @@ fn parse_binary_expr(b: &mut Bin<'_>, depth: usize) -> Result<Node, IoError> {
             let c = u32::try_from(nonneg(b.i32()?, "opcode")?)
                 .map_err(|_| invalid("binary", "opcode out of range"))?;
             let ar = match c {
-                15 | 16 | 41 | 43 | 44 | 46 => 1,
-                0 | 1 | 2 | 3 | 5 => 2,
-                54 => nonneg(b.i32()?, "sum arity")?,
+                15 | 16 | 37..=47 | 49..=53 => 1,
+                0 | 1 | 2 | 3 | 5 | 48 => 2,
+                11 | 12 | 54 => nonneg(b.i32()?, "n-ary operator arity")?,
                 _ => {
                     return Err(IoError::UnsupportedNl {
                         section: "expression".into(),
@@ -639,14 +639,14 @@ fn parse_binary_expr(b: &mut Bin<'_>, depth: usize) -> Result<Node, IoError> {
                     });
                 }
             };
-            if c == 54 {
+            if matches!(c, 11 | 12 | 54) {
                 let mut xs =
                     Vec::with_capacity(bounded_capacity(ar, b.bytes.len().saturating_sub(b.pos)));
                 let child_depth = next_expression_depth(depth)?;
                 for _ in 0..ar {
                     xs.push(parse_binary_expr(b, child_depth)?);
                 }
-                Ok(Node::Sum(xs))
+                Ok(Node::Nary(c, xs))
             } else {
                 let child_depth = next_expression_depth(depth)?;
                 let a = parse_binary_expr(b, child_depth)?;
@@ -679,9 +679,9 @@ fn parse_expr(lines: &[String], i: &mut usize, depth: usize) -> Result<Node, IoE
         .parse()
         .map_err(|_| invalid("expression", "bad opcode"))?;
     let arity = match code {
-        15 | 16 | 41 | 43 | 44 | 46 => 1,
-        0 | 1 | 2 | 3 | 5 => 2,
-        54 => {
+        15 | 16 | 37..=47 | 49..=53 => 1,
+        0 | 1 | 2 | 3 | 5 | 48 => 2,
+        11 | 12 | 54 => {
             if *i >= lines.len() {
                 return Err(invalid("expression", "missing sum arity"));
             }
@@ -699,13 +699,13 @@ fn parse_expr(lines: &[String], i: &mut usize, depth: usize) -> Result<Node, IoE
             });
         }
     };
-    if code == 54 {
+    if matches!(code, 11 | 12 | 54) {
         let mut xs = Vec::with_capacity(bounded_capacity(arity, lines.len().saturating_sub(*i)));
         let child_depth = next_expression_depth(depth)?;
         for _ in 0..arity {
             xs.push(parse_expr(lines, i, child_depth)?);
         }
-        return Ok(Node::Sum(xs));
+        return Ok(Node::Nary(code, xs));
     }
     let child_depth = next_expression_depth(depth)?;
     let a = parse_expr(lines, i, child_depth)?;
@@ -833,10 +833,22 @@ fn lower<'a>(m: &'a Model, vars: &[Expr<'a>], n: Node, depth: usize) -> Result<E
             Ok(match c {
                 15 => x.abs(),
                 16 => -x,
+                37 => x.tanh(),
+                38 => x.tan(),
+                39 => x.sqrt(),
+                40 => x.sinh(),
                 41 => x.sin(),
+                42 => x.log10(),
                 43 => x.log(),
                 44 => x.exp(),
+                45 => x.cosh(),
                 46 => x.cos(),
+                47 => x.atanh(),
+                49 => x.atan(),
+                50 => x.asinh(),
+                51 => x.asin(),
+                52 => x.acosh(),
+                53 => x.acos(),
                 _ => return Err(invalid("expression", "unsupported unary opcode")),
             })
         }
@@ -850,16 +862,30 @@ fn lower<'a>(m: &'a Model, vars: &[Expr<'a>], n: Node, depth: usize) -> Result<E
                 2 => x * y,
                 3 => x / y,
                 5 => x.pow(y),
+                48 => x.atan2(y),
                 _ => return Err(invalid("expression", "unsupported binary opcode")),
             })
         }
-        Node::Sum(xs) => {
+        Node::Nary(code, xs) => {
             let mut it = xs.into_iter();
-            let Some(first) = it.next() else { return Ok(m.__constant(0.0)) };
+            let Some(first) = it.next() else {
+                return Ok(m.__constant(match code {
+                    54 => 0.0,
+                    11 => f64::INFINITY,
+                    12 => f64::NEG_INFINITY,
+                    _ => return Err(invalid("expression", "unsupported n-ary opcode")),
+                }));
+            };
             let child_depth = next_expression_depth(depth)?;
             let mut e = lower(m, vars, first, child_depth)?;
             for x in it {
-                e = e + lower(m, vars, x, child_depth)?;
+                let next = lower(m, vars, x, child_depth)?;
+                e = match code {
+                    54 => e + next,
+                    11 => e.min(next),
+                    12 => e.max(next),
+                    _ => return Err(invalid("expression", "unsupported n-ary opcode")),
+                };
             }
             Ok(e)
         }

--- a/crates/oximo-io/tests/nl_functions.rs
+++ b/crates/oximo-io/tests/nl_functions.rs
@@ -1,0 +1,136 @@
+use oximo_core::prelude::*;
+use oximo_expr::evaluate;
+use oximo_io::{IoError, WriteOptions, read_nl, to_nl_string, write_nl_with};
+
+fn full_model() -> Model {
+    let m = Model::new("nl_functions");
+    variable!(m, -0.9 <= x <= 0.9);
+    let positive = x + 2.0;
+    let e = -x.sin()
+        + x.abs()
+        + positive.sqrt()
+        + x.exp()
+        + x.exp2()
+        + positive.log()
+        + positive.log10()
+        + x.sin()
+        + x.cos()
+        + x.tan()
+        + x.asin()
+        + x.acos()
+        + x.atan()
+        + x.sinh()
+        + x.cosh()
+        + x.tanh()
+        + x.asinh()
+        + positive.acosh()
+        + x.atanh()
+        + x.atan2(positive)
+        + x.min(positive)
+        + x.max(positive);
+    objective!(m, Min, e);
+    m
+}
+
+fn objective_value(model: &Model, x: f64) -> f64 {
+    let values: &[f64] = &[x];
+    let objective_ref = model.objective();
+    let objective = objective_ref.as_ref().unwrap();
+    evaluate(&model.arena(), objective.expr, &values).unwrap()
+}
+
+#[test]
+fn documented_unary_opcodes_are_exact() {
+    macro_rules! assert_root_opcode {
+        ($name:literal, $opcode:literal, |$arg:ident| $body:expr) => {{
+            let m = Model::new($name);
+            variable!(m, x);
+            let $arg: oximo_expr::Expr<'_> = x;
+            let expression = $body;
+            objective!(m, Min, expression);
+
+            let text = to_nl_string(&m).unwrap();
+            let mut lines = text.lines();
+            let objective_header = lines.find(|line| line.starts_with("O0 "));
+            assert_eq!(objective_header, Some("O0 0"), "{name}: {text}", name = $name);
+            assert_eq!(
+                lines.next(),
+                Some(concat!("o", stringify!($opcode))),
+                "{name}: {text}",
+                name = $name
+            );
+        }};
+    }
+
+    assert_root_opcode!("abs", 15, |x| x.abs());
+    assert_root_opcode!("neg", 16, |x| x.sin().neg());
+    assert_root_opcode!("tanh", 37, |x| x.tanh());
+    assert_root_opcode!("tan", 38, |x| x.tan());
+    assert_root_opcode!("sqrt", 39, |x| x.sqrt());
+    assert_root_opcode!("sinh", 40, |x| x.sinh());
+    assert_root_opcode!("sin", 41, |x| x.sin());
+    assert_root_opcode!("log10", 42, |x| x.log10());
+    assert_root_opcode!("log", 43, |x| x.log());
+    assert_root_opcode!("exp", 44, |x| x.exp());
+    assert_root_opcode!("cosh", 45, |x| x.cosh());
+    assert_root_opcode!("cos", 46, |x| x.cos());
+    assert_root_opcode!("atanh", 47, |x| x.atanh());
+    assert_root_opcode!("atan", 49, |x| x.atan());
+    assert_root_opcode!("asinh", 50, |x| x.asinh());
+    assert_root_opcode!("asin", 51, |x| x.asin());
+    assert_root_opcode!("acosh", 52, |x| x.acosh());
+    assert_root_opcode!("acos", 53, |x| x.acos());
+}
+
+#[test]
+fn documented_ascii_opcodes_round_trip() {
+    let model = full_model();
+    let text = to_nl_string(&model).unwrap();
+    for opcode in
+        [11_u32, 12, 15, 16, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53]
+    {
+        assert!(text.lines().any(|line| line.starts_with(&format!("o{opcode}"))), "o{opcode}");
+    }
+    // exp2 is the exact documented pow encoding, `2 ^ x`.
+    assert!(text.contains("o5\nn2\n"), "{text}");
+
+    let decoded = read_nl(text.as_bytes()).unwrap();
+    for x in [-0.5, 0.25, 0.75] {
+        let expected = objective_value(&model, x);
+        let actual = objective_value(&decoded, x);
+        assert!((actual - expected).abs() <= 1e-12 * expected.abs().max(1.0));
+    }
+}
+
+#[test]
+fn documented_binary_opcodes_round_trip() {
+    let model = full_model();
+    let mut bytes = Vec::new();
+    write_nl_with(&model, &mut bytes, &WriteOptions::binary()).unwrap();
+    let decoded = read_nl(bytes.as_slice()).unwrap();
+    for x in [-0.25, 0.5] {
+        let expected = objective_value(&model, x);
+        let actual = objective_value(&decoded, x);
+        assert!((actual - expected).abs() <= 1e-12 * expected.abs().max(1.0));
+    }
+}
+
+#[test]
+fn undocumented_unary_families_return_typed_errors() {
+    for name in ["cbrt", "expm1", "log1p", "log2"] {
+        let m = Model::new(name);
+        variable!(m, x);
+        let expr = match name {
+            "cbrt" => x.cbrt(),
+            "expm1" => x.expm1(),
+            "log1p" => x.log1p(),
+            "log2" => x.log2(),
+            _ => unreachable!(),
+        };
+        objective!(m, Min, expr);
+        assert!(matches!(
+            to_nl_string(&m),
+            Err(IoError::UnsupportedNonlinearOperator { operator }) if operator == name
+        ));
+    }
+}

--- a/crates/oximo-io/tests/nl_functions.rs
+++ b/crates/oximo-io/tests/nl_functions.rs
@@ -39,8 +39,25 @@ fn objective_value(model: &Model, x: f64) -> f64 {
     evaluate(&model.arena(), objective.expr, &values).unwrap()
 }
 
+fn read_literal_objective(body: &str) -> Model {
+    let header = "\
+g3 1 1 0
+ 0 0 1 0 0
+ 0 1
+ 0 0
+ 0 0 0
+ 0 0 0 1
+ 0 0 0 0 0
+ 0 0
+ 0 0
+ 0 0 0 0 0
+O0 0
+";
+    read_nl(format!("{header}{body}").as_bytes()).unwrap()
+}
+
 #[test]
-fn documented_unary_opcodes_are_exact() {
+fn documented_root_opcodes_are_exact() {
     macro_rules! assert_root_opcode {
         ($name:literal, $opcode:literal, |$arg:ident| $body:expr) => {{
             let m = Model::new($name);
@@ -80,6 +97,28 @@ fn documented_unary_opcodes_are_exact() {
     assert_root_opcode!("asin", 51, |x| x.asin());
     assert_root_opcode!("acosh", 52, |x| x.acosh());
     assert_root_opcode!("acos", 53, |x| x.acos());
+    assert_root_opcode!("min", 11, |x| x.min(x + 1.0));
+    assert_root_opcode!("max", 12, |x| x.max(x + 1.0));
+}
+
+#[test]
+fn literal_extrema_opcodes_decode_independently() {
+    let minimum = read_literal_objective("o11\n3\nn3\nn-2\nn5\n");
+    let maximum = read_literal_objective("o12\n3\nn3\nn-2\nn5\n");
+
+    assert_eq!(objective_value(&minimum, 0.0).to_bits(), (-2.0_f64).to_bits());
+    assert_eq!(objective_value(&maximum, 0.0).to_bits(), 5.0_f64.to_bits());
+}
+
+#[test]
+fn literal_atan2_opcode_preserves_y_x_operand_order() {
+    let model = read_literal_objective("o48\nn1\nn-1\n");
+    let actual = objective_value(&model, 0.0);
+    let expected = 1.0_f64.atan2(-1.0);
+    let reversed = (-1.0_f64).atan2(1.0);
+
+    assert_eq!(actual.to_bits(), expected.to_bits());
+    assert_ne!(actual.to_bits(), reversed.to_bits());
 }
 
 #[test]

--- a/crates/oximo-macros/src/extrema.rs
+++ b/crates/oximo-macros/src/extrema.rs
@@ -1,0 +1,89 @@
+//! `min!` and `max!` indexed-domain expressions.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Expr, Token};
+
+use crate::IndexBind;
+use crate::oximo_root;
+
+pub(crate) enum Extremum {
+    Min,
+    Max,
+}
+
+struct ExtremaInput {
+    body: Expr,
+    binds: Vec<IndexBind>,
+    cond: Option<Expr>,
+}
+
+impl Parse for ExtremaInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let body = input.parse::<Expr>()?;
+        input.parse::<Token![for]>()?;
+        let binds = Punctuated::<IndexBind, Token![,]>::parse_separated_nonempty(input)?;
+        let cond = if input.peek(Token![if]) {
+            input.parse::<Token![if]>()?;
+            Some(input.parse::<Expr>()?)
+        } else {
+            None
+        };
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after extremum clauses"));
+        }
+        Ok(Self { body, binds: binds.into_iter().collect(), cond })
+    }
+}
+
+pub(crate) fn expand(input: TokenStream2, kind: Extremum) -> syn::Result<TokenStream2> {
+    let input = crate::index::rewrite_index_subscripts(input);
+    let ExtremaInput { body, binds, cond } = syn::parse2(input)?;
+    let root = oximo_root();
+    let name = match kind {
+        Extremum::Min => "min",
+        Extremum::Max => "max",
+    };
+    let over = format_ident!("{name}_over");
+    let terms = format_ident!("{name}_terms");
+
+    let Some(cond) = cond else {
+        let mut expr = quote!(#body);
+        for b in binds.iter().rev() {
+            let param = b.closure_param();
+            let used = crate::bind::mark_bindings_used(std::slice::from_ref(b));
+            let domain = &b.domain;
+            expr = quote!( #root::__macro_support::#over(&(#domain), |#param| { #used #expr }) );
+        }
+        return Ok(expr);
+    };
+
+    let mut inner = quote! {
+        if #cond {
+            __terms.push(#body);
+        }
+    };
+    for b in binds.iter().rev() {
+        let pat = &b.pat;
+        let used = crate::bind::mark_bindings_used(std::slice::from_ref(b));
+        let domain = &b.domain;
+        let keys = if let Some(ty) = b.keys_of_type() {
+            quote!( #root::__macro_support::keys_of::<#ty, _>(&(#domain)) )
+        } else {
+            quote!( #root::__macro_support::keys_of(&(#domain)) )
+        };
+        inner = quote! {
+            for #pat in #keys {
+                #used
+                #inner
+            }
+        };
+    }
+    Ok(quote! {{
+        let mut __terms = ::std::vec::Vec::new();
+        #inner
+        #root::__macro_support::#terms(__terms)
+    }})
+}

--- a/crates/oximo-macros/src/extrema.rs
+++ b/crates/oximo-macros/src/extrema.rs
@@ -48,6 +48,7 @@ pub(crate) fn expand(input: TokenStream2, kind: Extremum) -> syn::Result<TokenSt
     };
     let over = format_ident!("{name}_over");
     let terms = format_ident!("{name}_terms");
+    let terms_acc = syn::Ident::new("__terms", proc_macro2::Span::mixed_site());
 
     let Some(cond) = cond else {
         let mut expr = quote!(#body);
@@ -62,7 +63,7 @@ pub(crate) fn expand(input: TokenStream2, kind: Extremum) -> syn::Result<TokenSt
 
     let mut inner = quote! {
         if #cond {
-            __terms.push(#body);
+            #terms_acc.push(#body);
         }
     };
     for b in binds.iter().rev() {
@@ -82,8 +83,8 @@ pub(crate) fn expand(input: TokenStream2, kind: Extremum) -> syn::Result<TokenSt
         };
     }
     Ok(quote! {{
-        let mut __terms = ::std::vec::Vec::new();
+        let mut #terms_acc = ::std::vec::Vec::new();
         #inner
-        #root::__macro_support::#terms(__terms)
+        #root::__macro_support::#terms(#terms_acc)
     }})
 }

--- a/crates/oximo-macros/src/lib.rs
+++ b/crates/oximo-macros/src/lib.rs
@@ -9,6 +9,7 @@ use syn::Ident;
 
 mod bind;
 mod constraint;
+mod extrema;
 mod index;
 mod objective;
 mod param;
@@ -91,6 +92,22 @@ pub fn objective(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn sum(input: TokenStream) -> TokenStream {
     sum::expand(input.into()).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// `min!(body for pat in domain[, pat in domain ...][ if cond])`, an indexed minimum.
+#[proc_macro]
+pub fn min(input: TokenStream) -> TokenStream {
+    extrema::expand(input.into(), extrema::Extremum::Min)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// `max!(body for pat in domain[, pat in domain ...][ if cond])`, an indexed maximum.
+#[proc_macro]
+pub fn max(input: TokenStream) -> TokenStream {
+    extrema::expand(input.into(), extrema::Extremum::Max)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 /// `param!(model, name = value)`, declare a re-bindable scalar parameter and

--- a/crates/oximo-pounce/src/fbbt.rs
+++ b/crates/oximo-pounce/src/fbbt.rs
@@ -8,7 +8,7 @@
 
 // TODO: Add support for Nightly/TNLP once v0.12 releases.
 
-use oximo_core::{ExprArenaSnapshot, ExprId, ExprNode, Model};
+use oximo_core::{ExprArenaSnapshot, ExprId, ExprNode, Model, UnaryOp};
 use pounce_rs::{FbbtOp, FbbtTape};
 use rustc_hash::FxHashMap;
 
@@ -50,29 +50,36 @@ fn emit(
         ExprNode::Const(value) => push(ops, FbbtOp::Const(*value)),
         ExprNode::Param(param) => push(ops, FbbtOp::Const(arena.param_value(*param))),
         ExprNode::Var(var) => push(ops, FbbtOp::Var(var.index())),
-        ExprNode::Neg(child) => {
+        ExprNode::Unary(UnaryOp::Neg, child) => {
             let a = emit(arena, *child, ops, slots);
             push(ops, FbbtOp::Neg(a))
         }
-        ExprNode::Sin(child) => {
+        ExprNode::Unary(UnaryOp::Sin, child) => {
             let a = emit(arena, *child, ops, slots);
             push(ops, FbbtOp::Sin(a))
         }
-        ExprNode::Cos(child) => {
+        ExprNode::Unary(UnaryOp::Cos, child) => {
             let a = emit(arena, *child, ops, slots);
             push(ops, FbbtOp::Cos(a))
         }
-        ExprNode::Exp(child) => {
+        ExprNode::Unary(UnaryOp::Exp, child) => {
             let a = emit(arena, *child, ops, slots);
             push(ops, FbbtOp::Exp(a))
         }
-        ExprNode::Log(child) => {
+        ExprNode::Unary(UnaryOp::Log, child) => {
             let a = emit(arena, *child, ops, slots);
             push(ops, FbbtOp::Ln(a))
         }
-        ExprNode::Abs(child) => {
+        ExprNode::Unary(UnaryOp::Abs, child) => {
             let a = emit(arena, *child, ops, slots);
             push(ops, FbbtOp::Abs(a))
+        }
+        ExprNode::Unary(UnaryOp::Sqrt, child) => {
+            let a = emit(arena, *child, ops, slots);
+            push(ops, FbbtOp::Sqrt(a))
+        }
+        ExprNode::Unary(_, _) | ExprNode::Atan2(_, _) | ExprNode::Min(_) | ExprNode::Max(_) => {
+            push(ops, FbbtOp::Opaque)
         }
         ExprNode::Div(lhs, rhs) => {
             let a = emit(arena, *lhs, ops, slots);
@@ -205,15 +212,16 @@ mod tests {
         let shared = x.sin();
         constraint!(model, unary, -shared + x.cos() + x.exp() + x.log() + x.abs() <= 100.0);
         constraint!(model, division, x.sin() / (y + 1.0) <= 100.0);
-        constraint!(model, square_root, x.powf(0.5) <= 100.0);
+        constraint!(model, square_root, x.sqrt() <= 100.0);
         constraint!(model, integer_power, x.powi(3) <= 100.0);
         constraint!(model, parameter_power, x.pow(exponent) <= 100.0);
         constraint!(model, variable_power, x.pow(y) <= 100.0);
+        constraint!(model, opaque_addition, x.cbrt() + x.atan2(y) <= 100.0);
         constraint!(model, linear, 2.0 * x + 3.0 * y + 1.0 <= 100.0);
         constraint!(model, constant, model.__constant(1.0) <= 2.0);
 
         let tapes = constraint_tapes(&model);
-        assert_eq!(tapes.len(), 8);
+        assert_eq!(tapes.len(), 9);
         let ops = tapes.into_iter().flatten().flat_map(|tape| tape.ops).collect::<Vec<_>>();
 
         assert!(ops.iter().any(|op| matches!(op, FbbtOp::Neg(..))));

--- a/crates/oximo-solver/benches/extraction_cache.rs
+++ b/crates/oximo-solver/benches/extraction_cache.rs
@@ -8,7 +8,8 @@ use oximo_solver::prepare::PreparedExpressions;
 fn bench(c: &mut Criterion) {
     let mut arena = ExprArena::new();
     let linear = arena.linear((0..64).map(|i| (VarId(i), 1.0)).collect(), 3.0);
-    let roots: Vec<_> = (0..256).map(|_| arena.push(ExprNode::Neg(linear))).collect();
+    let roots: Vec<_> =
+        (0..256).map(|_| arena.push(ExprNode::Unary(oximo_expr::UnaryOp::Neg, linear))).collect();
     let a = roots[0];
     let shard = |id: oximo_expr::ExprId| id.0.wrapping_mul(0x9e37_79b9) >> 28;
     let b = *roots.iter().find(|&&id| id != a && shard(id) == shard(a)).unwrap();

--- a/crates/oximo-solver/src/status.rs
+++ b/crates/oximo-solver/src/status.rs
@@ -127,6 +127,8 @@ pub enum SolverError {
     NoObjective,
     #[error("{location} contains a nonlinear term unsupported by this backend: {term}")]
     Nonlinear { location: String, term: String },
+    #[error("{backend} does not support nonlinear operator {operator}")]
+    UnsupportedNonlinearOperator { backend: &'static str, operator: &'static str },
     #[error("backend error: {0}")]
     Backend(String),
     #[error(transparent)]

--- a/crates/oximo-solver/tests/preparation.rs
+++ b/crates/oximo-solver/tests/preparation.rs
@@ -61,7 +61,10 @@ fn all_model_families_retain_original_entities() {
     let objective = prepared.objective().unwrap().expr;
     assert!(prepared.linear(objective).is_none());
     assert!(prepared.quadratic(objective).is_none());
-    assert!(matches!(prepared.arena().get(objective), oximo_core::ExprNode::Exp(_)));
+    assert!(matches!(
+        prepared.arena().get(objective),
+        oximo_core::ExprNode::Unary(oximo_core::UnaryOp::Exp, _)
+    ));
 }
 
 #[test]

--- a/crates/oximo/tests/solve_baron.rs
+++ b/crates/oximo/tests/solve_baron.rs
@@ -66,6 +66,22 @@ fn baron_lp_duals_and_reduced_costs() {
 }
 
 #[test]
+fn baron_accepts_per_constraint_convexity_hint() {
+    let m = Model::new("convex_hint");
+    variable!(m, -1.0 <= x <= 1.0);
+    variable!(m, -1.0 <= y <= 1.0);
+    let disk = constraint!(m, disk, x.powi(2) + y.powi(2) <= 1.0);
+    objective!(m, Min, x + y);
+
+    let options =
+        BaronOptions::default().convex_equations([disk]).time_limit(Duration::from_secs(30));
+    let result = Baron::new().solve(&m, &options).expect("solve with convex-equation hint");
+
+    assert_eq!(result.termination, TerminationStatus::Optimal);
+    assert!((result.objective().unwrap() + std::f64::consts::SQRT_2).abs() < 1e-4);
+}
+
+#[test]
 fn baron_milp_duals_at_best_point() {
     // max 2a + 3b  s.t.  a + b <= 1,  a, b binary.
     // Optimal: (0, 1), obj 3.

--- a/crates/oximo/tests/solve_gams.rs
+++ b/crates/oximo/tests/solve_gams.rs
@@ -95,6 +95,78 @@ fn gams_nlp_duals_at_local_point() {
 }
 
 #[test]
+fn gams_continuous_abs_routes_to_dnlp() {
+    let m = Model::new("dnlp_abs");
+    variable!(m, -10.0 <= x <= 10.0);
+    objective!(m, Min, (x - 2.0).abs());
+
+    let result = Gams::new().solve(&m, &GamsOptions::default()).unwrap();
+    assert!(result.has_solution(), "termination={:?}", result.termination);
+    assert!((result.value_of(x).unwrap() - 2.0).abs() < 1e-5);
+    assert!(result.objective().unwrap().abs() < 1e-5);
+}
+
+#[test]
+fn gams_generated_supported_nonlinear_vocabulary_solves() {
+    let x_value: f64 = 0.5;
+    let y_value: f64 = 1.5;
+    let m = Model::new("dnlp_supported_functions");
+    variable!(m, 0.1 <= x <= 2.0);
+    variable!(m, 0.1 <= y <= 2.0);
+    m.fix(x, x_value);
+    m.fix(y, y_value);
+
+    let expression = (x - y).abs()
+        + x.sqrt()
+        + y.exp2()
+        + x.exp()
+        + x.log()
+        + x.log2()
+        + y.log10()
+        + x.sin()
+        + x.cos()
+        + x.tan()
+        + (x / 2.0).asin()
+        + (x / 2.0).acos()
+        + x.atan()
+        + x.sinh()
+        + y.cosh()
+        + x.tanh()
+        + x.atan2(y)
+        + x.min(y)
+        + x.max(y);
+    objective!(m, Min, expression);
+
+    let opts = GamsOptions::default()
+        .solver(GamsSolverConfig::Conopt(GamsConoptOptions::default()))
+        .time_limit(Duration::from_secs(30));
+    let result = Gams::new().solve(&m, &opts).expect("solve generated nonlinear vocabulary");
+    assert!(result.has_solution(), "termination={:?}", result.termination);
+
+    let expected = (x_value - y_value).abs()
+        + x_value.sqrt()
+        + y_value.exp2()
+        + x_value.exp()
+        + x_value.ln()
+        + x_value.log2()
+        + y_value.log10()
+        + x_value.sin()
+        + x_value.cos()
+        + x_value.tan()
+        + (x_value / 2.0).asin()
+        + (x_value / 2.0).acos()
+        + x_value.atan()
+        + x_value.sinh()
+        + y_value.cosh()
+        + x_value.tanh()
+        + x_value.atan2(y_value)
+        + x_value.min(y_value)
+        + x_value.max(y_value);
+    let actual = result.objective().expect("objective");
+    assert!((actual - expected).abs() < 1e-5, "objective={actual}, expected={expected}");
+}
+
+#[test]
 fn gams_mip_duals_at_fixed_point() {
     // max 2a + 3b  s.t.  a + b <= 1,  a, b binary.
     // Ask CPLEX to re-solve with integers fixed, so `.m` carries the duals


### PR DESCRIPTION
## Description

This PR expands the nonlinear operators supported by oximo. IO and the backends have been updated.
I also added support for hinting convex equations in BARON.

I did the initial implementation and used Codex to update the backends (forgot to add commit trailer).

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have added tests that cover my changes
- [x] I have run `cargo fmt` and `cargo clippy` to ensure code quality
- [x] All default tests pass (`cargo test`)
- [x] `cargo test --features gams` passes (requires GAMS)
- [x] `cargo test --features gurobi` passes (requires Gurobi)
- [x] `cargo test --features mosek` passes (requires MOSEK)
- [x] `cargo test --features baron` passes (requires BARON)